### PR TITLE
harp(update): var changes to allow use with harp 0.17.0

### DIFF
--- a/public/_includes/_head-include.jade
+++ b/public/_includes/_head-include.jade
@@ -1,8 +1,8 @@
-language = current.path[1]
-version = ''
+- var language = current.path[1]
+- var version = ''
 
 if current.path[2]
-  version = current.path[2].replace(/\_+/gm, ".")
+  - var version = current.path[2].replace(/\_+/gm, ".")
 
 if language == 'js'
 if language == 'dart'

--- a/public/_includes/_hero.jade
+++ b/public/_includes/_hero.jade
@@ -1,7 +1,7 @@
-textFormat = ''
+- var textFormat = ''
 
 if current.path[4] && current.path[3] == 'api'
-  textFormat = 'is-standard-case'
+  - var textFormat = 'is-standard-case'
 
 
 header(class="hero background-sky")

--- a/public/_includes/_hover-card.jade
+++ b/public/_includes/_hover-card.jade
@@ -1,5 +1,5 @@
-hasIcon = icon ? 'has-icon' : ''
-iconNumber = number ? number : ''
+- var hasIcon = icon ? 'has-icon' : ''
+- var iconNumber = number ? number : ''
 a(class="hover-card is-button #{hasIcon}" href="#{url}" md-button)
   if icon
     span(class="hover-card-icon #{icon}") #{iconNumber}

--- a/public/_includes/_next-item.jade
+++ b/public/_includes/_next-item.jade
@@ -1,6 +1,6 @@
-currentPage = false
-nextPage = false
-data = public.docs[current.path[1]][current.path[2]][current.path[3]]._data
+- var currentPage = false
+- var nextPage = false
+- var data = public.docs[current.path[1]][current.path[2]][current.path[3]]._data
 
 for page, slug in data
 
@@ -13,8 +13,8 @@ for page, slug in data
           a(href="/docs/#{current.path[1]}/#{current.path[2]}/#{current.path[3]}/#{slug}.html") #{page.title}
 
         //NEXT PAGE HAS NOW BEEN SET
-        nextPage = true
+        - var nextPage = true
 
     // SET CURRENT PAGE FLAG WHEN YOU PASS IT
     if current.path[4] == slug
-      currentPage = true
+      - var currentPage = true

--- a/public/_includes/_version-dropdown.jade
+++ b/public/_includes/_version-dropdown.jade
@@ -1,43 +1,43 @@
-language = current.path[1]
-title = "JavaScript "
-filter = /(\.html$)/
-replace = /(\.html$)|(^index\.html$)/
-version = ''
-page = ''
+- var language = current.path[1]
+- var title = "JavaScript "
+- var filter = /(\.html$)/
+- var replace = /(\.html$)|(^index\.html$)/
+- var version = ''
+- var page = ''
 
 <!-- Replace _ undscores with . dots -->
 if current.path[2]
-  version = current.path[2].replace(/\_+/gm, ".")
+  - var version = current.path[2].replace(/\_+/gm, ".")
 
 <!-- Replace _ undscores with . dots -->
 if current.path[3]
   if public.docs[current.path[1]][current.path[2]][current.path[3]]
-    page = current.path[3] + '/'
+    - var page = current.path[3] + '/'
   else
-    page = current.path[3] + '.html'
+    - var page = current.path[3] + '.html'
 
 <!-- VERSION TREE CREATOR MIXIN -->
 mixin tree(directory, urlPrefix, name, latest)
   ul
     for val, semvar in directory
       if semvar !== '.git' && semvar !== '_data'
-        libVersion = (semvar == "latest") ?  latest : semvar.replace(/\_+/gm, ".")
+        - var libVersion = (semvar == "latest") ?  latest : semvar.replace(/\_+/gm, ".")
         li <a href="#{urlPrefix}/#{semvar}/#{page}" md-button>#{name} #{libVersion}</a>
 
 
 <!-- BUTTON TITLE GENERATION  -->
 if language == 'js'
   if version == "latest"
-    title = 'Angular 2 for JavaScript'
+    - var title = 'Angular 2 for JavaScript'
   else
