### PR TITLE
Fixed typos in documentaion

### DIFF
--- a/public/docs/ts/latest/guide/attribute-directives.jade
+++ b/public/docs/ts/latest/guide/attribute-directives.jade
@@ -61,7 +61,7 @@ include ../../../../_includes/_util-fns
   and relocate the call to `bootstrap` to a separate `boot.ts` file.
 +makeExample('attribute-directives/ts/app/boot.ts', null, 'app/boot.ts')
 :marked
-  A clean `app.component.ts` without bootstrapping is much easer to test.
+  A clean `app.component.ts` without bootstrapping is much easier to test.
   
   Finally, we remember to update `index.html` to load `boot.ts`
   

--- a/public/docs/ts/latest/guide/user-input.jade
+++ b/public/docs/ts/latest/guide/user-input.jade
@@ -115,7 +115,7 @@ figure.image-display
 :marked
   That local template variable is intriguing. It's clearly easier to get to the textbox with that
   variable than to go through the `$event` object. Maybe we can re-write our previous
-  "key-up" example using the variable to acquire the user's' input. Let's give it a try.
+  "key-up" example using the variable to acquire the user's input. Let's give it a try.
 +makeExample('user-input/ts/app/keyup.components.ts', 'key-up-component-2' ,'app/keyup.components.ts (v2)')
 :marked
   That sure seems easier.

--- a/public/docs/ts/latest/guide/user-input.jade
+++ b/public/docs/ts/latest/guide/user-input.jade
@@ -113,7 +113,7 @@ figure.image-display
     We're binding to the number 0, the shortest expression we can think of.
     That is all it takes to keep Angular happy. We said it would be clever!
 :marked
-  That local template variable is intriguing. It's clearly easer to get to the textbox with that
+  That local template variable is intriguing. It's clearly easier to get to the textbox with that
   variable than to go through the `$event` object. Maybe we can re-write our previous
   "key-up" example using the variable to acquire the user's' input. Let's give it a try.
 +makeExample('user-input/ts/app/keyup.components.ts', 'key-up-component-2' ,'app/keyup.components.ts (v2)')


### PR DESCRIPTION
In the typescript guide, fixed two typos (spelling errors) in

* attribute-directives.jade
* user-input.jade