### PR TITLE
(docs): toh - fix typo

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt1.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt1.jade
@@ -225,7 +225,7 @@ include ../../../../_includes/_util-fns
 
     ## Declare Multiple Form Directives
 
-    We learned from our latest error message that we can’t the import `NgModel` alone.
+    We learned from our latest error message that we can’t import the `NgModel` alone.
     We need additional directives to enable two-way data binding with `NgModel`.
 
     We could hunt them down and add each of them to the `directives` array one by one.


### PR DESCRIPTION
fix typo in toh pt1: we can’t **the import** `NgModel` alone -> we can’t **import the** `NgModel` alone