-    title = 'Angular ' + version + ' for JavaScript'
+    - var title = 'Angular ' + version + ' for JavaScript'
 
 
 if language == 'dart'
   if version == "latest"
-    title = 'Angular 2 for Dart'
+    - var title = 'Angular 2 for Dart'
   else
-    title = 'Angular ' + version + ' for Dart'
+    - var title = 'Angular ' + version + ' for Dart'
 
 
 <!-- DROPDOWN BUTTON -->

--- a/public/_layout.jade
+++ b/public/_layout.jade
@@ -12,7 +12,7 @@ html(lang="en" ng-app="angularIOApp" itemscope itemtype="http://schema.org/Frame
     else
       != partial("/_includes/_hero")
 
-    format = autoformat ? 'docs-content' : ''
+    - var format = autoformat ? 'docs-content' : ''
 
 
     article(class="l-content #{format}")

--- a/public/docs/_includes/sidenav/_primary.jade
+++ b/public/docs/_includes/sidenav/_primary.jade
@@ -13,9 +13,9 @@ nav.side-nav.l-pinned-left.l-layer-4.l-offset-nav
     if current.path[2]
       for page, slug in public.docs[current.path[1]][current.path[2]]._data
 
-        name = page.menuTitle || page.title
-        selected =  current.path[3] == slug ? 'is-selected':''
-        pathSuffix = public.docs[current.path[1]][current.path[2]][slug] ? "/" : ".html"
+        - var name = page.menuTitle || page.title
+        - var selected =  current.path[3] == slug ? 'is-selected':''
+        - var pathSuffix = public.docs[current.path[1]][current.path[2]][slug] ? "/" : ".html"
 
         li(class="#{selected}") <a href="/docs/#{current.path[1]}/#{current.path[2]}/#{slug}#{pathSuffix}" md-button><span class="side-nav-icon icon-#{page.icon}"></span> #{name}</a>
 

--- a/public/docs/_includes/sidenav/_secondary.jade
+++ b/public/docs/_includes/sidenav/_secondary.jade
@@ -1,11 +1,11 @@
-secondaryPath = public.docs[current.path[1]][current.path[2]][current.path[3]]
+- var secondaryPath = public.docs[current.path[1]][current.path[2]][current.path[3]]
 
 if secondaryPath
-  data = secondaryPath._data
-  listType = data._listtype
-  ordered = listType == "ordered" ? "is-ordered" : ""
-  items = listType == 'api' ? secondaryPath : data
-  number = 1
+  - var data = secondaryPath._data
+  - var listType = data._listtype
+  - var ordered = listType == "ordered" ? "is-ordered" : ""
+  - var items = listType == 'api' ? secondaryPath : data
+  - var number = 1
 
 
   //SECONDARY NAVIGATION
@@ -14,21 +14,21 @@ if secondaryPath
     for page, slug in items
 
       // DEFAULT LIST VALUES
-      selected =  current.path[4] == slug ? 'is-selected':''
-      name = page.title;
-      path = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug + ".html"
+      - var selected =  current.path[4] == slug ? 'is-selected':''
+      - var name = page.title;
+      - var path = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug + ".html"
 
 
       if slug != "_listtype" && slug != 'index' && slug != '_contents' && slug != '_data'
         // API LIST VALUES
         if listType == 'api'
-          name = public.docs[current.path[1]][current.path[2]][current.path[3]][slug]._data["index"]["title"]
-          path = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug
+          - var name = public.docs[current.path[1]][current.path[2]][current.path[3]][slug]._data["index"]["title"]
+          - var path = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug
 
         // ORDERED LIST VALUES
         if listType == 'ordered'
-          num = number++
-          name = (listType == "ordered") ?  num + '. ' + page.title : page.title;
+          - var num = number++
+          - var name = (listType == "ordered") ?  num + '. ' + page.title : page.title;
 
 
         li(class="#{selected}") <a href="#{path}" md-button>#{name}</a>

--- a/public/docs/_includes/sidenav/_tertiary.jade
+++ b/public/docs/_includes/sidenav/_tertiary.jade
@@ -1,14 +1,14 @@
 
 // TERTIARY NAVIGATION
-tertiaryPath = public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]
+- var tertiaryPath = public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]
 
 if tertiaryPath
