### PR TITLE
fix(quickstart): add issue link for traceur

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -172,7 +172,7 @@
 
   p.
     Inside the <code>head</code> tag of <code>index.html</code>,
-    include the traceur-runtime ( necessary until <a href="https://github.com/angular/angular/issues/2335">#2335</a> is resolved ) and the Angular bundle.
+    include the traceur-runtime ( necessary until <a href="https://github.com/angular/angular/issues/2829">angular/angular#2829</a> is resolved ) and the Angular bundle.
     Instantiate the <code>my-app</code> component in the <code>body</code>.
 
   code-example(language="html" format="linenums").

--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -172,7 +172,7 @@
 
   p.
     Inside the <code>head</code> tag of <code>index.html</code>,
-    include the traceur-runtime and the Angular bundle.
+    include the traceur-runtime ( necessary until <a href="https://github.com/angular/angular/issues/2335">#2335</a> is resolved ) and the Angular bundle.
     Instantiate the <code>my-app</code> component in the <code>body</code>.
 
   code-example(language="html" format="linenums").


### PR DESCRIPTION
I'm not sure if this is proper way, but surely users should know why they need to include traceur-runtime in Angular 2 project.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.io/146)
<!-- Reviewable:end -->
