### PR TITLE
docs(quickstart): typo in TypeScript configuration file name

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -431,9 +431,9 @@ include ../../../_includes/_util-fns
   :marked
     <a id="tsconfig"></a>
     ### Appendix: TypeScript configuration
-    We added a TypeScript configuration file (`tsconfig.js`) to our project to
+    We added a TypeScript configuration file (`tsconfig.json`) to our project to
     guide the compiler as it generates JavaScript files.
-    Get details about `tsconfig.js` from the official
+    Get details about `tsconfig.json` from the official
     [TypeScript wiki](https://github.com/Microsoft/TypeScript/wiki/tsconfig.json).
 
     We'd like a moment to discuss the `noImplicitAny` flag.


### PR DESCRIPTION
tsconfig.json instead of tsconfig.js