### PR TITLE
News card structure fixed

### DIFF
--- a/public/news.jade
+++ b/public/news.jade
@@ -13,8 +13,9 @@
            href="http://angularjs.blogspot.com/2016/01/angular-2-mit-open-source-licensed.html"
         ) Angular 2: an MIT Open Source Licensed Framework
       p As of beta.2 this week, we're moving Angular 2, its related libraries, and any code snippets and examples to the MIT license. Open source licenses are meant to protect developers by making it clear how code can be used. We want developers to be confident that they can use, fork...
-      img(src="/resources/images/bios/naomi.jpg")
-      .posted Posted by <b>Naomi Black</b>
+      .author 
+        img(src="/resources/images/bios/naomi.jpg")
+        .posted Posted by <b>Naomi Black</b>
   .c6
     .article-card
       .date December 15, 2015
@@ -24,7 +25,6 @@
           href="http://angularjs.blogspot.com/2015/12/angular-2-beta.html"
         ) Angular 2 Beta
       p We're ecstatic to announce that we've reached Angular 2 Beta.  You can read about many of the improvements over Angular 1 in a recent post.  Get started learning Angular 2 now at angular.io. What does 'beta' mean? Beta means we're now confident that most developers can be successful building large applications using Angular 2....
-
       .author 
         img(src="/resources/images/bios/brad-green.jpg")
         .posted Posted by <b>Brad Green</b>


### PR DESCRIPTION
Structure for "Licensing" news was fixed to match the rest of articles