### PR TITLE
Typo fix in forms page of TS guide

### DIFF
--- a/public/docs/ts/latest/guide/forms.jade
+++ b/public/docs/ts/latest/guide/forms.jade
@@ -173,7 +173,7 @@ code-example(format="").
 
     1. We import the new `HeroFormComponent`.
 
-    1. The `template` is simply the new element tag identified by the component's `select` property.
+    1. The `template` is simply the new element tag identified by the component's `selector` property.
 
     1. The `directives` array tells Angular that our template depends upon the `HeroFormComponent`
     which is itself a Directive (as are all Components).


### PR DESCRIPTION
It have to be `selector` of component.