### PR TITLE
docs(guide): add placeholders for missing Dart chapters

### DIFF
--- a/public/docs/dart/latest/guide/_data.json
+++ b/public/docs/dart/latest/guide/_data.json
@@ -2,7 +2,7 @@
   "_listtype": "ordered",
 
   "index": {
-    "title": "Developers Guide"
+    "title": "Developer Guides"
   },
 
   "cheatsheet": {
@@ -15,16 +15,61 @@
 
   "displaying-data": {
     "title": "Displaying Data",
-    "intro": "Displaying data is job number one for any good application. In Angular, you bind data to elements in HTML templates and Angular automatically updates the UI as data changes."
+    "intro": "Interpolation and other forms of property binding help us show app data in the UI."
   },
 
   "user-input": {
     "title": "User Input",
-    "intro": "DOM events drive user input in Angular. You can use the native events like click, mouseover, and keyup. Angular uses a special syntax to register events to DOM elements. This section covers all the ins and outs of using the event syntax."
+    "intro": "User input triggers DOM events. We listen to those events with event bindings that funnel updated values back into our components and models."
   },
 
   "forms": {
     "title": "Forms",
     "intro": "A form creates a cohesive, effective, and compelling data entry experience. An Angular form coordinates a set of data-bound user controls, tracks changes, validates input, and presents errors."
+  },
+
+  "dependency-injection": {
+    "title": "Dependency Injection",
+    "intro": "Angular's dependency injection system creates and delivers dependent services \"just-in-time\"."
+  },
+
+  "template-syntax": {
+    "title": "Template Syntax",
+    "intro": "Learn how to write templates that display data and consume user events with the help of data binding."
+  },
+
+  "pipes": {
+    "title": "Pipes",
+    "intro": "Pipes transform displayed values within a template."
+  },
+
+  "router": {
+    "title": "Routing & Navigation",
+    "intro": "Discover the basics of screen navigation with the Angular 2 router."
+  },
+
+  "lifecycle-hooks": {
+    "title": "Lifecycle Hooks",
+    "intro": "Angular calls lifecycle hook methods on directives and components as it creates, changes, and destroys them."
+  },
+
+  "attribute-directives": {
+    "title": "Attribute Directives",
+    "intro": "Attribute directives attach behavior to elements."
+  },
+
+  "structural-directives": {
+    "title": "Structural Directives",
+    "intro": "Angular has a powerful template engine that lets us easily manipulate the DOM structure of our elements."
+  },
+
+  "hierarchical-dependency-injection": {
+    "title": "Hierarchical Injectors",
+    "intro": "Angular's hierarchical dependency injection system supports nested injectors in parallel with the component tree."
+  },
+
+  "glossary": {
+    "title": "Glossary",
+    "intro": "Brief definitions of the most important words in the Angular 2 vocabulary"
   }
 }

--- a/public/docs/dart/latest/guide/attribute-directives.jade
+++ b/public/docs/dart/latest/guide/attribute-directives.jade
@@ -2,11 +2,11 @@ include ../../../../_includes/_util-fns
 
 :marked
   We're working on the Dart version of this chapter.
-  In the meantime, please see the resources:
+  In the meantime, please see these resources:
 
   * [Attribute Directives](/docs/ts/latest/guide/attribute-directives.html):
     The TypeScript version of this chapter
 
-  * [Dart source code](): [PENDING: insert link]
+  * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/attribute-directives/dart):
     A preliminary version of the example code that will appear in this chapter
-   
+

--- a/public/docs/dart/latest/guide/attribute-directives.jade
+++ b/public/docs/dart/latest/guide/attribute-directives.jade
@@ -1,0 +1,12 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this chapter.
+  In the meantime, please see the resources:
+
+  * [Attribute Directives](/docs/ts/latest/guide/attribute-directives.html):
+    The TypeScript version of this chapter
+
+  * [Dart source code](): [PENDING: insert link]
+    A preliminary version of the example code that will appear in this chapter
+   

