### PR TITLE
Improved readme.md with respect to gulp tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Angular.io is currently the preview site for Angular 2. This site also includes 
 - [File an issue on github](https://github.com/angular/angular.io/issues)
 - [Contribute to Angular.io](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md)
 
-
 ## Development Setup
 1. install [nvm](https://www.npmjs.com/package/nvm)
 2. cd into root directory `angular.io/`
@@ -29,7 +28,6 @@ Angular.io is currently the preview site for Angular 2. This site also includes 
 - Grids: A highly customizable CSS Grid Framework built with Sass
 - Prettify: A JS module and CSS for syntax highlighting of source code snippets.
 - Icomoon: Custom built icon fonts
-
 
 ## License
 Powered by Google ©2010-2015. Code licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0). Documentation licensed under [CC BY 3.0](http://creativecommons.org/licenses/by/3.0/).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Angular.io is currently the preview site for Angular 2. This site also includes 
 1. install [nvm](https://www.npmjs.com/package/nvm)
 2. cd into root directory `angular.io/`
 3. make sure you are using the latest node and npm by running `nvm use 4`.
-3. install local packages by running `npm install`
+4. install local packages by running `npm install`
+5. clone the [angular](https://github.com/angular/angular) repository.
 
 ## Development setup with watches and browser reloaded
  1. cd into root directory `angular.io/`

--- a/README.md
+++ b/README.md
@@ -12,16 +12,12 @@ Angular.io is currently the preview site for Angular 2. This site also includes 
 3. make sure you are using the latest node and npm by running `nvm use 4`.
 3. install local packages by running `npm install`
 
-## Development setup with watches
- 1. cd into root directory `angular.io/`
- 2. run `gulp serve-and-watch`
- 3. open this url in the browser: [http://localhost:9000/](http://localhost:9000/)
- 4. refresh your browser to see any changes.
-
-## Development setup with watches and browser reload
+## Development setup with watches and browser reloaded
  1. cd into root directory `angular.io/`
  2. run `gulp serve-and-sync`
- 3. browser will launch ( on localhost:3000 instead of localhost:9000) and stay refreshed automatically.
+ 3. open this url in the browser: [http://localhost:9000/](http://localhost:9000/)
+ 4. refresh your browser to see any changes.
+ 5. You also could open this url in the browser, which refreshes automatically: [http://localhost:5000/](http://localhost:5000/)
 
 ## Technology Used
 - Angular 1.x: The production ready version of Angular


### PR DESCRIPTION
The readme is quite unclear and outdated about which gulp task to use for development. I improved 

This is the current situation, before merging this PR:
`serve-and-watch`: is in readme, but gulp task does not exist anymore
`serve-and-sync`: still in readme, watches *all* files, reloads on port 5000, does not reload on port 9000
`build-and-serve`: replacement in gulpfile for `serve-and-watch`, does the same as `serve-and-sync`, but does not watch code example files.

This PR solely leaves `serve-and-sync` in the readme. The `build-and-serve` still exists in the gulpfile, but IMO can be removed later.