### PR TITLE
docs(quickstart): simplify System.import usage

### DIFF
--- a/public/docs/_examples/quickstart/ts/index.html
+++ b/public/docs/_examples/quickstart/ts/index.html
@@ -17,7 +17,7 @@
     <!-- #docregion systemjs -->
     <script>
       System.config({
-        packages: {        
+        packages: {
           app: {
             format: 'register',
             defaultExtension: 'js'
@@ -25,7 +25,9 @@
         }
       });
       System.import('app/boot')
-            .then(null, console.error.bind(console));
+            .catch(function(err) {
+              console.error(err);
+            });
     </script>
     <!-- #enddocregion systemjs -->
 


### PR DESCRIPTION
In my opinion, the current usage of `System.import` is a bit clunky, and perhaps intimidating for novices.

__Current__
```typescript
System.import('app/boot')
        .then(null, console.error.bind(console)); 
```

__This PR__
```js
System.import('app/boot')
        .catch(err => console.error(err));
```

__Alt 1__
```js
System.import('app/boot')
        .catch(function(err) {
          console.error(err);
        });
```

__Alt 2__
```js
System.import('app/boot')
        .catch(console.error.bind(console));
```