--- a/public/docs/dart/latest/guide/dependency-injection.jade
+++ b/public/docs/dart/latest/guide/dependency-injection.jade
@@ -1,0 +1,6 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this chapter.
+  In the meantime, please read the
+  [TypeScript version of this chapter](/docs/ts/latest/guide/dependency-injection.html).

--- a/public/docs/dart/latest/guide/glossary.jade
+++ b/public/docs/dart/latest/guide/glossary.jade
@@ -1,0 +1,6 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this glossary.
+  In the meantime, please read the
+  [TypeScript glossary](/docs/ts/latest/guide/glossary.html).

--- a/public/docs/dart/latest/guide/glossary.jade
+++ b/public/docs/dart/latest/guide/glossary.jade
@@ -3,4 +3,4 @@ include ../../../../_includes/_util-fns
 :marked
   We're working on the Dart version of this glossary.
   In the meantime, please read the
-  [TypeScript glossary](/docs/ts/latest/guide/glossary.html).
+  [TypeScript version of the glossary](/docs/ts/latest/guide/glossary.html).

--- a/public/docs/dart/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/dart/latest/guide/hierarchical-dependency-injection.jade
@@ -2,11 +2,11 @@ include ../../../../_includes/_util-fns
 
 :marked
   We're working on the Dart version of this chapter.
-  In the meantime, please see the resources:
+  In the meantime, please see these resources:
 
-  * [Hierarchical Dependency Injection](/docs/ts/latest/guide/hierarchical-dependency-injection.html):
+  * [Hierarchical Injectors](/docs/ts/latest/guide/hierarchical-dependency-injection.html):
     The TypeScript version of this chapter
 
   * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/hierarchical-dependency-injection/dart):
     A preliminary version of the example code that will appear in this chapter
-   
+

--- a/public/docs/dart/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/dart/latest/guide/hierarchical-dependency-injection.jade
@@ -1,0 +1,12 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this chapter.
+  In the meantime, please see the resources:
+
+  * [Hierarchical Dependency Injection](/docs/ts/latest/guide/hierarchical-dependency-injection.html):
+    The TypeScript version of this chapter
+
+  * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/hierarchical-dependency-injection/dart):
+    A preliminary version of the example code that will appear in this chapter
+   

--- a/public/docs/dart/latest/guide/lifecycle-hooks.jade
+++ b/public/docs/dart/latest/guide/lifecycle-hooks.jade
@@ -7,6 +7,6 @@ include ../../../../_includes/_util-fns
   * [Lifecycle Hooks](/docs/ts/latest/guide/lifecycle-hooks.html):
     The TypeScript version of this chapter
 
-  * [Dart source code](): [PENDING: insert link]
+  * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/lifecyle-hooks/dart):
     A preliminary version of the example code that will appear in this chapter
    

--- a/public/docs/dart/latest/guide/lifecycle-hooks.jade
+++ b/public/docs/dart/latest/guide/lifecycle-hooks.jade
@@ -1,0 +1,12 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this chapter.
+  In the meantime, please see the resources:
+
+  * [Lifecycle Hooks](/docs/ts/latest/guide/lifecycle-hooks.html):
+    The TypeScript version of this chapter
+
+  * [Dart source code](): [PENDING: insert link]
+    A preliminary version of the example code that will appear in this chapter
+   

--- a/public/docs/dart/latest/guide/lifecycle-hooks.jade
+++ b/public/docs/dart/latest/guide/lifecycle-hooks.jade
@@ -2,11 +2,11 @@ include ../../../../_includes/_util-fns
 
 :marked
   We're working on the Dart version of this chapter.
-  In the meantime, please see the resources:
+  In the meantime, please see these resources:
 
   * [Lifecycle Hooks](/docs/ts/latest/guide/lifecycle-hooks.html):
     The TypeScript version of this chapter
 
-  * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/lifecyle-hooks/dart):
+  * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/lifecycle-hooks/dart):
     A preliminary version of the example code that will appear in this chapter
-   
+

