### PR TITLE
Directive doctypes - initial functionality

### DIFF
--- a/public/api-builder/angular.io-package/index.js
+++ b/public/api-builder/angular.io-package/index.js
@@ -32,10 +32,6 @@ module.exports = new Package('angular.io', [basePackage])
   ];
   readTypeScriptModules.hidePrivateMembers = true;
 
-  // HACK - readFileProcessor.basePath set to point to a local repo location
-  // because the docs-package-processor will
-  // have previously set it to point to angular/angular repo.
-  // needed because the writeFilesProcessor uses the readFilesProcessor's basePath.
   readFilesProcessor.basePath = path.resolve(__dirname, "../../docs");
   writeFilesProcessor.outputFolder  = 'js/latest/api';
 })

--- a/public/api-builder/angular.io-package/index.js
+++ b/public/api-builder/angular.io-package/index.js
@@ -7,6 +7,9 @@ module.exports = new Package('angular.io', [basePackage])
 .factory(require('./services/renderMarkdown'))
 .processor(require('./processors/addJadeDataDocsProcessor'))
 .processor(require('./processors/filterUnwantedDecorators'))
+.processor(require('./processors/extractDirectiveClasses'))
+.processor(require('./processors/matchUpDirectiveDecorators'))
+
 // overrides base packageInfo and returns the one for the 'angular/angular' repo.
 .factory(require('./services/packageInfo'))
 

--- a/public/api-builder/angular.io-package/processors/extractDirectiveClasses.js
+++ b/public/api-builder/angular.io-package/processors/extractDirectiveClasses.js
@@ -1,0 +1,30 @@
+var _ = require('lodash');
+
+module.exports = function extractDirectiveClassesProcessor(EXPORT_DOC_TYPES) {
+
+  // Add the "directive" docType into those that can be exported from a module
+  EXPORT_DOC_TYPES.push('directive');
+
+  return {
+    $runAfter: ['processing-docs'],
+    $runBefore: ['docs-processed'],
+    decoratorTypes: ['Directive', 'Component', 'View'],
+    $process: function(docs) {
+      var decoratorTypes = this.decoratorTypes;
+
+      _.forEach(docs, function(doc) {
+
+        _.forEach(doc.decorators, function(decorator) {
+
+          if (decoratorTypes.indexOf(decorator.name) !== -1) {
+            doc.docType = 'directive';
+
+            doc[decorator.name.toLowerCase() + 'Options'] = decorator.argumentInfo[0];
+          }
+        });
+      });
+
+      return docs;
+    }
+  };
+};

--- a/public/api-builder/angular.io-package/processors/extractDirectiveClasses.spec.js
+++ b/public/api-builder/angular.io-package/processors/extractDirectiveClasses.spec.js
@@ -1,0 +1,51 @@
+var mockPackage = require('../mocks/mockPackage');
+var Dgeni = require('dgeni');
+
+describe('extractDirectiveClasses processor', function() {
+  var dgeni, injector, processor;
+
+  beforeEach(function() {
+    dgeni = new Dgeni([mockPackage()]);
+    injector = dgeni.configureInjector();
+    processor = injector.get('extractDirectiveClassesProcessor');
+  });
+
+  it('should extract specified decorator arguments', function() {
+    var doc = {
+      id: 'angular2/angular2.ngFor',
+      name: 'ngFor',
+      docType: 'class',
+      decorators: [
+        {
+          name: 'Directive',
+          arguments: ['{selector: \'[ng-for][ng-for-of]\', properties: [\'ngForOf\']}'],
+          argumentInfo: [
+            { selector: '[ng-for][ng-for-of]', properties: ['ngForOf'] }
+          ]
+        }
+      ]
+    };
+
+    var docs = processor.$process([doc]);
+
+    expect(doc).toEqual(jasmine.objectContaining({
+      id: 'angular2/angular2.ngFor',
+      name: 'ngFor',
+      docType: 'directive',
+      decorators: [
+        {
+          name: 'Directive',
+          arguments: ['{selector: \'[ng-for][ng-for-of]\', properties: [\'ngForOf\']}'],
+          argumentInfo: [
+            { selector: '[ng-for][ng-for-of]', properties: ['ngForOf'] }
+          ]
+        }
+      ]
+    }));
+
+    expect(doc.directiveOptions).toEqual({
+      selector: '[ng-for][ng-for-of]',
+      properties: ['ngForOf']
+    });
+  });
+});

