### PR TITLE
chore(upgrade) fix .gitignore for PhoneCat examples

### DIFF
--- a/public/docs/_examples/upgrade/.gitignore
+++ b/public/docs/_examples/upgrade/.gitignore
@@ -1,0 +1,3 @@
+!karma.conf.js
+!package.json
+!tsconfig.json

--- a/public/docs/_examples/upgrade/ts/classes/package.json
+++ b/public/docs/_examples/upgrade/ts/classes/package.json
@@ -1,0 +1,41 @@
+{
+  "version": "0.0.0",
+  "private": true,
+  "name": "angular-phonecat",
+  "description": "A tutorial application for AngularJS",
+  "repository": "https://github.com/angular/angular-phonecat",
+  "license": "MIT",
+  "dependencies": {
+    "systemjs": "0.19.6"
+  },
+  "devDependencies": {
+    "karma": "^0.12.16",
+    "karma-chrome-launcher": "^0.1.4",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-jasmine": "~0.2.0",
+    "protractor": "^3.0.0",
+    "http-server": "^0.6.1",
+    "tmp": "0.0.23",
+    "bower": "^1.3.1",
+    "shelljs": "^0.2.6",
+    "typescript": "1.7.3"
+  },
+  "scripts": {
+    "postinstall": "bower install",
+
+    "prestart": "npm install",
+    "start": "http-server -a 0.0.0.0 -p 8000",
+
+    "pretest": "npm install",
+    "test": "node node_modules/karma/bin/karma start test/karma.conf.js",
+    "test-single-run": "node node_modules/karma/bin/karma start test/karma.conf.js  --single-run",
+
+    "preupdate-webdriver": "npm install",
+    "update-webdriver": "webdriver-manager update",
+
+    "preprotractor": "npm run update-webdriver",
+    "protractor": "protractor test/protractor-conf.js",
+
+    "tsc": "tsc -p . -w"
+  }
+}

--- a/public/docs/_examples/upgrade/ts/classes/test/karma.conf.js
+++ b/public/docs/_examples/upgrade/ts/classes/test/karma.conf.js
@@ -1,0 +1,40 @@
+module.exports = function(config){
+  config.set({
+
+    basePath : '..',
+
+    // #docregion files
+    files : [
+      'app/bower_components/angular/angular.js',
+      'app/bower_components/angular-route/angular-route.js',
+      'app/bower_components/angular-resource/angular-resource.js',
+      'app/bower_components/angular-animate/angular-animate.js',
+      'app/bower_components/angular-mocks/angular-mocks.js',
+      'node_modules/systemjs/dist/system.src.js',
+      'test/karma_test_shim.js',
+      {pattern: 'app/js/**/*.js', included: false, watched: true},
+      {pattern: 'test/unit/**/*.js', included: false, watched: true}
+    ],
+    // #enddocregion files
+
+    autoWatch : true,
+
+    frameworks: ['jasmine'],
+
+    browsers : ['Chrome', 'Firefox'],
+
+    plugins : [
+      'karma-chrome-launcher',
+      'karma-firefox-launcher',
+      'karma-jasmine'
+    ],
+
+    junitReporter : {
+      outputFile: 'test_out/unit.xml',
+      suite: 'unit'
+    },
+
+    logLevel: 'LOG_DEBUG'
+
+  });
+};

--- a/public/docs/_examples/upgrade/ts/classes/tsconfig.json
+++ b/public/docs/_examples/upgrade/ts/classes/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "system",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": false
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/public/docs/_examples/upgrade/ts/ng2_components/package.json
+++ b/public/docs/_examples/upgrade/ts/ng2_components/package.json
@@ -1,0 +1,47 @@
+{
+  "version": "0.0.0",
+  "private": true,
+  "name": "angular-phonecat",
+  "description": "A tutorial application for AngularJS",
+  "repository": "https://github.com/angular/angular-phonecat",
+  "license": "MIT",
+  "dependencies": {
+    "angular2": "2.0.0-alpha.53",
+    "es6-promise": "^3.0.2",
+    "es6-shim": "^0.33.3",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-alpha.14",
+    "zone.js": "0.5.8",
+    "systemjs": "0.19.6"
+  },
+  "devDependencies": {
+    "karma": "^0.12.16",
+    "karma-chrome-launcher": "^0.1.4",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-jasmine": "~0.2.0",
+    "protractor": "^3.0.0",
+    "http-server": "^0.6.1",
+    "tmp": "0.0.23",
+    "bower": "^1.3.1",
+    "shelljs": "^0.2.6",
+    "typescript": "1.7.3"
+  },
+  "scripts": {
+    "postinstall": "bower install",
+
+    "prestart": "npm install",
+    "start": "http-server -a 0.0.0.0 -p 8000",
+
+    "pretest": "npm install",
+    "test": "node node_modules/karma/bin/karma start test/karma.conf.js",
+    "test-single-run": "node node_modules/karma/bin/karma start test/karma.conf.js  --single-run",
+
+    "preupdate-webdriver": "npm install",
+    "update-webdriver": "webdriver-manager update",
+
+    "preprotractor": "npm run update-webdriver",
+    "protractor": "protractor test/protractor-conf.js",
+
+    "tsc": "tsc -p . -w"
+  }
+}

