### PR TITLE
Update imported angular version in index.html example.

### DIFF
--- a/public/docs/js/latest/guide/setup.jade
+++ b/public/docs/js/latest/guide/setup.jade
@@ -46,7 +46,7 @@
         &lt;head&gt;
           &lt;script src=&quot;https://github.jspm.io/jmcriffey/bower-traceur-runtime@0.0.87/traceur-runtime.js&quot;&gt;&lt;/script&gt;
           &lt;script src=&quot;https://jspm.io/system@0.16.js&quot;&gt;&lt;/script&gt;
-          &lt;script src=&quot;https://code.angularjs.org/2.0.0-alpha.26/angular2.dev.js&quot;&gt;&lt;/script&gt;
+          &lt;script src=&quot;https://code.angularjs.org/2.0.0-alpha.32/angular2.dev.js&quot;&gt;&lt;/script&gt;
         &lt;/head&gt;
         &lt;body&gt;
           &lt;my-app&gt;&lt;/my-app&gt;
@@ -60,7 +60,7 @@
       &lt;!DOCTYPE html&gt;
       &lt;html&gt;
         &lt;head&gt;
-          &lt;script src=&quot;https://code.angularjs.org/2.0.0-alpha.26/angular2.sfx.dev.js&quot;&gt;&lt;/script&gt;
+          &lt;script src=&quot;https://code.angularjs.org/2.0.0-alpha.32/angular2.sfx.dev.js&quot;&gt;&lt;/script&gt;
           &lt;script src=&quot;main.js&quot;&gt;&lt;/script&gt;
         &lt;/head&gt;
         &lt;body&gt;

--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -188,7 +188,7 @@
       &lt;head&gt;
         &lt;title&gt;Angular 2 Quickstart&lt;/title&gt;
         &lt;script src="https://github.jspm.io/jmcriffey/bower-traceur-runtime@0.0.87/traceur-runtime.js"&gt;&lt;/script&gt;
-        &lt;script src="https://code.angularjs.org/2.0.0-alpha.28/angular2.dev.js"&gt;&lt;/script&gt;
+        &lt;script src="https://code.angularjs.org/2.0.0-alpha.32/angular2.dev.js"&gt;&lt;/script&gt;
       &lt;/head&gt;
       &lt;body&gt;
 
@@ -223,7 +223,7 @@
       &lt;title&gt;Angular 2 Quickstart&lt;/title&gt;
       &lt;script src="https://github.jspm.io/jmcriffey/bower-traceur-runtime@0.0.87/traceur-runtime.js"&gt;&lt;/script&gt;
       &lt;script src="https://jspm.io/system@0.16.js"&gt;&lt;/script&gt;
-      &lt;script src="https://code.angularjs.org/2.0.0-alpha.28/angular2.dev.js"&gt;&lt;/script&gt;
+      &lt;script src="https://code.angularjs.org/2.0.0-alpha.32/angular2.dev.js"&gt;&lt;/script&gt;
     &lt;/head&gt;
 
   p.


### PR DESCRIPTION
Using version alpha 28 we are unable to use component injection used in other part of the tutorial.
I take this error : 

    Error during instantiation of Token(ComponentRef)!. ORIGINAL ERROR: TypeError: Cannot read
    property 'toString' of undefined

    Error
        at InstantiationError.BaseException (angular2.dev.js:7248)
    ...


I had to check and update angular version to alpha 32 in order to make my service injection work.