### PR TITLE
Update Dart quick start to angular2 alpha 19

### DIFF
--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -26,14 +26,16 @@ p.
       &gt; vim pubspec.yaml  # Use your favorite editor!
 
   p.
-    In <code>pubspec.yaml</code>, add the angular2 and browser packages as dependencies:
+    In <code>pubspec.yaml</code>, add the angular2 and browser packages as dependencies.
+    Angular 2 is changing rapidly, so specify an exact version:
+    <b>2.0.0-alpha.19</b>.
 
   pre.prettyprint.linenums.lang-basic
     code.
       name: hello_world
       version: 0.0.1
       dependencies:
-        angular2: "&gt;=2.0.0-alpha.6 &lt;3.0.0"
+        angular2: 2.0.0-alpha.19
         browser: any
   p.
     In the same directory, run <code>pub get</code>
@@ -44,20 +46,12 @@ p.
     code.
       &gt; pub get
       Resolving dependencies... (2.7s)
-      + analyzer 0.24.1 (0.25.0-dev.3 available)
-      ... more messages ...
-      Changed 21 dependencies!
-      Precompiling dependencies...
-      Loading source assets...
-      Precompiled dart_style.
+      # ... messages ...
+      + angular2 2.0.0-alpha.19
+      # ... more messages ...
 
   // PENDING: Create template? Link to pub/pubspec docs?
   // Is browser really needed?
-
-  .alert.is-helpful.
-    Depending on your version of Dart and the latest version of angular2,
-    your messages are probably going to be different from what's shown above.
-    That's fine.
 
 
 // STEP 2 - Import Angular ##########################
@@ -102,8 +96,8 @@ p.
       @Component(
         selector: 'my-app'
       )
-      @Template(
-        inline: '&lt;h1&gt;Hello {{ name }}&lt;/h1&gt;'
+      @View(
+        template: '&lt;h1&gt;Hello {{ name }}&lt;/h1&gt;'
       )
       class AppComponent {
         String name = 'Alice';


### PR DESCRIPTION
@alexwolfe could you patch this in ASAP? The alpha 19 release broke the Dart instructions.