### PR TITLE
docs(guide/template-syntax) fix typo painfull -> painfully

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -546,7 +546,7 @@ table
   They do not correspond to element properties and they do not set element properties.
   There are no property targets to bind to.
 
-  We become painfull aware of this fact when we try to write something like this:
+  We become painfully aware of this fact when we try to write something like this:
 code-example(language="html").
   &lt;tr>&lt;td colspan="{{1 + 1}}">Three-Four&lt;/td>&lt;/tr>
 :marked


### PR DESCRIPTION
The word 'painfully' is missing its trailing 'y'.