### PR TITLE
docs: fix broken link in template-syntax (TS). fixes #415

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -102,7 +102,7 @@ code-example(format="" language="html" escape="html").
   * The `new` operator is prohibited.
   * The bit-wise operators, `|` and `&`, are not supported.
   * Increment and decrement operators, `++` and `--`, aren’t supported.
-  * [Template expression operators](#expression-operators), such as `|` and `?.`, add new meaning.
+  * [Template expression operators](#expression-ops), such as `|` and `?.`, add new meaning.
 
   Perhaps more surprising, we cannot refer to anything in the global namespace.
   We can’t refer to `window` or `document`. We can’t call `console.log`.


### PR DESCRIPTION
 In 'Template expression operators' section linking to 'Template expression operators'

fixes #415

