### PR TITLE
docs(ts/displaying-data): Fix minor typos/npm command.

### DIFF
--- a/public/docs/ts/latest/guide/displaying-data.jade
+++ b/public/docs/ts/latest/guide/displaying-data.jade
@@ -12,7 +12,7 @@ include ../../../../_includes/_util-fns
   We'll display the list of hero names and
   conditionally show a selected hero in a detail area below the list.
 
-  [Live Example](/resources/live-examples/displaying-data/ts/plnkr.html).
+  [Live Example](/resources/live-examples/displaying-data/ts/plnkr.html)
 
   Our final UI looks like this:
 
@@ -95,7 +95,7 @@ figure.image-display
   We're using the *inline* style because the template is small and it makes for clearer demonstration.
   The choice between them is a matter of taste, circumstances, and organization policy.
 
-  In either style, The template data bindings have the same access to the component's properties.
+  In either style, the template data bindings have the same access to the component's properties.
 
   ## Constructor or variable initialization?
 
@@ -154,7 +154,7 @@ figure.image-display
     In fact, `NgFor` can repeat items for any [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
     object.
 :marked
-  Assuming we're still running under the `npm both` command,
+  Assuming we're still running under the `npm go` command,
   we should see heroes appearing in an unordered list.
 
 figure.image-display


### PR DESCRIPTION
Fix a few small typos/issues:

 - punctuation
 - capitalization
 - npm command: `npm both` to `npm go`