### PR TITLE
Add tsconfig.json file to the Quick-Start tutorial

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -30,10 +30,22 @@
     $ tsd install angular2 es6-promise rx rx-lite
 
   p.
-    Next, create two empty files, <code>index.html</code> and <code>app.ts</code>, both at the root of the project:
+    Next, create three empty files, <code>index.html</code>, <code>app.ts</code>, and <code>tsconfig.json</code>, at the root of the project:
 
   code-example.
-    $ touch app.ts index.html
+    $ touch app.ts index.html tsconfig.json
+  
+  p.
+    Finally, inside of <code>tsconfig.json</code>, insert the following TypeScript configration which configures <code>tsc</code> to target ES5, use the <code>commonjs</code> module, and add support for Experimental Decorators, which you will learn about later.
+  code-example.
+    {
+        "compilerOptions": {
+            "target": "ES5",
+            "module": "commonjs",
+            "experimentalDecorators": true
+        }
+    }
+
 
 // STEP 2 - Start the TypeScript compiler ##########################
 .l-main-section
@@ -47,7 +59,7 @@
 
   code-example.
     $ npm install -g typescript@^1.5.0-beta
-    $ tsc --watch -m commonjs -t es5 --emitDecoratorMetadata app.ts
+    $ tsc --watch app.ts
 
 .callout.is-helpful
   p.


### PR DESCRIPTION
Include the tsconfig.json file with some basic TypeScript configuration elements so that IDEs such as Visual Studio Code and WebStorm will not throw errors later on in the tutorial due to missing "module", "target" or "experimental decorator" configuration.