### PR TITLE
Update getting started for alpha.41 - no more tsd

### DIFF
--- a/public/docs/_examples/gettingstarted/ts/package.json
+++ b/public/docs/_examples/gettingstarted/ts/package.json
@@ -4,8 +4,6 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npm run tsd",
-    "tsd": "tsd link --config src/tsd.json && tsd reinstall -ro --config src/tsd.json",
     "tsc": "tsc -p src -w",
     "start": "live-server --open=src",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/public/docs/_examples/gettingstarted/ts/src/app.ts
+++ b/public/docs/_examples/gettingstarted/ts/src/app.ts
@@ -1,8 +1,10 @@
 // #docregion
-import {Component, View, bootstrap} from 'angular2/angular2';
+import {Component, bootstrap} from 'angular2/angular2';
 
-@Component({selector: 'my-app'})
-@View({template: '<h1>My First Angular 2 App</h1>'})
+@Component({
+  selector: 'my-app',
+  template: '<h1>My First Angular 2 App</h1>'
+})
 class AppComponent { }
 
 bootstrap(AppComponent);

--- a/public/docs/_examples/gettingstarted/ts/src/app/app.ts
+++ b/public/docs/_examples/gettingstarted/ts/src/app/app.ts
@@ -1,8 +1,10 @@
 // #docregion
-import {Component, View, bootstrap} from 'angular2/angular2';
+import {Component, bootstrap} from 'angular2/angular2';
 
-@Component({selector: 'my-app'})
-@View({template: '<h1>My First Angular 2 App</h1>'})
+@Component({
+  selector: 'my-app',
+  template: '<h1>My First Angular 2 App</h1>'
+})
 class AppComponent { }
 
 bootstrap(AppComponent);

--- a/public/docs/_examples/gettingstarted/ts/src/tsconfig.json
+++ b/public/docs/_examples/gettingstarted/ts/src/tsconfig.json
@@ -6,6 +6,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,
-    "noImplicitAny": true
+    "noImplicitAny": false
   }
 }

--- a/public/docs/ts/latest/guide/gettingStarted.jade
+++ b/public/docs/ts/latest/guide/gettingStarted.jade
@@ -61,19 +61,18 @@ include ../../../../_includes/_util-fns
     `@Component` tells Angular that this class *is an Angular component*.
     The configuration object passed to the `@Component` method
     specifies a CSS selector for an HTML element named `my-app`.
-    When Angular sees `my-app`, it will know to
-    create and display an instance of our component.
-
-    `@View` is another decoration that describes how our
+    It also describes how our
     component renders on the screen. This one is dead simple,
     a single line of HTML announcing "My First Angular App".
+    When Angular sees `my-app`, it will know to
+    create and display an instance of our component.
 
     The `bootstrap` line tells Angular to start the application with this
     component at the application root.
     We'd be correct to guess that someday our application will
     consist of more components arising in tree-like fashion from this root.
 
-    In the top line we imported the `Component`, `View`, and `bootstrap` methods
+    In the top line we imported the `Component` and `bootstrap` methods
     from the Angular 2 library. That's the way we do things now.
     We no longer expect to find our code or any library code in a global namespace.
     We `import` exactly what we need, as we need it, from named file and library resources.
@@ -153,13 +152,6 @@ include ../../../../_includes/_util-fns
     compile locally and push the generated JavaScript to the server. We'll need some tools for that.
 
 
-    * We are writing TypeScript because we want strong-typing and some information
-    about the APIs we're using. If we wrote `AppComponent` in a TypeScript-aware editor,
-    we saw lots of red squiggly lines complaining about our code and
-    we received no guidance about what `Component`, `View`, and `bootstrap` can do.
-    We'll want to load TypeScript definition files to improve our coding experience.
-
-
     * Downloading JavaScript libraries from the web is OK for demos but
     it slows our development. Every time our app reloads, it must refetch these libraries.
     Don't count on browser caching.
@@ -236,12 +228,9 @@ include ../../../../_includes/_util-fns
 
     >**system.js** - an open-source library that provides module loading.
 
-    We'll also install three development tools:
+    We'll also install two development tools:
 
     >**typescript** - the TypeScript compiler