--- a/public/docs/_examples/upgrade/ts/ng2_components/test/karma.conf.js
+++ b/public/docs/_examples/upgrade/ts/ng2_components/test/karma.conf.js
@@ -1,0 +1,59 @@
+module.exports = function(config){
+  config.set({
+
+    basePath : '..',
+
+    // #docregion html
+    files : [
+    // #enddocregion html
+      'app/bower_components/angular/angular.js',
+      'app/bower_components/angular-route/angular-route.js',
+      'app/bower_components/angular-resource/angular-resource.js',
+      'app/bower_components/angular-animate/angular-animate.js',
+      'app/bower_components/angular-mocks/angular-mocks.js',
+      // #docregion ng2
+      'node_modules/systemjs/dist/system.src.js',
+      'node_modules/angular2/bundles/angular2.dev.js',
+      // #enddocregion ng2
+      // #docregion ng2-http
+      'node_modules/angular2/bundles/http.dev.js',
+      // #enddocregion ng2-http
+      'test/karma_test_shim.js',
+      {pattern: 'app/js/**/*.js', included: false, watched: true},
+      {pattern: 'test/unit/**/*.js', included: false, watched: true},
+      // #docregion ng2-testing
+      'node_modules/angular2/bundles/testing.js',
+      {pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false},
+      // #enddocregion ng2-testing
+
+      // #docregion html
+      {pattern: 'js/**/*.html', included: false, watched: true}
+    ],
+
+    proxies: {
+      // required for component assests fetched by Angular's compiler
+      "/js/": "/base/app/js"
+    },
+    // #enddocregion html
+
+    autoWatch : true,
+
+    frameworks: ['jasmine'],
+
+    browsers : ['Chrome', 'Firefox'],
+
+    plugins : [
+      'karma-chrome-launcher',
+      'karma-firefox-launcher',
+      'karma-jasmine'
+    ],
+
+    junitReporter : {
+      outputFile: 'test_out/unit.xml',
+      suite: 'unit'
+    },
+
+    logLevel: 'LOG_DEBUG'
+
+  });
+};

--- a/public/docs/_examples/upgrade/ts/ng2_components/tsconfig.json
+++ b/public/docs/_examples/upgrade/ts/ng2_components/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "system",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": false
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/public/docs/_examples/upgrade/ts/ng2_final/package.json
+++ b/public/docs/_examples/upgrade/ts/ng2_final/package.json
@@ -1,0 +1,47 @@
+{
+  "version": "0.0.0",
+  "private": true,
+  "name": "angular-phonecat",
+  "description": "A tutorial application for AngularJS",
+  "repository": "https://github.com/angular/angular-phonecat",
+  "license": "MIT",
+  "dependencies": {
+    "angular2": "2.0.0-alpha.53",
+    "es6-promise": "^3.0.2",
+    "es6-shim": "^0.33.3",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-alpha.14",
+    "zone.js": "0.5.8",
+    "systemjs": "0.19.6"
+  },
+  "devDependencies": {
+    "karma": "^0.12.16",
+    "karma-chrome-launcher": "^0.1.4",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-jasmine": "~0.2.0",
+    "protractor": "^3.0.0",
+    "http-server": "^0.6.1",
+    "tmp": "0.0.23",
+    "bower": "^1.3.1",
+    "shelljs": "^0.2.6",
+    "typescript": "1.7.3"
+  },
+  "scripts": {
+    "postinstall": "bower install",
+
+    "prestart": "npm install",
+    "start": "http-server -a 0.0.0.0 -p 8000",
+
+    "pretest": "npm install",
+    "test": "node node_modules/karma/bin/karma start test/karma.conf.js",
+    "test-single-run": "node node_modules/karma/bin/karma start test/karma.conf.js  --single-run",
+
+    "preupdate-webdriver": "npm install",
+    "update-webdriver": "webdriver-manager update",
+
+    "preprotractor": "npm run update-webdriver",
+    "protractor": "protractor test/protractor-conf.js",
+
+    "tsc": "tsc -p . -w"
+  }
+}

