### PR TITLE
removes first demo

### DIFF
--- a/public/docs/ts/latest/tutorial/index.jade
+++ b/public/docs/ts/latest/tutorial/index.jade
@@ -73,7 +73,7 @@ figure.image-display
 
 .l-main-section
 :marked
-  ## How We Roll
+  ## Up Next
 
   We’ll build this Tour of Heroes together, step by step.
   We'll motivate each step with a requirement that we've

--- a/public/index.jade
+++ b/public/index.jade
@@ -12,27 +12,14 @@ div(layout='row' style='margin: 0 -24px')
     p.text-body Supports several languages including plain JavaScript, TypeScript, and Dart. Also supports both object-style data structure with POJO data-binding  and functional reactive style with unidirectional data flow and support for observables and immutable data structures.
 br
 div
-  h3.text-headline Basics
-  code-example(language='ts' format='linenums').
-    import {bootstrap, Component} from 'angular2/angular2';
-
-    @Component({
-       selector: 'my-app',
-       template: '&lt;h1&gt;My First Angular 2 App&lt;/h1&gt;'
-    })
-    class AppComponent {}
-
-    bootstrap(AppComponent);
-br
-div
-  h3.text-headline Structure your app
+  h3.text-headline The Basics
   p.text-body In Angular you display data by defining components.  Data in your component classes is automatically available to display in your templates or control how they render as in the example below.
   p.text-body While this example uses TypeScript, Angular works equally well with ES5, ES6 and Dart as well.
   p(style='text-align:right')
     md-button.md-primary(href='http://plnkr.co/edit/hjHrTZw8HvkzAGhGiJhu?p=preview' target='_blank')
       span.icon-open-in-new
-      |   Edit on Plunker
-  +makeTabs('../docs/_fragments/homepage-hello-world/ts/src/index.html,../docs/_fragments/homepage-hello-world/ts/src/hello_world.html,../docs/_fragments/homepage-hello-world/ts/src/hello_world.ts', null, 'index.html,hello_world.html,hello_world.ts')
+      |   Try in Plunker
+  +makeTabs('../docs/_fragments/homepage-hello-world/ts/src/hello_world.ts,../docs/_fragments/homepage-hello-world/ts/src/hello_world.html,../docs/_fragments/homepage-hello-world/ts/src/index.html', null, 'hello_world.ts,hello_world.html,index.html')
 br
 div
   h3.text-headline Structuring apps with components
@@ -41,6 +28,6 @@ div
   p(style='text-align:right')
     md-button.md-primary(href='http://plnkr.co/edit/UHEUnL8jpUoZBw3TaqWT?p=preview' target='_blank')
       span.icon-open-in-new
-      |   Edit on Plunker
-  +makeTabs('../docs/_fragments/homepage-todo/ts/src/index.html,../docs/_fragments/homepage-todo/ts/src/todo.ts,../docs/_fragments/homepage-todo/ts/src/todo_app.ts,../docs/_fragments/homepage-todo/ts/src/todo_form.ts,../docs/_fragments/homepage-todo/ts/src/todo_list.ts', null, 'index.html,todo.ts,todo_app.ts,todo_form.ts,todo_list.ts')
+      |   Try in Plunker
+  +makeTabs('../docs/_fragments/homepage-todo/ts/src/todo_app.ts,../docs/_fragments/homepage-todo/ts/src/todo_form.ts,../docs/_fragments/homepage-todo/ts/src/todo_list.ts,../docs/_fragments/homepage-todo/ts/src/todo.ts,../docs/_fragments/homepage-todo/ts/src/index.html', null, 'todo_app.ts,todo_form.ts,todo_list.ts,todo.ts,index.html')
 br

--- a/public/resources/css/base/_type.scss
+++ b/public/resources/css/base/_type.scss
@@ -7,7 +7,7 @@
 body {
   font-family: $brand-font;
   font-size: 14px;
-  color: $platinum;
+  color: #1a2326;
 }
 
 a {

--- a/public/resources/css/module/_code.scss
+++ b/public/resources/css/module/_code.scss
@@ -30,7 +30,7 @@
   overflow: auto;
   position: relative;
   padding: 0px;
-  font-size: 15px;
+  font-size: 13px;
   // font-weight: 600;
   line-height: 24px;
   margin-bottom: $unit * 3;
@@ -50,7 +50,7 @@
 
   code {
     background: none;
-    font-size: 15px;
+    font-size: 13px;
     padding: 0px;
   }
 
@@ -60,7 +60,7 @@
     margin: 0px;
     overflow: auto;
     // font-weight: 600;
-    font-size: 15px;
+    font-size: 13px;
 
     li {
       color: $bismark;
@@ -76,7 +76,7 @@
 
       code {
         background: none;
-        font-size: 15px;
+        font-size: 13px;
       }
     }
   }


### PR DESCRIPTION
changes text from `how we roll` to `up next`
changes font size for code blocks from `15px` to `13px`
changes links from `edit on plunker` to `try in plunker`
re-orders tabs in code samples