### PR TITLE
styling of download button

### DIFF
--- a/public/_includes/_cta-bar.jade
+++ b/public/_includes/_cta-bar.jade
@@ -1,3 +1,3 @@
 .cta-bar
   a(href="/docs/js/latest/quickstart.html" class="button button-large button-shield md-raised md-primary" md-button) Learn in 5 Min
-  a(href="download/" class="button button-large button-secondary" md-button) Download
+  a(href="download/" class="button button-large md-raised md-primary" md-button) Download


### PR DESCRIPTION
- adds 'md-raised' 'md-primary' classes to download button
- removes 'button-secondary' class from download button

Download button in the bottom of the page has very low contrast in and the text is barely visible in both normal and hover state.

![angular.io download button](http://i.imgur.com/Aqv5g4b.gif)

Tested in [Color Contrast Analyzer](https://chrome.google.com/webstore/detail/color-contrast-analyzer/dagdlcijhfbmgkjokkjicnnfimlebcll?hl=en)
![angular](https://cloud.githubusercontent.com/assets/5694967/10376343/16e30eaa-6e1b-11e5-8010-3cd6df8c346d.png)

Tried other button colors and went with primary button. 
after the changes:
![changed](https://cloud.githubusercontent.com/assets/5694967/10376428/7e58e082-6e1b-11e5-9167-69050e72f185.png)
