### PR TITLE
docs: remove repeated 'class'

### DIFF
--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -79,7 +79,7 @@ p.
     Components are the primary way to create application views
     and support them with application logic.
 
-    This component is an empty, do-nothing class class named `AppComponent`.
+    This component is an empty, do-nothing class named `AppComponent`.
     You can add properties and application logic to it later,
     when you're ready to build a substantive application.
 

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -45,7 +45,7 @@ include ../../../_includes/_util-fns
     Components are our primary means of creating application views
     and supporting them with application logic.
 
-    Ours is an empty, do-nothing class class named `AppComponent`.
+    Ours is an empty, do-nothing class named `AppComponent`.
     It would expand with properties and application
     logic when we're ready to build a substantive application.
 


### PR DESCRIPTION
Remove repeated 'class' from component explanation to improve grammer
and readability of the documentation.