### PR TITLE
Updated code example to build array of Hero

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt2.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt2.jade
@@ -60,10 +60,17 @@ include ../../../../_includes/_util-fns
       { "id": 18, "name": "Dr IQ" },
       { "id": 19, "name": "Magma" },
       { "id": 20, "name": "Tornado" }
-    ];
+    ].map(function(heroAttribute) {
+      var hero: Hero;
+      hero = new Hero();
+      hero.id = heroAttribute.id;
+      hero.name = heroAttribute.name;
+      return hero;
+    });
     ```
     The `HEROES` array is of type `Hero`.
     We are taking advantage of the `Hero` class we coded previously to create an array of our heroes.
+    By mapping over our array of objects and instantiating a new class `Hero` and setting the attributes, we have have an array of heroes (`HEROES: Hero[]`)
     We aspire to get this list of heroes from a web service, but let’s take small steps
     on this road and start by displaying these mock heroes in the browser.
 


### PR DESCRIPTION
Previously the instructions indicated that this builds an array of Hero instances:

```
var HEROES: Hero[] = [
      { "id": 11, "name": "Mr. Nice" },
      { "id": 12, "name": "Narco" },
      { "id": 13, "name": "Bombasto" },
      { "id": 14, "name": "Celeritas" },
      { "id": 15, "name": "Magneta" },
      { "id": 16, "name": "RubberMan" },
      { "id": 17, "name": "Dynama" },
      { "id": 18, "name": "Dr IQ" },
      { "id": 19, "name": "Magma" },
      { "id": 20, "name": "Tornado" }
    ]
```

```
console.log(HEROES[0]) # => Object {...}
```

This actually builds an array of Object instances as we are not instantiating `Hero`. This is confusing as a user would think they can add a function to the `Hero` class and access it via an instance.

In order to instantiate an array of Hero instances, we need to map over the array and instantiate `Hero` for each entity:

```
var HEROES: Hero[] = [
      { "id": 11, "name": "Mr. Nice" },
      { "id": 12, "name": "Narco" },
      { "id": 13, "name": "Bombasto" },
      { "id": 14, "name": "Celeritas" },
      { "id": 15, "name": "Magneta" },
      { "id": 16, "name": "RubberMan" },
      { "id": 17, "name": "Dynama" },
      { "id": 18, "name": "Dr IQ" },
      { "id": 19, "name": "Magma" },
      { "id": 20, "name": "Tornado" }
    ].map(function(heroAttribute) {
      var hero: Hero;
      hero = new Hero();
      hero.id = heroAttribute.id;
      hero.name = heroAttribute.name;
      return hero;
    });
```

Now we have an array of Hero entities:

```
console.log(HEROES[0]) # => Hero {...}
```