### PR TITLE
docs: Change label of case to 'kebab' for attrs

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -372,10 +372,10 @@ code-example(format="", language="html").
 :marked
   Notice that it forced mixed-case ""text**C**ontent" to lowercase "text**c**ontent".
 
-  The solution is to write the target property name in “**lower snake case**”,
+  The solution is to write the target property name in “**lower kebab case**”,
   with a dash before each uppercase letter. We can correct the example as follows:
   ```
-  <!-- Lower Snake Case -->
+  <!-- Lower Kebab Case -->
   <label [text-content] = "title">
   <hero-detail [is-active] = "isActive">
   ```

--- a/public/docs/ts/latest/guide/user-input.jade
+++ b/public/docs/ts/latest/guide/user-input.jade
@@ -159,7 +159,7 @@ figure.image-display
   The browser forces all attribute and element names to lowercase, turning what would be `#newHero`
   into `#newhero` (all lowercase). We don't want a `newhero` variable name in our template expressions.
 
-  The Angular workaround is to spell the declaration in "snake case". Angular translates "#new-hero"
+  The Angular workaround is to spell the declaration in "kebab case". Angular translates "#new-hero"
   to `newHero` for template expressions ... which is exactly what we want.
 
   ### **newHero refers to the `<input>` element**


### PR DESCRIPTION
The docs refer to `this-style-of-casing` as snake case, but it's
actually "kebab case." Snake case looks `like_this_instead`.

https://en.wikipedia.org/wiki/Letter_case#Special_case_styles