### PR TITLE
docs(quickstart): remove reference to ts editor

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -56,8 +56,8 @@ figure.image-display
 :marked
   ## Development Environment
   
-  We'll need a place to stand (the application project folder), some libraries, 
-  some TypeScript configuration and the TypeScript-aware editor of your choice.
+  We'll need a place to stand (the application project folder), some libraries 
+  and your editor of choice.
 
   ### Create a new project folder
   


### PR DESCRIPTION
Fix #607