### PR TITLE
docs(quickstart): include NativeScript as an alternative bootstrap option

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -423,7 +423,7 @@ code-example(format="").
   this library most of the time. It's pretty "core" if we're always writing for a browser.
     
   But it is possible to load a component in a different enviroment. 
-  We might load it on a mobile device with [Apache Cordova](https://cordova.apache.org/)
+  We might load it on a mobile device with [Apache Cordova](https://cordova.apache.org/) or [NativeScript](https://www.nativescript.org/).
   We might wish to render the first page of our application on the server 
   to improve launch performance or facilitate 
   [SEO](http://static.googleusercontent.com/media/www.google.com/en//webmasters/docs/search-engine-optimization-starter-guide.pdf).

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -536,7 +536,7 @@ code-example(format="").
   this library most of the time. It's pretty "core" if we're always writing for a browser.
     
   But it is possible to load a component in a different enviroment. 
-  We might load it on a mobile device with [Apache Cordova](https://cordova.apache.org/)
+  We might load it on a mobile device with [Apache Cordova](https://cordova.apache.org/) or [NativeScript](https://www.nativescript.org/).
   We might wish to render the first page of our application on the server 
   to improve launch performance or facilitate 
   [SEO](http://static.googleusercontent.com/media/www.google.com/en//webmasters/docs/search-engine-optimization-starter-guide.pdf).


### PR DESCRIPTION
Hey there,

We’d love a shout out for NativeScript as we already have a [functioning bootstrap implementation](https://github.com/NativeScript/nativescript-angular/blob/master/src/nativescript-angular/application.ts#L32-L57). In Apache Cordova you’d probably use the browser bootstrap anyways because you’re still running in a browser, albeit a natively embedded one. Full disclosure: I work for Telerik on the NativeScript team.

Thanks!