### PR TITLE
Add more required type definitions to quickstart

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -27,7 +27,7 @@
 
   code-example.
     $ npm install -g tsd
-    $ tsd query angular2 --action install
+    $ tsd query angular2 es6-promise rx rx-lite --action install
 
   p.
     Next, create two empty files, <code>index.html</code> and <code>app.ts</code>, both at the root of the project:


### PR DESCRIPTION
I needed these additional type definitions to get the quickstart to work. Otherwise I got this error:

```bash
typings/angular2/angular2.d.ts(15,1): error TS6053: File 'typings/es6-promise/es6-promise.d.ts' not found.
typings/angular2/angular2.d.ts(16,1): error TS6053: File 'typings/rx/rx.d.ts' not found.

...

typings/rx/rx.d.ts(6,1): error TS6053: File 'typings/rx/rx-lite.d.ts' not found.
```