### PR TITLE
docs: fixed typos in user input js (typescript) step by step guide

### DIFF
--- a/public/docs/js/latest/guide/user-input.jade
+++ b/public/docs/js/latest/guide/user-input.jade
@@ -107,7 +107,7 @@
   code-tabs
     code-pane(language="javascript" name="TypeScript" format="linenums").
       //TypeScript
-      import {Component, View, bootstrap, NgFor, NgIf} from 'angular2/angular2';
+      import {Component, View, bootstrap, NgFor} from 'angular2/angular2';
 
       @Component({
         selector: 'todo-list'
@@ -115,7 +115,7 @@
       @View({
         template: `
           &lt;ul&gt;
-            &lt;li *ngfor="#todo of todos"&gt;
+            &lt;li *ng-for="#todo of todos"&gt;
               {{ todo }}
             &lt;/li&gt;
           &lt;/ul&gt;
@@ -123,7 +123,7 @@
           &lt;input #todotext (keyup)="doneTyping($event)"&gt;
           &lt;button (click)="addTodo(todotext.value)"&gt;Add Todo&lt;/button&gt;
                 `,
-        directives: [NgFor, NIf]
+        directives: [NgFor]
       })
       class TodoList {
         todos: Array&lt;string&gt;;


### PR DESCRIPTION
- NgIf is not used in the code but it is imported.
- Typo on Line 18: NIf needs to either be removed or replaced by NgIf
- Typo on Line 10: *ngfor needs to be replaced by *ng-for

Closes #159