### PR TITLE
docs(js/latest/quickstart.jade): remove references to .ts files

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -295,8 +295,8 @@ figure.image-display
     .file node_modules
     .file app
     .children
-      .file app.component.ts
-      .file boot.ts
+      .file app.component.js
+      .file boot.js
     .file index.html
     .file package.json
 :marked


### PR DESCRIPTION
remove erroneous references to .ts app files from Final Structure section