### PR TITLE
fix(quickstart): Add helpful note for Windows users

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -49,6 +49,13 @@
     $ npm install -g typescript@^1.5.0-beta
     $ tsc --watch -m commonjs -t es5 --emitDecoratorMetadata app.ts
 
+.callout.is-helpful
+  p.
+    Windows users: if you get an error that an option is unknown, you are probably running
+    an older version of TypeScript. 
+    See <a href="http://stackoverflow.com/questions/23267858/how-do-i-install-typescript">
+    Stack Overflow: How do I install Typescript</a>
+
 // STEP 3 - Import Angular ##########################
 .l-main-section
   h2#section-transpile 3. Import Angular


### PR DESCRIPTION
A number of people have commented on github that they get the wrong typescript version, because of Visual Studio's
version being found instead of npm.

Fixes #99