### PR TITLE
docs(developer-guides): incorrect QuickStart link in How to Read this…

### DIFF
--- a/public/docs/ts/latest/guide/index.jade
+++ b/public/docs/ts/latest/guide/index.jade
@@ -46,7 +46,7 @@ figure
   
   There is a learning path for those of us who are new to Angular.
   
-  It starts *outside* the guide with the [QuickStart](../quickstart). The QuickStart is the "Hello, World" of Angular 2. 
+  It starts *outside* the guide with the [QuickStart](../quickstart.html). The QuickStart is the "Hello, World" of Angular 2. 
   It shows us how to setup the libraries and tools we'll need to write *any* Angular app. 
   It ends with a "proof of life", a running Angular app.
   


### PR DESCRIPTION
… Guide section

quickstart -> quickstart.html prevent 404 page