--- a/public/api-builder/angular.io-package/processors/matchUpDirectiveDecorators.js
+++ b/public/api-builder/angular.io-package/processors/matchUpDirectiveDecorators.js
@@ -1,0 +1,65 @@
+var _ = require('lodash');
+
+/**
+ * @dgProcessor
+ * @description
+ *
+ */
+module.exports = function matchUpDirectiveDecoratorsProcessor(aliasMap) {
+
+  return {
+    $runAfter: ['ids-computed', 'paths-computed'],
+    $runBefore: ['rendering-docs'],
+    decoratorMappings: {
+      'Inputs' : 'inputs',
+      'Outputs' : 'outputs'
+    },
+    $process: function(docs) {
+      var decoratorMappings = this.decoratorMappings;
+      _.forEach(docs, function(doc) {
+        if (doc.docType === 'directive') {
+          doc.selector = doc.directiveOptions.selector;
+
+          for(decoratorName in decoratorMappings) {
+            var propertyName = decoratorMappings[decoratorName];
+            doc[propertyName] = getDecoratorValues(doc.directiveOptions[propertyName], decoratorName, doc.members);
+          }
+        }
+      });
+    }
+  };
+};
+
+function getDecoratorValues(classDecoratorValues, memberDecoratorName, members) {
+  var optionMap = {};
+  var decoratorValues = {};
+
+  // Parse the class decorator
+  _.forEach(classDecoratorValues, function(option) {
+    // Options are of the form: "propName : bindingName" (bindingName is optional)
+    var optionPair = option.split(':');
+    var propertyName = optionPair.shift().trim();
+    var bindingName = (optionPair.shift() || '').trim() || propertyName;
+
+    decoratorValues[propertyName] = {
+      propertyName: propertyName,
+      bindingName: bindingName
+    };
+  });
+
+  _.forEach(members, function(member) {
+    _.forEach(member.decorators, function(decorator) {
+      if (decorator.name === memberDecoratorName) {
+        decoratorValues[member.name] = {
+          propertyName: member.name,
+          bindingName: decorator.arguments[0] || member.name
+        };
+      }
+    });
+    if (decoratorValues[member.name]) {
+      decoratorValues[member.name].memberDoc = member;
+    }
+  });
+
+  return decoratorValues;
+}

--- a/public/api-builder/angular.io-package/templates/class.template.html
+++ b/public/api-builder/angular.io-package/templates/class.template.html
@@ -20,10 +20,10 @@ p.location-badge.
   h2 Annotations
 {%- for decorator in doc.decorators %}
   .l-sub-section
-    h3.annotation {$ decorator.name $}
-    pre.prettyprint
-      code.
-        @{$ decorator.name $}{$ paramList(decorator.arguments) | indent(8, false) $}
+    h3.annotation
+      pre.prettyprint
+        code.
+          @{$ decorator.name $}{$ paramList(decorator.arguments) | indent(8, false) $}
 {% endfor %}
 {%- endif %}
 
@@ -34,32 +34,23 @@ p.location-badge.
 
 {%- if doc.constructorDoc %}
   .l-sub-section
-    h3#{$ doc.constructorDoc.name | toId $} {$ doc.constructorDoc.name $}
-
-    {% if doc.constructorDoc.parameters %}
-    pre.prettyprint
-      code.
-        {$ doc.constructorDoc.name $}{$ paramList(doc.constructorDoc.parameters) | indent(8, false) | trim $}
-    {% endif %}
+    h3#{$ doc.constructorDoc.name | toId $}
+      pre.prettyprint
+        code.
+          {$ doc.constructorDoc.name $}{$ paramList(doc.constructorDoc.parameters) | indent(8, false) | trim $}
     :markdown
 {$ doc.constructorDoc.description | indentForMarkdown(6) | replace('## Example', '') | replace('# Example', '') | trimBlankLines $}
-
-
 {% endif -%}
 
 {%- for member in doc.members %}{% if not member.internal %}
   .l-sub-section
-    h3#{$ member.name | toId $} {$ member.name $}{% if member.optional %}?{% endif %}
+    h3#{$ member.name | toId $}
+      pre.prettyprint
+        code.
+          {$ member.name $}{$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(member.returnType) $}
 
-    {% if member.parameters %}
-    pre.prettyprint
-      code.
-        {$ member.name $}{$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(doc.returnType) $}
-    {% endif %}
     :markdown
 {$ member.description | indentForMarkdown(6) | replace('## Example', '') | replace('# Example', '') | trimBlankLines $}
-
-
 
 {% endif %}{% endfor %}
 {%- endif -%}

