### PR TITLE
chore(docs-shredder): fixes misspelled word

### DIFF
--- a/tools/doc-shredder/doc-shredder.js
+++ b/tools/doc-shredder/doc-shredder.js
@@ -68,7 +68,7 @@ function createShredPackage(shredOptions) {
     .config(function(readFilesProcessor, regionFileReader) {
       readFilesProcessor.fileReaders = [regionFileReader];
     })
-    // default configs - may be overriden
+    // default configs - may be overridden
     .config(function(readFilesProcessor) {
       // Specify the base path used when resolving relative paths to source and output files
       readFilesProcessor.basePath = "/";


### PR DESCRIPTION
'overriden' should be 'overridden'

http://dictionary.reference.com/browse/overridden