### PR TITLE
Added traceur runtime script to the TS code in the step-by-step guide

### DIFF
--- a/public/docs/js/latest/guide/setup.jade
+++ b/public/docs/js/latest/guide/setup.jade
@@ -44,6 +44,7 @@
       &lt;!DOCTYPE html&gt;
       &lt;html&gt;
         &lt;head&gt;
+          &lt;script src=&quot;https://github.jspm.io/jmcriffey/bower-traceur-runtime@0.0.87/traceur-runtime.js&quot;&gt;&lt;/script&gt;
           &lt;script src=&quot;https://jspm.io/system@0.16.js&quot;&gt;&lt;/script&gt;
           &lt;script src=&quot;https://code.angularjs.org/2.0.0-alpha.23/angular2.dev.js&quot;&gt;&lt;/script&gt;
         &lt;/head&gt;


### PR DESCRIPTION
This PR fixes issue https://github.com/angular/angular.io/issues/102. The traceur runtime script was not added in the example and throws an error in the console indicating that `$traceurRuntime` is not defined.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.io/143)
<!-- Reviewable:end -->
