### PR TITLE
#38: Add an optional data-file attribute to display file names in header

### DIFF
--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -17,9 +17,8 @@
     a <code>pubspec.yaml</code> file:
 
   .code-box
-    pre.prettyprint.lang-dart(data-name="dart")
+    pre.prettyprint.lang-dart(data-name="dart", data-file="web/main.dart")
       code.
-        // web/main.dart
         library displaying_data;
 
         import 'package:angular2/angular2.dart';
@@ -32,9 +31,8 @@
           reflector.reflectionCapabilities = new ReflectionCapabilities();
           bootstrap(DisplayComponent);
         }
-    pre.prettyprint.lang-html(data-name="html")
+    pre.prettyprint.lang-html(data-name="html", data-file="web/index.html")
       code.
-        &lt;!-- web/index.html --&gt;
         &lt;!DOCTYPE html&gt;
         &lt;html&gt;
           &lt;head&gt;
@@ -48,9 +46,8 @@
             &lt;script src=&quot;packages/browser/dart.js&quot;&gt;&lt;/script&gt;
           &lt;/body&gt;
         &lt;/html&gt;
-    pre.prettyprint.lang-yaml(data-name="yaml")
+    pre.prettyprint.lang-yaml(data-name="yaml", data-file="pubspec.yaml")
       code.
-        # pubspec.yaml
         name: displaying_data
         description: Dart version of Angular 2 example, Displaying Data
         version: 0.0.1

--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -75,22 +75,22 @@
     named <code>show_properties.dart</code>,
     and add the following:
 
-  pre.prettyprint.lang-dart
-    code.
-      // web/show_properties.dart
-      part of displaying_data;
+  .code-box
+    pre.prettyprint.lang-dart(data-file="web/show_properties.dart")
+      code.
+        part of displaying_data;
 
-      @Component(
-        selector: 'display'
-      )
-      @View(
-        template: '''
-      &lt;p>My name: {{ myName }}&lt/p>
-      '''
-      )
-      class DisplayComponent {
-        String myName = 'Alice';
-      }
+        @Component(
+          selector: 'display'
+        )
+        @View(
+          template: '''
+        &lt;p>My name: {{ myName }}&lt/p>
+        '''
+        )
+        class DisplayComponent {
+          String myName = 'Alice';
+        }
 
   p.
     You've just defined a component that encompasses a view and controller for the app. The view

--- a/public/resources/css/module/_code-box.scss
+++ b/public/resources/css/module/_code-box.scss
@@ -39,7 +39,7 @@
 
       .icon {
         position: relative;
-        top: 2px;
+        top: 1px;
         margin-right: 5px;
         color: $tin;
       }

--- a/public/resources/css/module/_code-box.scss
+++ b/public/resources/css/module/_code-box.scss
@@ -29,6 +29,21 @@
         color: $snow;
       }
     }
+
+    .file-name {
+      color: $sky;
+      float: right;
+      line-height: 24px;
+      text-transform: lowercase;
+      font-size: 13px;
+
+      .icon {
+        position: relative;
+        top: 2px;
+        margin-right: 5px;
+        color: $tin;
+      }
+    }
   }
 
   .prettyprint {

--- a/public/resources/js/site.js
+++ b/public/resources/js/site.js
@@ -118,6 +118,7 @@ angularIO.controller('AppCtrl', ['$scope', '$mdDialog', function($scope, $mdDial
         });
 
         $nav.append($button, $file);
+        $examples.length < 2 ? $button.css('visibility', 'hidden') : '';
         $nav.find('.file-name').addClass('is-hidden').first().removeClass('is-hidden');
       });
 

--- a/public/resources/js/site.js
+++ b/public/resources/js/site.js
@@ -91,7 +91,9 @@ angularIO.controller('AppCtrl', ['$scope', '$mdDialog', function($scope, $mdDial
         var name = $example.data('name');
         var tabName = getTabName(name);
         var selected = (index === 0) ? 'is-selected' : '';
-        var $button = $("<button class='button " + selected + "' data-name='" + name + "'>" + tabName + "</button>");
+        var file = $example.data('file');
+        var $button = $("<button class='button " + selected + "' data-name='" + name + ( file ? "' data-file='" + file : '' ) + "'>" + tabName + "</button>");
+        var $file = file ? $("<span class='button file-name' data-file='" + file + "'><i class='icon icon-content-copy'></i> " + file + "</span>") : null;
 
         // ADD EVENTS FOR CODE SNIPPETS
         $button.on('click', function(e) {
@@ -102,13 +104,21 @@ angularIO.controller('AppCtrl', ['$scope', '$mdDialog', function($scope, $mdDial
           $buttons.removeClass('is-selected');
           $currentButton.addClass('is-selected');
 
-          //UPDAT VIEW ON SELECTTION
+          //UPDATE VIEW ON SELECTION
           $examples.addClass('is-hidden');
           var $currentExample = $codeBox.find(".prettyprint[data-name='" + selectedName + "']");
           $currentExample.removeClass('is-hidden').addClass('animated fadeIn');
+
+          //UPDATE FILE ON SELECTION
+          var $files = $nav.find('.file-name');
+          var selectedFile = $currentButton.data('file');
+          $files.addClass('is-hidden');
+          var $currentFile = $nav.find(".file-name[data-file='" + selectedFile + "']");
+          $currentFile.removeClass('is-hidden').addClass('animated fadeIn');
         });
 
-        $nav.append($button);
+        $nav.append($button, $file);
+        $nav.find('.file-name').addClass('is-hidden').first().removeClass('is-hidden');
       });
 
       //ADD HEADER TO DOM


### PR DESCRIPTION
Hey @kwalrath, how about this?
For an example, see the first code section in `http://localhost:9000/docs/dart/latest/guide/displaying-data.html`

To display a corresponding file name/path pass an optional attribute **data-file**, like this: 
```
data-file="web/main.dart"
``` 
Check my changes in `displaying-data.jade` to see all that is required for adding file names.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.io/116)
<!-- Reviewable:end -->
