### PR TITLE
Typo in code example of lib/show_properties.dart

### DIFF
--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -74,7 +74,7 @@
     that contains the following code:
 
   code-example(language="dart" format="linenums" escape="html").
-    // web/show_properties.dart
+    // lib/show_properties.dart
     library displaying_data.show_properties;
 
     import 'package:angular2/angular2.dart';


### PR DESCRIPTION
In the text show_properties.dart is (correctly) placed in the lib directory,
while in the comment at the top of the file, it's path is under web.