### PR TITLE
Update toh-pt2.jade

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt2.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt2.jade
@@ -47,7 +47,7 @@ code-example(format="." language="bash").
 
 :marked
   The `HEROES` array is of type `Hero`.
-  We are taking advantage of the `Hero` class we coded previously to create an array of our heroes.
+  We are taking advantage of the `Hero` interface we coded previously to create an array of our heroes.
   We aspire to get this list of heroes from a web service, but let’s take small steps
   on this road and start by displaying these mock heroes in the browser.
 


### PR DESCRIPTION
Fixed a typo referring to the `Hero` type as a class, when it was defined in part 1 as an interface.