### PR TITLE
(docs) Angular 2 isn't ES6, it's TypeScript

### DIFF
--- a/public/features.jade
+++ b/public/features.jade
@@ -13,17 +13,17 @@
       material design UI components with responsive, cross-device support.
 
 
-<!-- ES6 -->
+<!-- TypeScript -->
 .grid-fluid.l-space-bottom-8
   .c3.text-center
     .sticker <span class="sticker-icon icon-fast-forward"></span>
   .c7
     h3.text-headline.text-uppercase  Future Ready
     p.text-body.
-      Angular 2 is written in ECMAScript 6 (ES6),
-      with the addition of types and annotations.
-      ES6 allows Angular to benefit from the best of JavaScript,
-      while maintaining clean and easy-to-read code.
+      Angular 2 is written in TypeScript, which is a superset of 
+      ECMAScript 6 (ES6) with the addition of features including
+      types and annotations. TypeScript allows Angular to benefit from the 
+      best of JavaScript, while maintaining clean and easy-to-read code.
 
 
 <!-- Coffee, Dart, ES6 -->


### PR DESCRIPTION
Angular 2 isn't just ES6 + types and annotations, so this will confuse people.

As an example, here's a file using two huge features that aren't part of ES6 classes - [object properties and privacy](https://github.com/jeffmo/es-class-static-properties-and-fields).