--- a/public/docs/dart/latest/guide/pipes.jade
+++ b/public/docs/dart/latest/guide/pipes.jade
@@ -1,0 +1,12 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this chapter.
+  In the meantime, please see the resources:
+
+  * [Pipes](/docs/ts/latest/guide/pipes.html):
+    The TypeScript version of this chapter
+
+  * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/pipes/dart):
+    A preliminary version of the example code that will appear in this chapter
+   

--- a/public/docs/dart/latest/guide/pipes.jade
+++ b/public/docs/dart/latest/guide/pipes.jade
@@ -2,11 +2,11 @@ include ../../../../_includes/_util-fns
 
 :marked
   We're working on the Dart version of this chapter.
-  In the meantime, please see the resources:
+  In the meantime, please see these resources:
 
   * [Pipes](/docs/ts/latest/guide/pipes.html):
     The TypeScript version of this chapter
 
   * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/pipes/dart):
     A preliminary version of the example code that will appear in this chapter
-   
+

--- a/public/docs/dart/latest/guide/router.jade
+++ b/public/docs/dart/latest/guide/router.jade
@@ -1,0 +1,6 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this chapter.
+  In the meantime, please read the
+  [TypeScript version of this chapter](/docs/ts/latest/guide/router.html).

--- a/public/docs/dart/latest/guide/structural-directives.jade
+++ b/public/docs/dart/latest/guide/structural-directives.jade
@@ -2,7 +2,7 @@ include ../../../../_includes/_util-fns
 
 :marked
   We're working on the Dart version of this chapter.
-  In the meantime, please see the resources:
+  In the meantime, please see these resources:
 
   * [Structural Directives](/docs/ts/latest/guide/structural-directives.html):
     The TypeScript version of this chapter

--- a/public/docs/dart/latest/guide/structural-directives.jade
+++ b/public/docs/dart/latest/guide/structural-directives.jade
@@ -1,0 +1,12 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this chapter.
+  In the meantime, please see the resources:
+
+  * [Structural Directives](/docs/ts/latest/guide/structural-directives.html):
+    The TypeScript version of this chapter
+
+  * [Dart source code](): [PENDING: insert link]
+    A preliminary version of the example code that will appear in this chapter
+   

--- a/public/docs/dart/latest/guide/structural-directives.jade
+++ b/public/docs/dart/latest/guide/structural-directives.jade
@@ -7,6 +7,6 @@ include ../../../../_includes/_util-fns
   * [Structural Directives](/docs/ts/latest/guide/structural-directives.html):
     The TypeScript version of this chapter
 
-  * [Dart source code](): [PENDING: insert link]
+  * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/structural-directives/dart):
     A preliminary version of the example code that will appear in this chapter
    

--- a/public/docs/dart/latest/guide/template-syntax.jade
+++ b/public/docs/dart/latest/guide/template-syntax.jade
@@ -2,11 +2,11 @@ include ../../../../_includes/_util-fns
 
 :marked
   We're working on the Dart version of this chapter.
-  In the meantime, please see the resources:
+  In the meantime, please see these resources:
 
   * [Template Syntax](/docs/ts/latest/guide/template-syntax.html):
     The TypeScript version of this chapter
 
-  * [Dart source code](): [PENDING: insert link]
+  * [Dart source code](https://github.com/angular/angular.io/tree/master/public/docs/_examples/template-syntax/dart):
     A preliminary version of the example code that will appear in this chapter
-   
+

--- a/public/docs/dart/latest/guide/template-syntax.jade
+++ b/public/docs/dart/latest/guide/template-syntax.jade
@@ -1,0 +1,12 @@
+include ../../../../_includes/_util-fns
+
+:marked
+  We're working on the Dart version of this chapter.
+  In the meantime, please see the resources:
+
+  * [Template Syntax](/docs/ts/latest/guide/template-syntax.html):
+    The TypeScript version of this chapter
+
+  * [Dart source code](): [PENDING: insert link]
+    A preliminary version of the example code that will appear in this chapter
+   


### PR DESCRIPTION
@wardbell and @naomiblack how do these look as placeholders?

I'd like to accept the remaining PRs for Dart samples, and add links to them, before finalizing this PR.