-  data = tertiaryPath._data
+  - var data = tertiaryPath._data
 
   ul.side-nav-tertiary
     for page, slug in data
-      name = page.title
-      selected =  current.path[5] == slug ? 'is-selected':''
+      - var name = page.title
+      - var selected =  current.path[5] == slug ? 'is-selected':''
 
       if slug != "index"
         li(class="#{selected}")<a  href="/docs/#{current.path[1]}/#{current.path[2]}/#{current.path[3]}/#{current.path[4]}/#{slug}.html" md-button>#{name}</a>

--- a/public/docs/dart/latest/guide/index.jade
+++ b/public/docs/dart/latest/guide/index.jade
@@ -1,10 +1,10 @@
-number = 1;
+- var number = 1;
 ul.is-plain.l-offset-page-header
   for page, slug in public.docs[current.path[1]][current.path[2]].guide._data
 
     if slug != '_listtype' && slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug + ".html"
-      num = number++
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug + ".html"
+      - var num = number++
 
       li
         != partial("../../../../_includes/_hover-card", { icon: "icon-number", number: num, name: page.title, url: url })

--- a/public/docs/js/latest/api/annotations/index.jade
+++ b/public/docs/js/latest/api/annotations/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/change_detection/index.jade
+++ b/public/docs/js/latest/api/change_detection/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/core/index.jade
+++ b/public/docs/js/latest/api/core/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/di/index.jade
+++ b/public/docs/js/latest/api/di/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/directives/index.jade
+++ b/public/docs/js/latest/api/directives/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/forms/index.jade
+++ b/public/docs/js/latest/api/forms/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/http/index.jade
+++ b/public/docs/js/latest/api/http/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/index.jade
+++ b/public/docs/js/latest/api/index.jade
@@ -11,8 +11,8 @@ ul.is-plain.l-offset-page-header
   for page, slug in public.docs[current.path[1]][current.path[2]].api
     if slug != 'index' && slug != '_contents' && slug != '_data'
 
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug
-      title = public.docs[current.path[1]][current.path[2]][current.path[3]][slug]._data["index"]["title"]
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug
+      - var title = public.docs[current.path[1]][current.path[2]][current.path[3]][slug]._data["index"]["title"]
 
       li
         != partial("../../../../_includes/_hover-card", {name: title, url: url })

--- a/public/docs/js/latest/api/pipes/index.jade
+++ b/public/docs/js/latest/api/pipes/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/router/index.jade
+++ b/public/docs/js/latest/api/router/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/api/test/index.jade
+++ b/public/docs/js/latest/api/test/index.jade
@@ -4,7 +4,7 @@ p.location-badge.
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data
     if slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + current.path[4] + "/" + slug + ".html"
 
       li.c8
         != partial("../../../../../_includes/_hover-card", {name: page.title, url: url })

--- a/public/docs/js/latest/guide/index.jade
+++ b/public/docs/js/latest/guide/index.jade
@@ -1,10 +1,10 @@
-number = 1;
+- var number = 1;
 ul.is-plain.l-offset-page-header
   for page, slug in public.docs[current.path[1]][current.path[2]].guide._data
 
     if slug != '_listtype' && slug != 'index'
-      url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug + ".html"
-      num = number++
+      - var url = "/docs/" + current.path[1] + "/" + current.path[2] + "/" + current.path[3] + "/" + slug + ".html"
+      - var num = number++
 
       li
         != partial("../../../../_includes/_hover-card", { icon: "icon-number", number: num, name: page.title, url: url })


### PR DESCRIPTION
This isn't ready to merge yet for two reasons:
1) I can't get `harp compile` to work: the API doc templates are throwing `Error - unexpected token "pipeless-text"` on docs like e.g. `docs/js/latest/api/annotations/ClassDefinition-interface.html`. I couldn't figure out what the error was.
2) I made local changes to some of the API doc index pages that contain vars set by the dgeni template. These should really be fixed in the angular/angular repo. They're in this PR for testing, but the error above makes me think I missed something...?

See https://github.com/angular/angular/issues/3325 in angular/angular for the template issue.