### PR TITLE
docs(dt/13554_typo_fix): fix Advanced Component Communication example

### DIFF
--- a/public/index.jade
+++ b/public/index.jade
@@ -34,7 +34,7 @@ br
 div
   h3.text-headline Advanced Component Communication
   p.text-body This demo shows an efficient implementation of tabs/panes. Each pane is only instantiated while it is visible. Panes which are not visible are released and do not have associated memory, DOM and change detection cost.
-  p.text-body The demo also showcases dependency injection and the ability of one component to query for other components. Such queries automatically update even as detail panes are added. This allows tobs component to work with <code>ngFor</code> without any special knowledge of it.
+  p.text-body The demo also showcases dependency injection and the ability of one component to query for other components. Such queries automatically update even as detail panes are added. This allows tab components to work with <code>ngFor</code> without any special knowledge of it.
   p(style='text-align:right')
     md-button.md-primary(href='http://plnkr.co/edit/9E7T5XyLvn0SNQTOrVrJ?p=preview' target='_blank')
       span.icon-open-in-new


### PR DESCRIPTION

change tob to tab and component to components
    
fix [#1355]