### PR TITLE
Quickstart guide: Add tsc 'experimentalDecorators' flag

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -47,7 +47,7 @@
 
   code-example.
     $ npm install -g typescript@^1.5.0-beta
-    $ tsc --watch -m commonjs -t es5 --emitDecoratorMetadata app.ts
+    $ tsc --watch -m commonjs -t es5 --emitDecoratorMetadata --experimentalDecorators app.ts
 
 .callout.is-helpful
   p.


### PR DESCRIPTION
Add `--experimentalDecorators` flag to quickstart `tsc --watch …` command to so no error will be output.