### PR TITLE
docs(toh-pt1): fix dead links

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt1.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt1.jade
@@ -73,7 +73,7 @@ include ../../../../_includes/_util-fns
     This is the "interpolation" form of one-way data binding.
   .l-sub-section
     :marked
-      Learn more about interpolation in the [Displaying Data chapter](../guide/displaying-data).
+      Learn more about interpolation in the [Displaying Data chapter](../guide/displaying-data.html).
   :marked
     ### Hero object
 
@@ -236,7 +236,7 @@ include ../../../../_includes/_util-fns
     bundled in a convenient array called `FORM_DIRECTIVES`.
   .l-sub-section
     :marked
-      Learn more about Angular Forms in the [Forms chapter](../guide/forms)
+      Learn more about Angular Forms in the [Forms chapter](../guide/forms.html)
   :marked
     Let’s forget about importing `NgModel` and import the `FORM_DIRECTIVES` array instead:
     ```


### PR DESCRIPTION
These aren't dead links when running the site locally with gulp, but are dead on [angular.io](https://angular.io/docs/ts/latest/tutorial/toh-pt1.html)