### PR TITLE
update dart angular2 version, don't display pub get output

### DIFF
--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -55,7 +55,7 @@
         description: Dart version of Angular 2 example, Displaying Data
         version: 0.0.1
         dependencies:
-          angular2: 2.0.0-alpha.20
+          angular2: 2.0.0-alpha.21
           browser: any
 
   p.
@@ -392,7 +392,7 @@
         description: Dart version of Angular 2 example, Displaying Data
         version: 0.0.1
         dependencies:
-          angular2: 2.0.0-alpha.20
+          angular2: 2.0.0-alpha.21
           browser: any
 .l-main-section
   h2#section-explanations Explanations

--- a/public/docs/dart/latest/guide/setup.jade
+++ b/public/docs/dart/latest/guide/setup.jade
@@ -31,7 +31,7 @@
       description: Dart version of Angular 2 example, Getting Started
       version: 0.0.1
       dependencies:
-        angular2: 2.0.0-alpha.20
+        angular2: 2.0.0-alpha.21
         browser: any
   p.
     Run <b>pub get</b> to download the packages your app depends on.

--- a/public/docs/dart/latest/guide/user-input.jade
+++ b/public/docs/dart/latest/guide/user-input.jade
@@ -212,5 +212,5 @@
         description: Dart version of Angular 2 example, Responding to User Input
         version: 0.0.1
         dependencies:
-          angular2: 2.0.0-alpha.20
+          angular2: 2.0.0-alpha.21
           browser: any

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -30,14 +30,14 @@ p.
   p.
     In <code>pubspec.yaml</code>, add the angular2 and browser packages as dependencies.
     Angular 2 is changing rapidly, so specify an exact version:
-    <b>2.0.0-alpha.19</b>.
+    <b>2.0.0-alpha.21</b>.
 
   pre.prettyprint.linenums.lang-basic
     code.
       name: hello_world
       version: 0.0.1
       dependencies:
-        angular2: 2.0.0-alpha.19
+        angular2: 2.0.0-alpha.21
         browser: any
   p.
     In the same directory, run <code>pub get</code>
@@ -47,10 +47,6 @@ p.
   pre.prettyprint.lang-basic
     code.
       &gt; pub get
-      Resolving dependencies... (2.7s)
-      # ... messages ...
-      + angular2 2.0.0-alpha.19
-      # ... more messages ...
 
   // PENDING: Create template? Link to pub/pubspec docs?
   // Is browser really needed?


### PR DESCRIPTION
@alexwolfe, could you publish these small updates at your earliest convenience?

The existing text isn't wrong, but it shows old version numbers.