### PR TITLE
docs(landing): media query for mobile to fix formatting with flex style

### DIFF
--- a/public/resources/css/base/_type.scss
+++ b/public/resources/css/base/_type.scss
@@ -208,3 +208,18 @@ table td {
     margin-right: 0;
   }
 }
+@media handheld and (max-width: 480px), screen and (max-device-width: 480px), screen and (max-width: 600px) {
+  .docs-content .card-row {
+    &[layout="row"] {
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column; 
+      & > div {   
+        & > .card {
+          margin-left: 0;
+          margin-right: 0;
+        }
+      }
+    }
+  }
+}

--- a/public/resources/css/module/_banner.scss
+++ b/public/resources/css/module/_banner.scss
@@ -12,7 +12,7 @@
   @media handheld and (max-width: $phone-breakpoint),
   screen and (max-device-width: $phone-breakpoint),
   screen and (max-width: $tablet-breakpoint) {
-    padding: ($unit * 2) 0;
+    padding: ($unit * 2);
   }
 
   &.is-centered {


### PR DESCRIPTION
Current state of mobile looked like this:
![img_3523](https://cloud.githubusercontent.com/assets/457187/12342751/762ba4da-bae2-11e5-9e2a-04f1e73d2bf4.PNG)
![img_3524](https://cloud.githubusercontent.com/assets/457187/12342752/762c338c-bae2-11e5-8375-33377367c084.PNG)

-----
# With these fixes:
![img_3525](https://cloud.githubusercontent.com/assets/457187/12342798/ee97d6f0-bae2-11e5-9f9d-1925c3c706bb.PNG)
![img_3527](https://cloud.githubusercontent.com/assets/457187/12342800/f2a39fa4-bae2-11e5-9a9a-33cc76bb3642.PNG)


