### PR TITLE
Set the minimum typescript version to 1.5.0

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -46,13 +46,13 @@
     are loaded, or configure your editor or IDE to do it.
 
   code-example.
-    $ npm install -g typescript@^1.5.0-beta
+    $ npm install -g typescript@^1.5.0
     $ tsc --watch -m commonjs -t es5 --emitDecoratorMetadata app.ts
 
 .callout.is-helpful
   p.
     Windows users: if you get an error that an option is unknown, you are probably running
-    an older version of TypeScript. 
+    an older version of TypeScript.
     See <a href="http://stackoverflow.com/questions/23267858/how-do-i-install-typescript">
     Stack Overflow: How do I install Typescript</a>
 


### PR DESCRIPTION
fixes #172

^1.5.0-beta means >= 1.5.0 and < 2.0.0 and is technically valid. however
it's probably nicer not to refer to beta versions in the doc.