### PR TITLE
docs(quickstart): typos in Quickstart

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -256,7 +256,7 @@ include ../../../_includes/_util-fns
     ```
 
     These commands both *install* the packages and *create* an npm `package.json` that will
-    help us develop and maintain our application in future.
+    help us develop and maintain our application in the future.
     The essence of our `package.json` should look like this:
 
   +makeJson('quickstart/ts/package.json', { paths: 'name, version, dependencies, devDependencies'})

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -60,7 +60,7 @@ include ../../../_includes/_util-fns
   :marked
     `@Component` tells Angular that this class *is an Angular component*.
     The configuration object passed to the `@Component` method has two
-    field, a `selector` and a `template`.
+    fields, a `selector` and a `template`.
 
     The `selector` specifies a CSS selector for a host HTML element named `my-app`.
     Angular creates and displays an instance of our `AppComponent`


### PR DESCRIPTION
Found a few typos while going through the Quickstart for the first time.