### PR TITLE
docs:add a2-in-memory-web-api support

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -24,7 +24,10 @@
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "zone.js": "0.5.10",
+    
+    "a2-in-memory-web-api": "^0.1.0",
     "bootstrap": "^3.3.6"
+
   },
   "devDependencies": {
     "concurrently": "^1.0.0",

--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -89,6 +89,11 @@ var _rxData = [
     to: 'https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.16/system-polyfills.js'
   },
   {
+    pattern: 'script',
+    from: 'node_modules/a2-in-memory-web-api/web-api.js',
+    to: 'https://npmcdn.com/a2-in-memory-web-api/web-api.js'
+  },
+  {
     pattern: 'link',
     from: 'node_modules/bootstrap/dist/css/bootstrap.min.css',
     to: 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap-theme.min.css'


### PR DESCRIPTION
Support an in-memory RESTy `HttpBackend` service for HTTP samples that can PUT/POST/DELETE
Adds optional package and plunker translation to samples
Available as [3rd party npm package](https://www.npmjs.com/package/a2-in-memory-web-api) until something like it offered by Angular
Package is MIT licensed,