### PR TITLE
Rename viewInjector to viewBindings in the developer guide

### DIFF
--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -258,12 +258,12 @@
 
   p.
     Next, make FriendsService available to dependency injection
-    by adding a <code>viewInjector</code> parameter to DisplayComponent's
+    by adding a <code>viewBindings</code> parameter to DisplayComponent's
     <code>@Component</code> annotation:
-    <!-- TODO: check with vsavkin: use viewInjector or hostInjector here? -->
+    <!-- TODO: check with vsavkin: use viewBindings or hostInjector here? -->
 
   code-example(language="dart").
-    @Component(selector: 'display', <span class="pnk">viewInjector: const [FriendsService]</span>)
+    @Component(selector: 'display', <span class="pnk">viewBindings: const [FriendsService]</span>)
 
 .l-main-section
   h2#Conditionally-displaying-data-with-NgIf Conditionally display data using *ng-if
@@ -297,7 +297,7 @@
       import 'package:angular2/angular2.dart';
       import 'package:displaying_data/friends_service.dart';
 
-      @Component(selector: 'display', viewInjector: const [FriendsService])
+      @Component(selector: 'display', viewBindings: const [FriendsService])
       @View(template: '''
       &lt;p&gt;My name: {{ myName }}&lt;/p&gt;
       &lt;p&gt;Friends:&lt;/p&gt;


### PR DESCRIPTION
This refactor has been made in the code, but was forgotten in the dev guide.

Fixes angular/angular#3781