--- a/public/docs/_examples/upgrade/ts/ng2_final/test/karma.conf.js
+++ b/public/docs/_examples/upgrade/ts/ng2_final/test/karma.conf.js
@@ -1,0 +1,34 @@
+// #docregion
+module.exports = function(config){
+  config.set({
+    basePath : '..',
+    files : [
+      'node_modules/systemjs/dist/system.src.js',
+      'node_modules/angular2/bundles/angular2.dev.js',
+      'node_modules/angular2/bundles/http.dev.js',
+      'node_modules/angular2/bundles/testing.js',
+      'node_modules/angular2/bundles/router.dev.js',
+      'test/karma_test_shim.js',
+      {pattern: 'app/js/**/*.js', included: false, watched: true},
+      {pattern: 'app/**/*.html', included: false, watched: true},
+      {pattern: 'test/unit/**/*.js', included: false, watched: true},
+      {pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false}
+    ],
+    autoWatch : true,
+    frameworks: ['jasmine'],
+    browsers : ['Chrome', 'Firefox'],
+    plugins : [
+      'karma-chrome-launcher',
+      'karma-firefox-launcher',
+      'karma-jasmine'
+    ],
+    junitReporter : {
+      outputFile: 'test_out/unit.xml',
+      suite: 'unit'
+    },
+    proxies: {
+      // required for component assests fetched by Angular's compiler
+      "/app/js/": "/base/src/app/js/"
+    }
+  });
+};

--- a/public/docs/_examples/upgrade/ts/ng2_final/tsconfig.json
+++ b/public/docs/_examples/upgrade/ts/ng2_final/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "system",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": false
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/public/docs/_examples/upgrade/ts/ng2_initial/package.json
+++ b/public/docs/_examples/upgrade/ts/ng2_initial/package.json
@@ -1,0 +1,47 @@
+{
+  "version": "0.0.0",
+  "private": true,
+  "name": "angular-phonecat",
+  "description": "A tutorial application for AngularJS",
+  "repository": "https://github.com/angular/angular-phonecat",
+  "license": "MIT",
+  "dependencies": {
+    "angular2": "2.0.0-alpha.53",
+    "es6-promise": "^3.0.2",
+    "es6-shim": "^0.33.3",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-alpha.14",
+    "zone.js": "0.5.8",
+    "systemjs": "0.19.6"
+  },
+  "devDependencies": {
+    "karma": "^0.12.16",
+    "karma-chrome-launcher": "^0.1.4",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-jasmine": "~0.2.0",
+    "protractor": "^3.0.0",
+    "http-server": "^0.6.1",
+    "tmp": "0.0.23",
+    "bower": "^1.3.1",
+    "shelljs": "^0.2.6",
+    "typescript": "1.7.3"
+  },
+  "scripts": {
+    "postinstall": "bower install",
+
+    "prestart": "npm install",
+    "start": "http-server -a 0.0.0.0 -p 8000",
+
+    "pretest": "npm install",
+    "test": "node node_modules/karma/bin/karma start test/karma.conf.js",
+    "test-single-run": "node node_modules/karma/bin/karma start test/karma.conf.js  --single-run",
+
+    "preupdate-webdriver": "npm install",
+    "update-webdriver": "webdriver-manager update",
+
+    "preprotractor": "npm run update-webdriver",
+    "protractor": "protractor test/protractor-conf.js",
+
+    "tsc": "tsc -p . -w"
+  }
+}

