### PR TITLE
chore(docs-app): add `code` directive to prevent unwanted compilation

### DIFF
--- a/public/_includes/_scripts-include.jade
+++ b/public/_includes/_scripts-include.jade
@@ -17,6 +17,7 @@ script(src="https://ajax.googleapis.com/ajax/libs/angular_material/0.8.3/angular
 script(src="/resources/js/site.js")
 script(src="/resources/js/controllers/app-controller.js")
 script(src="/resources/js/directives/bio.js")
+script(src="/resources/js/directives/code.js")
 script(src="/resources/js/directives/code-tabs.js")
 script(src="/resources/js/directives/code-pane.js")
 script(src="/resources/js/directives/code-example.js")

--- a/public/docs/ts/latest/guide/cheatsheet.jade
+++ b/public/docs/ts/latest/guide/cheatsheet.jade
@@ -22,5 +22,5 @@ article(class="l-content-small grid-fluid docs-content")
         th(ng-bind-html="appCtrl.getSafeHtml(section.description)")
       tr(ng-repeat='child in section.items')
         td
-          code(bold='child.bold') {{child.syntax}}
+          code(bold='child.bold',ng-compile) {{child.syntax}}
         td(ng-bind-html="appCtrl.getSafeHtml(child.description)")

--- a/public/resources/js/directives/code.js
+++ b/public/resources/js/directives/code.js
@@ -1,0 +1,23 @@
+/*
+* Code Directive
+* Don't compile the contents of `<code>` elements.
+* This allows examples to contain angular syntax.
+*
+* But DO compile if the element also contains the `ng-compile` attribute
+* E.g. `<code ng-compile>{{ 'do interpolate' + 'me' }}</code>`
+*/
+
+angularIO.directive('code', function($compile) {
+  return {
+    priority: 100,
+    restrict: 'E',
+    terminal: true,
+    link: function($scope, $element, $attrs) {
+      // If the element contains the `ng-compile` attribute then
+      // go ahead and compile anyway
+      if ($attrs.ngCompile) {
+        $compile($element, null, 100, 'code')($scope);
+      }
+    }
+  };
+});


### PR DESCRIPTION
@wardbell this should solve the problem with demonic interpolated code blocks.