### PR TITLE
docs(quickstart): added system.js configuration to use 3rd party ng2 modules

### DIFF
--- a/public/docs/_examples/quickstart/ts/index2.html
+++ b/public/docs/_examples/quickstart/ts/index2.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!-- #docregion -->
+<html>
+
+  <head>
+    <title>Angular 2 QuickStart</title>
+
+    <!-- 1. Load libraries -->
+    <!-- #docregion libraries -->
+    <script src="node_modules/angular2/bundles/angular2-polyfills.js"></script>
+    <script src="node_modules/systemjs/dist/system.src.js"></script>
+    <script src="node_modules/rxjs/bundles/Rx.js"></script>
+    <script src="node_modules/angular2/bundles/angular2.dev.js"></script>
+    <!-- #enddocregion libraries -->
+
+    <!-- 2. Configure SystemJS -->
+    <!-- #docregion systemjs -->
+    <script>
+      System.config({
+        packages: {
+          app: {
+            format: 'register',
+            defaultExtension: 'js'
+          },
+          'ng2-bootstrap': {}
+        },
+        map: {
+          'ng2-bootstrap': 'node_modules/ng2-bootstrap'
+        }
+      });
+      System.import('app/boot')
+            .then(null, console.error.bind(console));
+    </script>
+    <!-- #enddocregion systemjs -->
+
+  </head>
+
+  <!-- 3. Display the application -->
+  <!-- #docregion my-app -->
+  <body>
+    <my-app>Loading...</my-app>
+  </body>
+  <!-- #enddocregion my-app -->
+
+</html>

--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -415,7 +415,7 @@ code-example(format="").
   and everything works.
   
   We are in good shape as long as there are no `npm ERR!` messages at the very end of `npm install`.
-  
+
 .l-main-section
 :marked
   <a id="boot"></a>

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -521,7 +521,24 @@ code-example(format="").
   
   All other modules are loaded upon request
   either by an import statement or by Angular itself.
-  
+
+.l-main-section
+:marked
+  <a id="3rd-party-modules"></a>
+  ### Appendix: Using 3rd party Angular2 modules
+
+  #### Installing 3rd party module
+  You can use `npm` or `jspm` package managers to install 3rd party libraries, like [`ng2-bootstrap`](https://github.com/valor-software/ng2-bootstrap).
+
+code-example(format="").
+  npm install ng2-bootstrap --save
+:marked
+  #### Configuring `System.js`
+  Now you need to update `System.js` config in `index.html` by adding new module references.
++makeExample('quickstart/ts/index2.html', 'systemjs', 'index.html (System configuration)')(format=".")
+:marked
+  After this you can import and use this module from your application.
+
 .l-main-section
 :marked
   <a id="boot"></a>


### PR DESCRIPTION
Hi
All the time I am getting reports about same issue from different people
who tries to follow `5 min start guide` and system.js
`Uncaught SyntaxError: Unexpected token < `
So I have prepared appendix to your guide with sample how to
install 3rd party angular2 module and configure system.js to work with it propertly

If any changes is required just wrote

Thanks in advance