### PR TITLE
term correction

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -142,7 +142,7 @@ code-example(format="").
 +makeExample('quickstart/js/app/app.component.js', 'iife', 'app/app.component.js (IIFE)')(format=".")
   
 :marked
-  Most application files *export* one thing into our faux-pas 'namespace', such as a component.
+  Most application files *export* one thing into our faux 'namespace', such as a component.
   Our `app.component.js` file exports the `AppComponent`.
   
 +makeExample('quickstart/js/app/app.component.js', 'export', 'app/app.component.js (export)')(format=".")


### PR DESCRIPTION
Fixing "faux-pas" to "faux", "faux-pas" is not the correct term here, "faux" is the intended term. Faux-pas is when you say something embarrassing or tactless in front of people, faux means artificial or imitation.