### PR TITLE
docs(quickstart-ts): add note about ES6 shim

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -143,7 +143,12 @@ include ../../../_includes/_util-fns
 
   :markdown
     Congratulations!  We are in business.
-
+    
+  .alert.is-helpful
+    :markdown
+      If you see `Loading...` displayed instead, see the 
+      [Browser ES6 support appendix](#es6support).
+    
 .l-main-section
   :markdown
     ## What's wrong with this?
@@ -458,3 +463,26 @@ include ../../../_includes/_util-fns
     ```
     "suppressImplicitAnyIndexErrors":true
     ```
+    
+.l-main-section
+  :markdown
+    <a id="es6support"></a>
+    ### Appendix: Browser ES6 support
+    Angular 2 requires ES6 support, such as can be found in most modern 
+    browsers. For older browsers (including IE 11) you can use a shim to get
+    the needed functionality. 
+    
+    After creating `package.json` (halfway through the quickguide), run this
+    command to add a shim to the project:
+    
+  code-example(language="sh" format=".").
+    npm install es6-shim --save
+    
+  :markdown
+    Now you can load the shim in your `index.html` before the other scripts:
+    
+  code-example(language="html" format=".").
+    &lt;script src=&quot;../node_modules/es6-shim/es6-shim.js&quot;&gt;&lt;/script&gt;
+    
+  
+    


### PR DESCRIPTION
Adding appendix to TS quickstart regarding ES6 support and how to use a shim to get the example working on older browsers.