### PR TITLE
Dart alpha 29

### DIFF
--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -48,7 +48,7 @@
       description: Dart version of Angular 2 example, Displaying Data
       version: 0.0.1
       dependencies:
-        angular2: 2.0.0-alpha.26
+        angular2: 2.0.0-alpha.28
         browser: ^0.10.0
       transformers:
       - angular2:
@@ -227,11 +227,11 @@
   p.
     Make a <code>FriendsService</code> class to implement a model
     containing a list of friends.
-    Put this in a new file under <code>web/</code>
+    Put this in a new file under <code>lib/</code>
     named <code>friends_service.dart</code>. Here's what the class looks like:
 
   code-example(language="dart" format="linenums").
-    // web/friends_service.dart
+    // lib/friends_service.dart
     library displaying_data.friends_service;
 
     import 'package:angular2/angular2.dart';
@@ -248,7 +248,7 @@
     Then set <code>friendNames</code> to the names provided by the service.
 
   code-example(language="dart").
-    // In web/show_properties.dart
+    // In lib/show_properties.dart
     <span class="pnk">import 'package:displaying_data/friends_service.dart';</span>
     ...
     class DisplayComponent {
@@ -359,7 +359,7 @@
       description: Displaying Data example
       version: 0.0.1
       dependencies:
-        angular2: 2.0.0-alpha.26
+        angular2: 2.0.0-alpha.28
         browser: ^0.10.0
       transformers:
       - angular2:

--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -48,7 +48,7 @@
       description: Dart version of Angular 2 example, Displaying Data
       version: 0.0.1
       dependencies:
-        angular2: 2.0.0-alpha.28
+        angular2: 2.0.0-alpha.29
         browser: ^0.10.0
       transformers:
       - angular2:
@@ -262,11 +262,12 @@
 
   p.
     Next, make FriendsService available to dependency injection
-    by adding an <code>appInjector</code> parameter to DisplayComponent's
+    by adding a <code>viewInjector</code> parameter to DisplayComponent's
     <code>@Component</code> annotation:
+    <!-- TODO: check with vsavkin: use viewInjector or hostInjector here? -->
 
   code-example(language="dart").
-    @Component(selector: 'display', <span class="pnk">appInjector: const [FriendsService]</span>)
+    @Component(selector: 'display', <span class="pnk">viewInjector: const [FriendsService]</span>)
 
 .l-main-section
   h2#Conditionally-displaying-data-with-NgIf Conditionally display data using *ng-if
@@ -300,7 +301,7 @@
       import 'package:angular2/angular2.dart';
       import 'package:displaying_data/friends_service.dart';
 
-      @Component(selector: 'display', appInjector: const [FriendsService])
+      @Component(selector: 'display', viewInjector: const [FriendsService])
       @View(template: '''
       &lt;p&gt;My name: {{ myName }}&lt;/p&gt;
       &lt;p&gt;Friends:&lt;/p&gt;
@@ -359,7 +360,7 @@
       description: Displaying Data example
       version: 0.0.1
       dependencies:
-        angular2: 2.0.0-alpha.28
+        angular2: 2.0.0-alpha.29
         browser: ^0.10.0
       transformers:
       - angular2:

--- a/public/docs/dart/latest/guide/setup.jade
+++ b/public/docs/dart/latest/guide/setup.jade
@@ -30,7 +30,7 @@
     description: Getting Started example
     version: 0.0.1
     dependencies:
-      angular2: 2.0.0-alpha.26
+      angular2: 2.0.0-alpha.28
       browser: ^0.10.0
     transformers:
     - angular2:

--- a/public/docs/dart/latest/guide/setup.jade
+++ b/public/docs/dart/latest/guide/setup.jade
@@ -30,7 +30,7 @@
     description: Getting Started example
     version: 0.0.1
     dependencies:
-      angular2: 2.0.0-alpha.28
+      angular2: 2.0.0-alpha.29
       browser: ^0.10.0
     transformers:
     - angular2:

--- a/public/docs/dart/latest/guide/user-input.jade
+++ b/public/docs/dart/latest/guide/user-input.jade
@@ -197,7 +197,7 @@
       description: User Input example
       version: 0.0.1
       dependencies:
-        angular2: 2.0.0-alpha.28
+        angular2: 2.0.0-alpha.29
         browser: ^0.10.0
       transformers:
       - angular2:

--- a/public/docs/dart/latest/guide/user-input.jade
+++ b/public/docs/dart/latest/guide/user-input.jade
@@ -52,6 +52,7 @@
         'Breathe',
         'Learn Angular'
       ];
+
       addTodo(String todo) {
         todos.add(todo);
       }
@@ -196,7 +197,7 @@
       description: User Input example
       version: 0.0.1
       dependencies:
-        angular2: 2.0.0-alpha.26
+        angular2: 2.0.0-alpha.28
         browser: ^0.10.0
       transformers:
       - angular2:

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -38,13 +38,13 @@ p.
     specify the angular2 and browser packages as dependencies,
     as well as the angular2 transformer.
     Angular 2 is changing rapidly, so provide an exact version:
-    <b>2.0.0-alpha.28</b>.
+    <b>2.0.0-alpha.29</b>.
 
   code-example(language="yaml" format="linenums").
     name: hello_world
     version: 0.0.1
     dependencies:
-      angular2: 2.0.0-alpha.28
+      angular2: 2.0.0-alpha.29
       browser: ^0.10.0
     transformers:
     - angular2:
@@ -252,9 +252,9 @@ p.
     [Info from Dart2JS]:
     Compiling hello_world|web/main.dart...
     [Info from Dart2JS]:
-    Took 0:00:17.408082 to compile hello_world|web/main.dart.
-    Built 65 files to "build".
-  //- REGENERATE THIS OUTPUT - or delete it? - when updating from 2.0.0-alpha.28
+    Took 0:00:16.908569 to compile hello_world|web/main.dart.
+    Built 75 files to "build".
+  //- REGENERATE THIS OUTPUT - or delete it? - when updating from 2.0.0-alpha.29
 
   p.
     The generated JavaScript appears, along with supporting files,
@@ -273,7 +273,7 @@ p.
     name: hello_world
     version: 0.0.1
     dependencies:
-      angular2: 2.0.0-alpha.28
+      angular2: 2.0.0-alpha.29
       browser: ^0.10.0
     <span class="pnk">transformers:
     - angular2:

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -38,13 +38,13 @@ p.
     specify the angular2 and browser packages as dependencies,
     as well as the angular2 transformer.
     Angular 2 is changing rapidly, so provide an exact version:
-    <b>2.0.0-alpha.26</b>.
+    <b>2.0.0-alpha.28</b>.
 
   code-example(language="yaml" format="linenums").
     name: hello_world
     version: 0.0.1
     dependencies:
-      angular2: 2.0.0-alpha.26
+      angular2: 2.0.0-alpha.28
       browser: ^0.10.0
     transformers:
     - angular2:
@@ -248,13 +248,13 @@ p.
     Loading source assets... 
     Loading angular2 transformers... 
     INFO: Formatter is being overwritten.
-    Building hello_world... (3.8s) 
+    Building hello_world... (4.2s) 
     [Info from Dart2JS]:
     Compiling hello_world|web/main.dart...
     [Info from Dart2JS]:
-    Took 0:00:15.612746 to compile hello_world|web/main.dart.
-    Built 63 files to "build".
-  //- REGENERATE THIS OUTPUT - or delete it? - when updating from 2.0.0-alpha.26
+    Took 0:00:17.408082 to compile hello_world|web/main.dart.
+    Built 65 files to "build".
+  //- REGENERATE THIS OUTPUT - or delete it? - when updating from 2.0.0-alpha.28
 
   p.
     The generated JavaScript appears, along with supporting files,
@@ -273,7 +273,7 @@ p.
     name: hello_world
     version: 0.0.1
     dependencies:
-      angular2: 2.0.0-alpha.26
+      angular2: 2.0.0-alpha.28
       browser: ^0.10.0
     <span class="pnk">transformers:
     - angular2:


### PR DESCRIPTION
I've tested, and all of the code works in alpha 29 *except* for examples that use directives (NgFor, NgIf) ONLY when run using `pub serve`. Everything's fine in Dartium with a SimpleHttpServer or in Chrome with a SimpleHttpServer & the output of `pub build`.