### PR TITLE
Remove duplicated `ng`.

### DIFF
--- a/public/docs/_examples/gettingstarted/js/app.js
+++ b/public/docs/_examples/gettingstarted/js/app.js
@@ -3,7 +3,7 @@
 
 // #docregion class-w-annotations
 var AppComponent = ng
-  ng.Component({
+  .Component({
     selector: 'my-app',
     template: '<h1>My First Angular 2 App</h1>'
   })


### PR DESCRIPTION
Remove the duplicated `ng` variable in the example of quickstart.