### PR TITLE
ng-conf video link

### DIFF
--- a/public/_includes/_hero-home.jade
+++ b/public/_includes/_hero-home.jade
@@ -12,7 +12,7 @@ header(class="background-sky")
 .banner.is-centered
   .banner-ng-annoucement
     h3.text-display-1 NG-CONF 2015
-    h4.text-subhead Videos now on YouTube
+    h4.text-subhead The Official Angular Conference
 
-  a(href="https://www.youtube.com/watch?v=QHulaj5ZxbI&index=1&list=PLOETEcp3DkCoNnlhE-7fovYvqwVPrRiY7" 
+  a(href="https://www.youtube.com/watch?v=QHulaj5ZxbI&index=1&list=PLOETEcp3DkCoNnlhE-7fovYvqwVPrRiY7"
     class="button button-large button-banner"  md-button) Watch ng-conf

--- a/public/_includes/_hero-home.jade
+++ b/public/_includes/_hero-home.jade
@@ -12,6 +12,7 @@ header(class="background-sky")
 .banner.is-centered
   .banner-ng-annoucement
     h3.text-display-1 NG-CONF 2015
-    h4.text-subhead March 5-6. Salt Lake City, Utah
+    h4.text-subhead Videos now on YouTube
 
-  a(href="http://www.ng-conf.org/" class="button button-large button-banner"  md-button) Watch ng-conf
+  a(href="https://www.youtube.com/watch?v=QHulaj5ZxbI&index=1&list=PLOETEcp3DkCoNnlhE-7fovYvqwVPrRiY7" 
+    class="button button-large button-banner"  md-button) Watch ng-conf


### PR DESCRIPTION
Fixes #3.

@alexwolfe Changed the ng-conf link to the Keynote and YouTube playlist. What do you think of the text "Videos now on YouTube"? I want to set the expectations that the link will take you to YouTube. Ideally I'd like a little play icon in the button, but let me know if that's overkill.