### PR TITLE
docs: Quickstart bash command needs -p flag

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -203,7 +203,7 @@ include ../../../_includes/_util-fns
     In OS/X and Linux:
 
   pre.prettyprint.lang-bash
-    code mkdir src/app
+    code mkdir -p src/app
 
   :marked
     In Windows:


### PR DESCRIPTION
Hi Angular, 

It's my first PR to angular, and I hope I'm following the contribution guidelines.

I noticed the `-p` flag was missing, I think this is the right place to change it?

CLA is signed. 