### PR TITLE
docs(quick start): fix Dart package name

### DIFF
--- a/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
@@ -1,5 +1,5 @@
 # #docregion
-name: angular2-getting-started
+name: angular2_getting_started
 version: 0.0.1
 dependencies:
   angular2: 2.0.0-beta.0

--- a/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
@@ -1,5 +1,5 @@
 # #docregion
-name: angular2-getting-started
+name: angular2_getting_started
 version: 0.0.1
 dependencies:
   angular2: 2.0.0-beta.0


### PR DESCRIPTION
Dart package names need underscores, not dashes.