### PR TITLE
Fix display bug of "number index"

### DIFF
--- a/public/docs/js/latest/api/annotations/DirectiveAnnotation-class.jade
+++ b/public/docs/js/latest/api/annotations/DirectiveAnnotation-class.jade
@@ -224,8 +224,8 @@ p.location-badge.
   }
   ```
   
-  This directive would be instantiated with a <a href='../core/QueryList-class.html'><code>QueryList</code></a> which contains `Dependency` 4 and
-  6. Here, `Dependency` 5 would not be included, because it is not a direct child.
+  This directive would be instantiated with a <a href='../core/QueryList-class.html'><code>QueryList</code></a> which contains `Dependency` 4 
+  and 6. Here, `Dependency` 5 would not be included, because it is not a direct child.
   
   ### Injecting a live collection of descendant directives
   


### PR DESCRIPTION
The `6.` at the begin of line will be thought as a __NUMBER INDEX__ by Markdown and the result the dispaly of `1.` in the `<li>` element.