### PR TITLE
fix(directives): remove dashCase pipe

### DIFF
--- a/tools/api-builder/angular.io-package/templates/directive.template.html
+++ b/tools/api-builder/angular.io-package/templates/directive.template.html
@@ -18,7 +18,7 @@
   h2 Inputs
   .l-sub-section{% for binding, property in doc.inputs %}
     h3.input
-      code {$ property.bindingName | dashCase $}
+      code {$ property.bindingName $}
       | &nbsp;bound to&nbsp;
       code {$ property.memberDoc.classDoc.name $}.{$ property.propertyName $}
     :marked
@@ -30,7 +30,7 @@
   h2 Outputs
   .l-sub-section{% for binding, property in doc.outputs %}
     h3.output
-      code {$ property.bindingName | dashCase $}
+      code {$ property.bindingName $}
       | &nbsp;bound to&nbsp;
       code {$ property.memberDoc.classDoc.name $}.{$ property.propertyName $}
     :marked


### PR DESCRIPTION
The current API doc generator generates the deprecated dashCase syntax for directive inputs/outputs.
This PR removes the use of the dashCase pipe for inputs/outputs.