### PR TITLE
fix Displaying Data heroes name array

### DIFF
--- a/public/docs/_examples/displaying-data/ts/src/app/app.2.ts
+++ b/public/docs/_examples/displaying-data/ts/src/app/app.2.ts
@@ -26,7 +26,7 @@ import {Component, bootstrap, NgFor} from 'angular2/angular2';
 // #docregion mock-heroes
 export class AppComponent {
   title = 'Tour of Heroes';
-  heroes = ['Windstorm', 'Bombasto', 'Magneta, Tornado'];
+  heroes = ['Windstorm', 'Bombasto', 'Magneta', 'Tornado'];
   myHero = this.heroes[0];
 }
 // #enddocregion mock-heroes


### PR DESCRIPTION
Displaying Data - Tour of Heroes

heroes name 'Magneta' and 'Tornado are the same item:
![image](https://cloud.githubusercontent.com/assets/1706703/10867146/8a441ade-803a-11e5-848e-452da1ca2597.png)

fixed to:
![image](https://cloud.githubusercontent.com/assets/1706703/10867150/b33494aa-803a-11e5-89e9-2625518b95cd.png)