### PR TITLE
docs(*): `npm run go` -> `npm start` (TS)

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -8,8 +8,7 @@
     "tsc:w": "tsc -w",
     "lite": "lite-server",
     "live": "live-server",
-    "start": "npm run lite",
-    "go": "concurrent \"npm run tsc:w\" \"npm run start\" ",
+    "start": "concurrent \"npm run tsc:w\" \"npm run lite\" ",
     "test": "karma start karma.conf.js",
     "build-and-test": "npm run tsc && npm run test"
   },

--- a/public/docs/_examples/quickstart/ts/package.1.json
+++ b/public/docs/_examples/quickstart/ts/package.1.json
@@ -5,7 +5,7 @@
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "lite": "lite-server",
-    "go": "concurrent \"npm run tsc:w\" \"npm run lite\" "
+    "start": "concurrent \"npm run tsc:w\" \"npm run lite\" "
   },
   "license": "ISC",
   "dependencies": {

--- a/public/docs/ts/latest/guide/displaying-data.jade
+++ b/public/docs/ts/latest/guide/displaying-data.jade
@@ -77,7 +77,7 @@ figure.image-display
   We're ready to see changes in a running app by firing up the npm script that both compiles and serves our applications
   while watching for changes.
 code-example(format="").
-  npm run go
+  npm start
 :marked
   We should see the title and hero name:
 figure.image-display

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -258,7 +258,7 @@ code-example(format="").
   
   Open a terminal window and enter this command:
 code-example(format="").
-  npm run go
+  npm start
 :marked
   That command runs two parallel node processes
   1. The TypeScript compiler in watch mode
@@ -389,7 +389,7 @@ code-example(language="html" format=".").
 :marked
   We've seen how we can run the compiler and a server at the same time with this command:
 code-example(format="").
-  npm run go
+  npm start
 :marked
   We execute npm scripts in that manner: `npm run` + *script-name*. Here's what these scripts do:
   

--- a/public/docs/ts/latest/tutorial/toh-pt1.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt1.jade
@@ -26,7 +26,7 @@ code-example(format="").
   We want to start the TypeScript compiler, have it watch for changes, and start our server. We'll do this by typing
 
 code-example(format="" language="bash").
-  npm run go
+  npm start
 
 :marked
   This command starts the server, launches the app in a browser,

--- a/public/docs/ts/latest/tutorial/toh-pt2.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt2.jade
@@ -32,7 +32,7 @@ code-example(format="").
   We want to start the TypeScript compiler, have it watch for changes, and start our server. We'll do this by typing
 
 code-example(format="." language="bash").
-  npm run go
+  npm start
 
 :marked
   This will keep the application running while we continue to build the Tour of Heroes.

--- a/public/docs/ts/latest/tutorial/toh-pt3.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt3.jade
@@ -25,7 +25,7 @@ include ../../../../_includes/_util-fns
     We want to start the TypeScript compiler, have it watch for changes, and start our server. We'll do this by typing
 
   code-example(format="." language="bash").
-    npm run go
+    npm start
   
   :marked
     This will keep the application running while we continue to build the Tour of Heroes.

--- a/public/docs/ts/latest/tutorial/toh-pt4.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt4.jade
@@ -30,7 +30,7 @@ include ../../../../_includes/_util-fns
     We want to start the TypeScript compiler, have it watch for changes, and start our server. We'll do this by typing
 
   code-example(format="." language="bash").
-    npm run go
+    npm start
 
   :marked
     ## Flying Overhead


### PR DESCRIPTION
Convert npm script command from `npm run go` to `npm start` ... because that's the way it should have been for TypeScript files.