### PR TITLE
docs: fix typo in Gulp task name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you are only going to work on a specific part of the docs, such as the API or
 
 * `serve-and-sync` : watch all the local Jade/Sass files, the API source and examples, and the dev guide files
 * `serve-and-sync-api-docs` : watch only the API source and example files
-* `serve-and-sync-devGuide` : watch only the dev guide files
+* `serve-and-sync-devguide` : watch only the dev guide files
 * `build-and-serve` : watch only the local Jade/Sass files
 
 ## Technology Used


### PR DESCRIPTION
Fixes Gulp task name error:
<img width="562" alt="screen shot 2015-12-27 at 14 37 30" src="https://cloud.githubusercontent.com/assets/6679057/12012441/3ba0d512-aca8-11e5-948c-a093176ffabe.png">


