### PR TITLE
Fix to attribute directive guide

### DIFF
--- a/public/docs/ts/latest/guide/attribute-directives.jade
+++ b/public/docs/ts/latest/guide/attribute-directives.jade
@@ -81,11 +81,17 @@ include ../../../../_includes/_util-fns
   :marked
     ### Why not call it "highlight"?
     *highlight* is a nicer name than *myHighlight* and, technically, it would work if we called it that.
-    However, the good folks at Angular strongly prefer hyphenated directive selector names. 
-    The HTML standards body will never name one of its attributes with a hyphen and there is
-    less risk of colliding with a third-party directive name when we give ours a prefix.
-    The `ng` prefix belongs to Angular. 
+ 
+    However, we recommend picking a selector name with a prefix to ensure
+    that it cannot conflict with any standard HTML attribute, now or in the future.
+    There is also less risk of colliding with a third-party directive name when we give ours a prefix.
+
+    We do **not** prefix our `highlight` directive name with **`ng`**.
+    That prefix belongs to Angular and
+    we don't want to confuse our directives with their directives.
+
     We need a prefix of our own, preferably short, and `my` will do for now.
+    
 :marked
   After the `@Directive` metadata comes the directive's controller class which we are exporting
   to make it accessible to other components. 

--- a/public/docs/ts/latest/guide/attribute-directives.jade
+++ b/public/docs/ts/latest/guide/attribute-directives.jade
@@ -361,7 +361,7 @@ figure.image-display
   In all previous bindings, the directive or component property was a binding ***source***.
   A property is a *source* if it appears in the template expression to the ***right*** of the (=).
   
-  A property is a *target* when it appears to the ***left** of the (=) ...
+  A property is a *target* when it appears to the **left** of the (=) ...
   as it is does when we bind to the `myHighlight` property of the `HighlightDirective`, 
 +makeExample('attribute-directives/ts/app/app.component.html','span')(format=".")
 :marked


### PR DESCRIPTION
Two small fixes to the attribute directive guide
* remove extra asterisk
* reword the section about prefixes to no longer mention hyphens