-
-    >**tsd** - the [tsd package manager](https://www.npmjs.com/package/tsd "TSD Package Manager") so we can access
-    [TypeScript type definition files](http://definitelytyped.org/ "Definitely Typed")
 
     >**[live-server](https://www.npmjs.com/package/live-server "Live-server")** - the static file server that reloads the browser when files change.
     We may have loaded it earlier. We're doing it again
@@ -253,8 +242,8 @@ include ../../../../_includes/_util-fns
     Enter these commands:
     ```
     npm init -y
-    npm i angular2@2.0.0-alpha.39 systemjs@0.19.2 --save --save-exact
-    npm i typescript tsd live-server --save-dev
+    npm i angular2@2.0.0-alpha.41 systemjs@0.19.2 --save --save-exact
+    npm i typescript live-server --save-dev
     ```
 
     These commands both *install* the packages and *create* an npm `package.json` that will
@@ -314,41 +303,17 @@ include ../../../../_includes/_util-fns
   :markdown
     ## Prepare for TypeScript Compilation
 
-    ### Add links to TypeScript definition files
+    ### Configure the TypeScript compiler
 
     We prefer writing TypeScript apps in editors that understand TypeScript,
     such as [Visual Studio Code](https://code.visualstudio.com/) and
     [Web Storm](https://www.jetbrains.com/webstorm/features/).
     Such editors improve the development experience by checking type information and
     displaying API documentation ("intellisense") based on TypeScript definition files (`.d.ts`).
-
-    The definition files we need are included in the npm packages we just installed.
-    We'll use the
-    [**tsd package manager**](https://www.npmjs.com/package/tsd "TSD Package Manager")
-    to generate an *aggregate TypeScript definition file*, **`tsd.d.ts`**,
-    that holds links to the type definition files in those packages.
-
-    In the ***root* folder** enter the following command
-    (one of the `npm` scripts we added a short while ago)
-
-  pre.prettyprint.lang-bash
-    code npm run tsd
-
-  :markdown
-    That produces a new **`src/typings`** folder with the **`tsd.d.ts`** file.
-
-    Now type-checking and intellisense light up automatically as we write our app
-    in the Visual Studio Code and Web Storm editors. Check your editor's documentation for
-    instructions on using the `tsd.d.ts` file.
-
-    ### Add the TypeScript configuration file
-
-    We'll add a configuration file named **`tsconfig.json`**
-    to tell the editor how to interpret our TypeScript code and
-    to simplify the TypeScript compilation command that we'll run very soon.
-
-    **Change to the `src` folder and create a `tsconfig.json`** file with the following content:
-  +makeJson('gettingstarted/ts/src/tsconfig.json', null, 'tsconfig.json')
+    
+    The definition files we need are included in the npm packages we just installed,
+    so type-checking and intellisense light up automatically as we write our app
+    in the Visual Studio Code and Web Storm editors.
 
   :markdown
     Our final project folder structure should look like this:
@@ -358,8 +323,6 @@ include ../../../../_includes/_util-fns
     ├── src
     │   ├── app
     |   │   └── app.ts
-    │   ├── typings
-    │   │   └──tsd.d.ts
     │   ├── index.html
     │   └── tsconfig.json
     └── package.json
@@ -438,9 +401,6 @@ include ../../../../_includes/_util-fns
 
     * our application loads faster with libraries installed locally and
     we can develop offline if we wish.
-
-    * we added TypeScript definition files to enhance team
-    productivity and code maintainability.
 
     * we're pre-compiling our TypeScript.
 

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -18,16 +18,11 @@
 
   p.
     To get started, create a new empty project directory. All the following commands should be run
-    from this directory.
-
-  p.
-    To get the benefits of TypeScript, we want to have the type definitions available for the compiler and the editor.
-    TypeScript type definitions are typically published in a repo called <a href="http://definitelytyped.org/">DefinitelyTyped</a>.
-    To fetch one of the type definitions to the local directory, we use the <a href="https://www.npmjs.com/package/tsd">tsd package manager</a>.
-
+    from this directory. Install typescript and angular from NPM.
+    
   code-example.
-    $ npm install -g tsd@^0.6.0
-    $ tsd install angular2 es6-promise rx rx-lite
+    $ npm install -g typescript
+    $ npm install angular2
 
   p.
     Next, create two empty files, <code>index.html</code> and <code>app.ts</code>, both at the root of the project:
@@ -35,7 +30,7 @@
   code-example.
     $ touch app.ts index.html
 
-// STEP 2 - Start the TypeScript compiler ##########################
+// STEP 2 - Configure TypeScript ##########################
 .l-main-section
   h2#start-tsc 2. Run the TypeScript compiler
 
@@ -46,8 +41,8 @@
     are loaded, or configure your editor or IDE to do it.
 
   code-example.
-    $ npm install -g typescript@^1.5.0-beta
-    $ tsc --watch -m commonjs -t es5 --emitDecoratorMetadata app.ts
+    $ tsc --init --experimentalDecorators --target es5 --emitDecoratorMetadata
+    $ tsc --watch
 
 .callout.is-helpful
   p.
@@ -60,13 +55,9 @@
 .l-main-section
   h2#section-transpile 3. Import Angular
 
-  p Inside of <code>app.ts</code>, import the type definitions from Angular:
+  p Inside of <code>app.ts</code>, your editor should be able to complete the available imports:
   code-example.
-    /// &lt;reference path="typings/angular2/angular2.d.ts" /&gt;
-
-  p Now your editor should be able to complete the available imports:
-  code-example.
-    import {Component, View, bootstrap} from 'angular2/angular2';
+    import {Component, bootstrap} from 'angular2/angular2';
 
   p.
     The above import statement uses ES6 module syntax to import three symbols from the Angular module.
@@ -90,9 +81,7 @@
   code-example(language="javascript" format="linenums").
     // Annotation section
     @Component({
-      selector: 'my-app'
-    })
-    @View({
+      selector: 'my-app',
       template: '&lt;h1&gt;Hello {{ name }}&lt;/h1&gt;'
     })
     // Component controller
@@ -105,25 +94,23 @@
     }
 
   .l-sub-section
-    h3 @Component and @View annotations
+    h3 The @Component decorator
 
     p.
-      A component annotation describes details about the component. An annotation can be identified by its at-sign (<code>@</code>).
+      A component decorator describes details about the component. A decorator can be identified by its at-sign (<code>@</code>).
     p.
-      The <code>@Component</code> annotation defines the HTML tag for the component by specifying the component's CSS selector.
+      The <code>@Component</code> decorator defines the HTML tag for the component by specifying the component's CSS selector.
     p.
-      The <code>@View</code> annotation defines the HTML that represents the component. The component you wrote uses an inline template, but you can also have an external template. To use an external template, specify a <code>templateUrl</code> property and give it the path to the HTML file.
+      The component you wrote uses an inline template, but you can also have an external template. To use an external template, specify a <code>templateUrl</code> property and give it the path to the HTML file.
 
     code-example(language="javascript" format="linenums").
       @Component({
-        selector: 'my-app' // Defines the &lt;my-app&gt;&lt;/my-app&gt; tag
-      })
-      @View({
+        selector: 'my-app', // Defines the &lt;my-app&gt;&lt;/my-app&gt; tag
         template: '&lt;h1&gt;Hello {{ name }}&lt;/h1&gt;' // Defines the inline template for the component
       })
 
     p.
-      The annotations above specify an HTML tag of <code>&lt;my-app&gt;</code>
+      The decorator above specifies an HTML tag of <code>&lt;my-app&gt;</code>
       and a template of <code ng-non-bindable>&lt;h1&gt;Hello &#123;&#123; name }}&lt;/h1&gt;</code>.
 
   .l-sub-section
@@ -187,9 +174,9 @@
     &lt;html&gt;
       &lt;head&gt;
         &lt;title&gt;Angular 2 Quickstart&lt;/title&gt;
-        &lt;script src="https://github.jspm.io/jmcriffey/bower-traceur-runtime@0.0.87/traceur-runtime.js"&gt;&lt;/script&gt;
-        &lt;script src="https://code.angularjs.org/2.0.0-alpha.28/angular2.dev.js"&gt;&lt;/script&gt;
-      &lt;/head&gt;
+        &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.33.6/es6-shim.js"></script>
+        &lt;script src="https://code.angularjs.org/tools/system.js"></script>
+        &lt;/head&gt;
       &lt;body&gt;
 
         &lt;!-- The app component created in app.ts --&gt;


### PR DESCRIPTION
cc @wardbell @johnpapa

This isn't totally finished. For example, it doesn't run the version of  `tsc` installed locally (though https://github.com/Microsoft/TypeScript/issues/5157 will fix that)

Ideally I'd like to point to updated getting started when alpha.41 is cut, so can we work through this?