--- a/public/api-builder/angular.io-package/templates/class.template.html
+++ b/public/api-builder/angular.io-package/templates/class.template.html
@@ -15,7 +15,7 @@ p.location-badge.
 {$ doc.description | indentForMarkdown(2) | trimBlankLines $}
 {% endif -%}
 
-{%- if doc.decorators %}
+{%- if doc.decorators.length %}
 .l-main-section
   h2 Annotations
 {%- for decorator in doc.decorators %}
@@ -25,10 +25,10 @@ p.location-badge.
       code.
         @{$ decorator.name $}{$ paramList(decorator.arguments) | indent(8, false) $}
 {% endfor %}
-{% endif -%}
+{%- endif %}
 
 
-{%- if doc.constructorDoc or doc.members.length -%}
+{% if doc.constructorDoc or doc.members.length -%}
 .l-main-section
   h2 Members
 

--- a/public/api-builder/angular.io-package/templates/class.template.html
+++ b/public/api-builder/angular.io-package/templates/class.template.html
@@ -4,6 +4,12 @@
 
 {% block body %}
 include ../../_util-fns
+
+h2(class="{$ doc.docType $} export")
+  pre.prettyprint
+    code.
+      export {$ doc.docType $} {$ doc.name $}
+
 p.location-badge.
   exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
   defined in {$ githubViewLink(doc) $}

--- a/public/api-builder/angular.io-package/templates/class.template.html
+++ b/public/api-builder/angular.io-package/templates/class.template.html
@@ -19,7 +19,10 @@ p.location-badge.
   *Not Yet Documented*
 {% else %}
 {$ doc.description | indentForMarkdown(2) | trimBlankLines $}
-{% endif -%}
+{% endif %}
+
+{% block additional %}
+{% endblock %}
 
 {%- if doc.decorators.length %}
 .l-main-section

--- a/public/api-builder/angular.io-package/templates/directive.template.html
+++ b/public/api-builder/angular.io-package/templates/directive.template.html
@@ -1,0 +1,33 @@
+{% include "lib/githubLinks.html" -%}
+{% include "lib/paramList.html" -%}
+{% extends 'class.template.html' -%}
+
+{% block additional %}
+.l-main-section
+  h2 Selector
+  .l-sub-section
+    h3.selector
+      code {$ doc.directiveOptions.selector $}
+
+.l-main-section
+  h2 Inputs
+  .l-sub-section
+    h3.input {% for binding, property in doc.inputs %}
+      code {$ property.bindingName | dashCase $}
+      | &nbsp;bound to&nbsp;
+      code {$ property.memberDoc.classDoc.name $}.{$ property.propertyName $}
+    :markdown
+{$ property.memberDoc.description | indentForMarkdown(2) | trimBlankLines $}
+  {% endfor %}
+
+.l-main-section
+  h2 Outputs
+  .l-sub-section
+    h3.input {% for binding, property in doc.outputs %}
+      code {$ property.bindingName | dashCase $}
+      | &nbsp;bound to&nbsp;
+      code {$ property.memberDoc.classDoc.name $}.{$ property.propertyName $}
+    :markdown
+{$ event.memberDoc.description | indentForMarkdown(2) | trimBlankLines $}
+  {% endfor %}
+{% endblock %}

--- a/public/api-builder/angular.io-package/templates/directive.template.html
+++ b/public/api-builder/angular.io-package/templates/directive.template.html
@@ -4,11 +4,14 @@
 
 {% block additional %}
 .l-main-section
-  h2 Selector
+  h2 Selectors
   .l-sub-section
+    {% for selector in doc.directiveOptions.selector.split(',') %}
     h3.selector
-      code {$ doc.directiveOptions.selector $}
+      code {$ selector $}
+    {% endfor %}
 
+{% if doc.inputs.length %}
 .l-main-section
   h2 Inputs
   .l-sub-section
@@ -19,7 +22,9 @@
     :markdown
 {$ property.memberDoc.description | indentForMarkdown(2) | trimBlankLines $}
   {% endfor %}
+{% endif %}
 
+{% if doc.ouputs.length %}
 .l-main-section
   h2 Outputs
   .l-sub-section
@@ -29,5 +34,6 @@
       code {$ property.memberDoc.classDoc.name $}.{$ property.propertyName $}
     :markdown
 {$ event.memberDoc.description | indentForMarkdown(2) | trimBlankLines $}
-  {% endfor %}
+{% endfor %}
+{% endif %}
 {% endblock %}

