### PR TITLE
#185 - Eliminate "error TS6064" while executing tsc --watch

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -47,7 +47,7 @@
 
   code-example.
     $ npm install -g typescript@^1.5.0
-    $ tsc --watch -m commonjs -t es5 --emitDecoratorMetadata app.ts
+    $ tsc --watch -m commonjs -t es5 --emitDecoratorMetadata --experimentalDecorators app.ts
 
 .callout.is-helpful
   p.


### PR DESCRIPTION
Below command given in QuickStart.html, throws error when executed. Therefore suggesting an extra option to eliminate it. 

tsc --watch -m commonjs -t es5 --emitDecoratorMetadata app.ts
error TS6064: Option 'experimentalDecorators' must also be specified when option 'emitDecoratorMetadata' is specified.
message TS6042: Compilation complete. Watching for file changes.
  
Works correctly with additional option.
tsc --watch -m commonjs -t es5 --emitDecoratorMetadata --experimentalDecorators app.ts
message TS6042: Compilation complete. Watching for file changes.