### PR TITLE
Use the `bindings` syntax in the latest step-by-step guide

### DIFF
--- a/public/docs/js/latest/guide/displaying-data.jade
+++ b/public/docs/js/latest/guide/displaying-data.jade
@@ -222,7 +222,7 @@
         }
 
     p.
-        Now replace the current list of friends in DisplayComponent by including the FriendsService in the injectables list,
+        Now replace the current list of friends in DisplayComponent by including the FriendsService in the bindings list,
         then including the service in the constructor, and finally setting the list of
         names in DisplayComponent to the names provided by the service you passed in.
 
@@ -257,7 +257,7 @@
         DisplayComponent.annotations = [
           new angular.ComponentAnnotation({
             selector: "display",
-            <span class='otl'>appInjector: [FriendsService]</span>
+            <span class='otl'>bindings: [FriendsService]</span>
           }),
           new angular.ViewAnnotation({
             template: '{{ myName }} &lt;ul&gt; &lt;li *for="#name of names"&gt;{{ name }}&lt;/li&gt; &lt;/ul&gt;',

--- a/public/docs/js/latest/guide/displaying-data.jade
+++ b/public/docs/js/latest/guide/displaying-data.jade
@@ -236,7 +236,7 @@
       code-pane(language="javascript" name="TypeScript" format="linenums").
         @Component({
           ...
-          <span class='otl'>appInjector: [FriendsService]</span>
+          <span class='otl'>bindings: [FriendsService]</span>
         })
         class DisplayComponent {
           myName: string;


### PR DESCRIPTION
The example as displayed here:  https://angular.io/docs/js/latest/guide/displaying-data.html does not work. The syntax has already been changed in alpha-35 to use `bindings` instead of `appInjector`