--- a/public/api-builder/angular.io-package/templates/function.template.html
+++ b/public/api-builder/angular.io-package/templates/function.template.html
@@ -5,13 +5,10 @@
 {% block body %}
 include ../../_util-fns
 .l-main-section
-  h2(class="function export") {$ doc.name $}
-
-  {% if doc.parameters %}
-  pre.prettyprint
-    code.
-      {$ doc.name $}{$ paramList(doc.parameters) | indent(4, true) | trim $}{$ returnType(doc.returnType) $}
-  {% endif %}
+  h2(class="function export")
+    pre.prettyprint
+      code.
+        export {$ doc.name $}{$ paramList(doc.parameters) | indent(4, true) | trim $}{$ returnType(doc.returnType) $}
 
   p.location-badge.
     exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }

--- a/public/api-builder/angular.io-package/templates/var.template.html
+++ b/public/api-builder/angular.io-package/templates/var.template.html
@@ -1,9 +1,15 @@
 {% include "lib/githubLinks.html" -%}
+{% include "lib/paramList.html" -%}
 {% extends 'layout/base.template.html' %}
 
 {% block body %}
 include ../../_util-fns
 .l-main-section
+  h2(class="variable export")
+    pre.prettyprint
+      code.
+        export {$ doc.name $}{$ returnType(doc.returnType) $}
+
   p.location-badge.
     exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
     defined in {$ githubViewLink(doc) $}

