### PR TITLE
Fix Docs Home layout for small devices

### DIFF
--- a/public/docs/dart/latest/index.jade
+++ b/public/docs/dart/latest/index.jade
@@ -1,4 +1,4 @@
-div.card-row(layout='row')
+div(layout='row',layout-sm='column')
   div(flex)
     md-card.card
       md-card-content

--- a/public/docs/js/latest/index.jade
+++ b/public/docs/js/latest/index.jade
@@ -1,4 +1,4 @@
-div.card-row(layout='row')
+div(layout='row',layout-sm='column')
   div(flex)
     md-card.card
       md-card-content

--- a/public/docs/ts/latest/index.jade
+++ b/public/docs/ts/latest/index.jade
@@ -1,4 +1,4 @@
-div.card-row(layout='row')
+div(layout='row',layout-sm='column')
   div(flex)
     md-card.card
       md-card-content


### PR DESCRIPTION
Docs Home page is not displayed correctly on mobile devices. Fix to set layout as column on small devices.
![image](https://cloud.githubusercontent.com/assets/1594654/12448676/f549cd36-bf34-11e5-86f4-93caffee38f4.png)
