### PR TITLE
docs(attribute-directives): Add missing semicolons in example code imports

### DIFF
--- a/public/docs/_examples/attribute-directives/ts/app/app.component.ts
+++ b/public/docs/_examples/attribute-directives/ts/app/app.component.ts
@@ -1,6 +1,6 @@
 // #docregion
 import {Component} from 'angular2/core';
-import {HighlightDirective} from './highlight.directive'
+import {HighlightDirective} from './highlight.directive';
 
 @Component({
   selector: 'my-app',

--- a/public/docs/_examples/attribute-directives/ts/app/boot.ts
+++ b/public/docs/_examples/attribute-directives/ts/app/boot.ts
@@ -1,5 +1,5 @@
 // #docregion
-import {bootstrap}    from 'angular2/platform/browser'
+import {bootstrap}    from 'angular2/platform/browser';
 import {AppComponent} from './app.component';
 
 bootstrap(AppComponent);


### PR DESCRIPTION
`public/docs/_examples/attribute-directives/ts/app/app.component.ts` and `public/docs/_examples/attribute-directives/ts/app/boot.ts` missed semicolons after some of the `import` statements.