### PR TITLE
mkdir error for OSX/Linux

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -203,7 +203,7 @@ include ../../../_includes/_util-fns
     In OS/X and Linux:
 
   pre.prettyprint.lang-bash
-    code mkdir src/app
+    code mkdir -p src/app
 
   :marked
     In Windows:


### PR DESCRIPTION
You need to include a "-p" argument to the mkdir command. Since the 'src' doesn't exist yet, the mkdir will return an error instead of creating the 2 directories.