### PR TITLE
fixed #92: '.docs-content' has no 'padding-left' in hand held mode

### DIFF
--- a/public/resources/css/base/_type.scss
+++ b/public/resources/css/base/_type.scss
@@ -156,3 +156,12 @@ table td {
 .docs-content .l-sub-section  aside {
   background: $snow;
 }
+
+.docs-content ul,
+.docs-content ol {
+  @media handheld and (max-width: $phone-breakpoint),
+  screen and (max-device-width: $phone-breakpoint),
+  screen and (max-width: $tablet-breakpoint) {
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
fixes hand held mode for following URLs (see issue #92):
- `/docs/js/latest/guide/`
- `/docs/js/latest/api/`