### PR TITLE
Fixing typo in pt4 of tutorial

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt4.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt4.jade
@@ -213,7 +213,7 @@ code-example(format="." language="html").
     it would ask Angular to inject the service into its constructor which would look just like the one for `AppComponent`:
   +makeExample('toh-4/ts/app/app.component.1.ts', 'ctor', 'hero-detailcomponent.ts (constructor)')
   :marked
-    The `HeroDetailComponent` must *not* repeat it's parent's `directives` array! Guess [why](#shadow-provider).
+    The `HeroDetailComponent` must *not* repeat it's parent's `providers` array! Guess [why](#shadow-provider).
     
     The `AppComponent` is the top level component of our application. 
     There should be only one instance of that component and only one instance of the `HeroService` in our entire app.


### PR DESCRIPTION
I think the author intended to reference `providers` and not `directives`.

Fixes issues mentioned in #594