### PR TITLE
Step by step guide: use http-server instead of python

### DIFF
--- a/public/docs/js/latest/guide/setup.jade
+++ b/public/docs/js/latest/guide/setup.jade
@@ -12,10 +12,18 @@
     You can edit and test out your apps by serving local files with a web server. Follow the steps in the <a href="../quickstart.html">quickstart</a> to get Typescript setup.
 
   p.
-    When you're serving local files, edit and save them and start a web server that serves files in that directory.  If you have Python installed, you can run a basic HTTP server from the root of your code directory with:
+    If you don't already have an HTTP server,
+    you can install one using <code>npm install -g http-server</code>.
+    (If that results in an access error, then you might need to use
+    <code><b>sudo</b> npm ...</code>.)
 
-  pre.prettyprint.lang-bash
-    code python -m SimpleHTTPServer 8000
+  p For example:
+
+  code-example.
+    # From the directory that contains index.html:
+    npm install -g http-server  # Or sudo npm install -g http-server
+    http-server                 # Creates a server at localhost:8080
+    # In a browser, visit localhost:8080/index.html
 
 .callout.is-helpful
   header Typescript vs ES5

--- a/public/docs/js/latest/guide/setupAlt.jade
+++ b/public/docs/js/latest/guide/setupAlt.jade
@@ -12,10 +12,16 @@ include ../../../../_includes/_util-fns
 
     You can edit and test out your apps by serving local files with a web server. Follow the steps in the <a href="../quickstart.html">quickstart</a> to get Typescript setup.
 
-    When you're serving local files, edit and save them and start a web server that serves files in that directory.  If you have Python installed, you can run a basic HTTP server from the root of your code directory with:
+    If you don't already have an HTTP server, you can install one using <code>npm install -g http-server</code>. (If that results in an access error, then you might need to use <code><b>sudo</b> npm ...</code>.)
+
+    For example:
 
   pre.prettyprint.lang-bash
-    code python -m SimpleHTTPServer 8000
+    code.
+      # From the directory that contains index.html:
+      npm install -g http-server  # Or sudo npm install -g http-server
+      http-server                 # Creates a server at localhost:8080
+      # In a browser, visit localhost:8080/index.html
 
 .callout.is-helpful
   header Typescript vs ES5
@@ -33,11 +39,11 @@ include ../../../../_includes/_util-fns
 
     In the `<body>`, add an element called `<my-app>` that will be the root of your
     application.
-    
+
     The TypeScript setup includes System.js, a third-party open-source library that adds ES6 module loading functionality to browsers. This step isn't needed for the ES5 version.
 
   +makeTabs('gettingstarted', 'ts/index.html,js/index.html', 'TypeScript, JavaScript')
-  
+
 .callout.is-helpful
   header Don't use code.angularjs.org in a live app
   :markdown

--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -245,8 +245,9 @@
     If you don't already have an HTTP server,
     you can install one using <code>npm install -g http-server</code>.
     (If that results in an access error, then you might need to use
-    <code><b>sudo</b> npm ...</code>)
-    For example:
+    <code><b>sudo</b> npm ...</code>.)
+
+  p For example:
 
   code-example.
     # From the directory that contains index.html:


### PR DESCRIPTION
- `http-server` is already used in the quick start guide,
- fontend devs are less likely to have Python installed