### PR TITLE
docs(guide/pipes): fix typo in pipe example

### DIFF
--- a/public/docs/ts/latest/guide/pipes.jade
+++ b/public/docs/ts/latest/guide/pipes.jade
@@ -134,7 +134,7 @@ figure.image-display
   
   * The `@Pipe` decorator takes an object with a name property whose value is the
      pipe name that we'll use within a template expression. It must be a valid JavaScript identifier.
-     Our pipe's name is `exponenentialStrength`.
+     Our pipe's name is `exponentialStrength`.
 
 .l-sub-section
   :marked


### PR DESCRIPTION
`exponenentialStrength` should be `exponentialStrength`.