### PR TITLE
docs: Remove accidental elvis operator

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -1256,7 +1256,7 @@ code-example(format="" language="html").
   We can code around that problem with [`ng-if`](#ng-if)
 code-example(format="" language="html").
     &lt;!-- No hero, div not displayed, no error -->
-    &lt;div *ng-if="nullHero">The null hero's name is {{nullHero?.firstName}}</div>
+    &lt;div *ng-if="nullHero">The null hero's name is {{nullHero.firstName}}</div>
 :marked
   This approach has merit but it’s cumbersome, especially if the property path is long.
   Imagine guarding against a null somewhere in a long property path such as `a.b.c.d`.


### PR DESCRIPTION
In the documentation, this section is discussing alternatives to
the elvis operator. This particular section is supposed to be
showing an alternative work around to the elvis operator, so
this error is especially confusing.

(https://angular.io/docs/ts/latest/guide/template-syntax.html#expression-ops)