--- a/public/docs/_examples/upgrade/ts/ng2_initial/test/karma.conf.js
+++ b/public/docs/_examples/upgrade/ts/ng2_initial/test/karma.conf.js
@@ -1,0 +1,53 @@
+module.exports = function(config){
+  config.set({
+
+    basePath : '..',
+
+    // #docregion ng2
+    files : [
+    // #enddocregion ng2
+      'app/bower_components/angular/angular.js',
+      'app/bower_components/angular-route/angular-route.js',
+      'app/bower_components/angular-resource/angular-resource.js',
+      'app/bower_components/angular-animate/angular-animate.js',
+      'app/bower_components/angular-mocks/angular-mocks.js',
+      // #docregion ng2
+      'node_modules/systemjs/dist/system.src.js',
+      'node_modules/es6-shim/es6-shim.js',
+      'node_modules/es6-promise/dist/es6-promise.js',
+      'node_modules/angular2/bundles/angular2-polyfills.js',
+      'node_modules/angular2/bundles/angular2.dev.js',
+      // #enddocregion ng2
+      // #docregion ng2-http
+      'node_modules/angular2/bundles/http.dev.js',
+      // #enddocregion ng2-http
+      'test/karma_test_shim.js',
+      {pattern: 'app/js/**/*.js', included: false, watched: true},
+      {pattern: 'test/unit/**/*.js', included: false, watched: true},
+      // #docregion ng2-testing
+      'node_modules/angular2/bundles/testing.js',
+      {pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false},
+      // #enddocregion ng2-testing
+    // #docregion ng2
+    ],
+    // #enddocregion ng2
+
+    autoWatch : true,
+
+    frameworks: ['jasmine'],
+
+    browsers : ['Chrome', 'Firefox'],
+
+    plugins : [
+      'karma-chrome-launcher',
+      'karma-firefox-launcher',
+      'karma-jasmine'
+    ],
+
+    junitReporter : {
+      outputFile: 'test_out/unit.xml',
+      suite: 'unit'
+    }
+
+  });
+};

--- a/public/docs/_examples/upgrade/ts/ng2_initial/tsconfig.json
+++ b/public/docs/_examples/upgrade/ts/ng2_initial/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "system",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": false
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/public/docs/_examples/upgrade/ts/typescript-conversion/package.json
+++ b/public/docs/_examples/upgrade/ts/typescript-conversion/package.json
@@ -1,0 +1,41 @@
+{
+  "version": "0.0.0",
+  "private": true,
+  "name": "angular-phonecat",
+  "description": "A tutorial application for AngularJS",
+  "repository": "https://github.com/angular/angular-phonecat",
+  "license": "MIT",
+  "dependencies": {
+    "systemjs": "0.19.6"
+  },
+  "devDependencies": {
+    "karma": "^0.12.16",
+    "karma-chrome-launcher": "^0.1.4",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-jasmine": "~0.2.0",
+    "protractor": "^3.0.0",
+    "http-server": "^0.6.1",
+    "tmp": "0.0.23",
+    "bower": "^1.3.1",
+    "shelljs": "^0.2.6",
+    "typescript": "1.7.3"
+  },
+  "scripts": {
+    "postinstall": "bower install",
+
+    "prestart": "npm install",
+    "start": "http-server -a 0.0.0.0 -p 8000",
+
+    "pretest": "npm install",
+    "test": "node node_modules/karma/bin/karma start test/karma.conf.js",
+    "test-single-run": "node node_modules/karma/bin/karma start test/karma.conf.js  --single-run",
+
+    "preupdate-webdriver": "npm install",
+    "update-webdriver": "webdriver-manager update",
+
+    "preprotractor": "npm run update-webdriver",
+    "protractor": "protractor test/protractor-conf.js",
+
+    "tsc": "tsc -p . -w"
+  }
+}

--- a/public/docs/_examples/upgrade/ts/typescript-conversion/test/karma.conf.js
+++ b/public/docs/_examples/upgrade/ts/typescript-conversion/test/karma.conf.js
@@ -1,0 +1,38 @@
+module.exports = function(config){
+  config.set({
+
+    basePath : '..',
+
+    // #docregion files
+    files : [
+      'app/bower_components/angular/angular.js',
+      'app/bower_components/angular-route/angular-route.js',
+      'app/bower_components/angular-resource/angular-resource.js',
+      'app/bower_components/angular-animate/angular-animate.js',
+      'app/bower_components/angular-mocks/angular-mocks.js',
+      'node_modules/systemjs/dist/system.src.js',
+      'test/karma_test_shim.js',
+      {pattern: 'app/js/**/*.js', included: false, watched: true},
+      {pattern: 'test/unit/**/*.js', included: false, watched: true}
+    ],
+    // #enddocregion files
+
+    autoWatch : true,
+
+    frameworks: ['jasmine'],
+
+    browsers : ['Chrome', 'Firefox'],
+
+    plugins : [
+      'karma-chrome-launcher',
+      'karma-firefox-launcher',
+      'karma-jasmine'
+    ],
+
+    junitReporter : {
+      outputFile: 'test_out/unit.xml',
+      suite: 'unit'
+    }
+
+  });
+};

--- a/public/docs/_examples/upgrade/ts/typescript-conversion/tsconfig.json
+++ b/public/docs/_examples/upgrade/ts/typescript-conversion/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "system",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": false
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Add a .gitignore under the upgrade example that keeps package.json,
tsconfig.json and karma.conf.js. Also restore the karma.conf.js
file under each example.