### PR TITLE
docs(tutorial): fix wrong text related to screenshots

### DIFF
--- a/public/docs/ts/latest/tutorial/index.jade
+++ b/public/docs/ts/latest/tutorial/index.jade
@@ -48,14 +48,16 @@ figure.image-display
 
 :marked
   Links at the top can take us to either of the main views.
-  We'll click the "Back" button which sends us to the "Heroes" master list view with
-  "Magneta" as the selected hero.
+  We could also navigate back to the "Dashboard" by clicking "Back".
+
+  However we'll click the "Dashboard" link instead, which sends us to the "Heroes" master list view.
+  There we select the hero named "Dynama". By doing that the hero is rendered as "selected" and
+  the readonly mini-detail is displayed beneath the list.
 
 figure.image-display
   img(src='/resources/images/devguide/toh/heroes-list-2.png' alt="Output of heroes list app")
 
 :marked
-  We click a different hero and the readonly mini-detail beneath the list reflects our new choice.
 
   We click the "View Details" button to drill into the
   editable details of our selected hero.


### PR DESCRIPTION
The text did not fit to the image in the tutorial. I changed the text a bit (tried to keep the same wording). 
It's still not 100% correct, to do that I think we'd either need to:

- introduce another image as a step between
- replace the image `heroes-list-2.png` with an image which also displays the readonly details

However this is probably a detail and I didn't know if you guys would be okay with it if I just replaced/added a new image and maybe we can also just leave it as it is.

So let me know what you think ;)