### PR TITLE
docs(help&support): create dart version of help&support

### DIFF
--- a/public/docs/dart/latest/help.jade
+++ b/public/docs/dart/latest/help.jade
@@ -1,1 +1,43 @@
-!= partial("../../_includes/_help")
+.l-main-section
+    h2 Get Help Using Angular
+
+    p.
+        We have an incredible community of developers who are passionate about solving problems.
+        We recommend some of the following methods to get help with Angular.
+
+
+    .l-sub-section
+        h3 Angular Google Group
+
+        ol
+            li.
+                Search the archive first.
+                It's likely that your question has already been answered.
+            li.
+                To avoid the spam moderation queue,
+                don't include code directly in your email. (See #3)
+            li.
+                Link to a live code example that demonstrates your problem or question,
+                so you'll get an answer faster.
+                <a href="http://plnkr.co/edit/jISF8yxbVGmarpBbqsYW?p=preview">Use this template</a>.
+            li.
+                If you get help, help others. Good karma rulez!
+
+        a(href="https://groups.google.com/forum/#!forum/angular" class="button button-primary" md-button) View the Google Group
+
+    .l-sub-section
+        h3 Angular Chat Room
+
+        p Talk in real time with other Angular developers on Slack.
+
+        a(href="http://dartlang-slack.herokuapp.com/" class="button button-primary" md-button) Join Dart on Slack
+
+        a(href="https://dartlang.slack.com/messages/angular2/" class="button button-primary" md-button) Go to the Angular channel
+
+
+    .l-sub-section
+        h3 Report an Issue
+
+        p If you run into an issue or have a feature request, you can create a new issue on our GitHub repository.
+
+        a(href="https://github.com/angular/angular/issues" class="button button-primary" md-button) Report an Issue


### PR DESCRIPTION
create dart version of help&support and link to the official slack channel

fix #675 