--- a/public/api-builder/docs-package/index.js
+++ b/public/api-builder/docs-package/index.js
@@ -15,6 +15,7 @@ module.exports = new Package('angular-v2-docs', [jsdocPackage, nunjucksPackage, 
 
 // Register the processors
 .processor(require('./processors/convertPrivateClassesToInterfaces'))
+.processor(require('./processors/extractDirectiveClasses'))
 .processor(require('./processors/generateNavigationDoc'))
 .processor(require('./processors/extractTitleFromGuides'))
 .processor(require('./processors/createOverviewDump'))

--- a/public/api-builder/docs-package/index.js
+++ b/public/api-builder/docs-package/index.js
@@ -43,17 +43,11 @@ module.exports = new Package('angular-v2-docs', [jsdocPackage, nunjucksPackage, 
   if (!fs.existsSync(angular_repo_path)) {
     throw new Error('build-api-docs task requires the angular2 repo to be at ' + angular_repo_path);
   }
-  readFilesProcessor.basePath = angular_repo_path;
-  readFilesProcessor.sourceFiles = [
-    { include: 'modules/*/docs/**/*.md', basePath: 'modules' },
-    { include: 'docs/content/**/*.md', basePath: 'docs/content' }
-  ];
-
   readTypeScriptModules.sourceFiles = [
     '*/*.@(js|es6|ts)',
     '*/src/**/*.@(js|es6|ts)'
   ];
-  readTypeScriptModules.basePath = path.resolve(readFilesProcessor.basePath, 'modules');
+  readTypeScriptModules.basePath = path.resolve(angular_repo_path, 'modules');
 })
 
 

--- a/public/api-builder/docs-package/processors/extractDirectiveClasses.js
+++ b/public/api-builder/docs-package/processors/extractDirectiveClasses.js
@@ -1,0 +1,32 @@
+var _ = require('lodash');
+var vm = require('vm');
+
+module.exports = function extractDirectiveClassesProcessor() {
+  return {
+    $runAfter: ['processing-docs'],
+    $runBefore: ['docs-processed'],
+    decoratorTypes: ['Directive', 'Component', 'View'],
+    $process: function(docs) {
+      var decoratorTypes = this.decoratorTypes;
+
+      _.forEach(docs, function(doc) {
+
+        _.forEach(doc.decorators, function(decorator) {
+
+          if (decoratorTypes.indexOf(decorator.name) !== -1) {
+
+            // We use this sneaky vm trick to extract the object literal
+            // argument from the decorator's constructor call
+            var args = decorator.arguments ?
+              vm.runInNewContext('dummy = ' + decorator.arguments[0]) : {};
+
+            doc[decorator.name.toLowerCase() + 'Options'] = args;
+            doc.docType = 'directive';
+          }
+        });
+      });
+
+      return docs;
+    }
+  };
+};

--- a/public/api-builder/docs-package/processors/extractDirectiveClasses.spec.js
+++ b/public/api-builder/docs-package/processors/extractDirectiveClasses.spec.js
@@ -1,0 +1,45 @@
+var mockPackage = require('../mocks/mockPackage');
+var Dgeni = require('dgeni');
+
+describe('extractDirectiveClasses processor', function() {
+  var dgeni, injector, processor;
+
+  beforeEach(function() {
+    dgeni = new Dgeni([mockPackage()]);
+    injector = dgeni.configureInjector();
+    processor = injector.get('extractDirectiveClassesProcessor');
+  });
+
+  it('should extract specified decorator arguments', function() {
+    var doc = {
+      id: 'angular2/angular2.ngFor',
+      name: 'ngFor',
+      docType: 'class',
+      decorators: [
+        {
+          name: 'Directive',
+          arguments: ['{selector: \'[ng-for][ng-for-of]\', properties: [\'ngForOf\']}']
+        }
+      ]
+    };
+
+    var docs = processor.$process([doc]);
+
+    expect(doc).toEqual(jasmine.objectContaining({
+      id: 'angular2/angular2.ngFor',
+      name: 'ngFor',
+      docType: 'directive',
+      decorators: [
+        {
+          name: 'Directive',
+          arguments: ['{selector: \'[ng-for][ng-for-of]\', properties: [\'ngForOf\']}']
+        }
+      ]
+    }));
+
+    expect(doc.directiveOptions).toEqual({
+      selector: '[ng-for][ng-for-of]',
+      properties: ['ngForOf']
+    });
+  });
+});

--- a/public/api-builder/typescript-package/index.js
+++ b/public/api-builder/typescript-package/index.js
@@ -44,12 +44,14 @@ module.exports = new Package('typescript-parsing', [basePackage])
   computeIdsProcessor.idTemplates.push({
     docTypes: ['member'],
     idTemplate: '${classDoc.id}.${name}',
-    getAliases: function(doc) { return [doc.id]; }
+    getAliases: function(doc) {
+      return doc.classDoc.aliases.map(function(alias) { return alias + '.' + doc.name; });
+    }
   });
 
   computePathsProcessor.pathTemplates.push({
     docTypes: ['member'],
-    pathTemplate: '${classDoc.path}/${name}',
+    pathTemplate: '${classDoc.path}#${name}',
     getOutputPath: function() {} // These docs are not written to their own file, instead they are part of their class doc
   });
 

--- a/public/docs/ts/latest/api/index.jade
+++ b/public/docs/ts/latest/api/index.jade
@@ -13,6 +13,6 @@ article(class="l-content-small grid-fluid docs-content")
     h3 {{ section.title }}
     ul.api-list
       li.api-item(ng-repeat='item in apiList[section.name] | filter: { title: apiFilter, docType: apiType }')
-        a(ng-href='{{ section.name }}/{{ item.title }}-{{ item.docType === "directive" ? "class" : item.docType }}.html')
+        a(ng-href='{{ section.name }}/{{ item.title }}-{{ item.docType }}.html')
           span(class='symbol {{ item.docType }}')
           | {{ item.title }}

--- a/public/resources/css/main.scss
+++ b/public/resources/css/main.scss
@@ -28,6 +28,7 @@
 @import 'module/buttons';
 @import 'module/table';
 @import 'module/code';
+@import 'module/heading-code';
 @import 'module/code-box';
 @import 'module/sticker';
 @import 'module/bio-card';

--- a/public/resources/css/module/_heading-code.scss
+++ b/public/resources/css/module/_heading-code.scss
@@ -1,0 +1,53 @@
+h1, h2, h3, h4 {
+  .prettyprint {
+    background: $snow;
+    font-family: $mono-font;
+    color: $steel;
+    overflow: hidden;
+    position: relative;
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 24px;
+    margin: 0;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+
+    code {
+      background: none;
+      font-size: 15px;
+      padding: 0px;
+    }
+
+
+    .kwd {
+      color: $steel;
+    }
+    .typ,
+    .tag {
+      color: $ruby;
+    }
+    .str,
+    .atv {
+      color: darken($sunshine, 50%);
+    }
+    .atn {
+      color: darken($cactus, 10%);
+    }
+    .com {
+      color: $cloud;
+    }
+    .lit {
+      color: darken($sunshine, 50%);
+    }
+    .pun {
+      color: $coal;
+    }
+    .pln {
+      color: $coal;
+    }
+    .dec {
+      color: darken($grape, 5%);
+    }
+  }
+}


### PR DESCRIPTION
The new processor will convert classes that are annotated (decorated) as Directives, to a new doc type of `directive` and also extract the juicy directive metadata into the doc so that it can be displayed nicely.