### PR TITLE
Update quickstart text for consistency

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -229,7 +229,7 @@
         &lt;/head&gt;
 
   p.
-    Add the following module-loading code before the <code>&lt;my-app&gt;</code> tag:
+    Add the following module-loading code after the <code>&lt;my-app&gt;</code> tag:
 
   pre.prettyprint.linenums
     code.


### PR DESCRIPTION
The provided example shows the module loading after the `<my-app>` tag.