### PR TITLE
Fix jasmine-core paths in  jasmine-testing-101

### DIFF
--- a/public/docs/ts/latest/testing/first-app-tests.jade
+++ b/public/docs/ts/latest/testing/first-app-tests.jade
@@ -29,13 +29,13 @@ include ../../../../_includes/_util-fns
 
   ```
   <html>
-    <title>Ng App Unit Tests</title>
-    <link rel="stylesheet" href="../node_modules/jasmine/lib/jasmine.css">
+  <head>
+    <title>1st Jasmine Tests</title>
+    <link rel="stylesheet" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
 
-    <script src="../node_modules/jasmine/lib/jasmine.js"></script>
-    <script src="../node_modules/jasmine/lib/jasmine-html.js"></script>
-    <script src="../node_modules/jasmine/lib/boot.js"></script>
-
+    <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+    <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+    <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
   </head>
 
   <body>

--- a/public/docs/ts/latest/testing/jasmine-testing-101.jade
+++ b/public/docs/ts/latest/testing/jasmine-testing-101.jade
@@ -42,11 +42,11 @@ pre.prettyprint.lang-bash
   <html>
   <head>
     <title>1st Jasmine Tests</title>
-    <link rel="stylesheet" href="../node_modules/jasmine/lib/jasmine.css">
+    <link rel="stylesheet" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
 
-    <script src="../node_modules/jasmine/lib/jasmine.js"></script>
-    <script src="../node_modules/jasmine/lib/jasmine-html.js"></script>
-    <script src="../node_modules/jasmine/lib/boot.js"></script>
+    <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+    <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+    <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
If you want to use `jasmine-core` instead of `jasmine`, the paths are different.