### PR TITLE
renamed app.js to app.component.js in example file, too

### DIFF
--- a/public/docs/_examples/forms/js/index.html
+++ b/public/docs/_examples/forms/js/index.html
@@ -18,9 +18,8 @@
     <script src='app/hero.js'></script>
     <!-- #enddocregion scripts-hero -->
     <script src='app/hero-form.component.js'></script>
-    <!-- #enddocregion scripts-hero-form -->
-    <!-- #docregion scripts, scripts-hero, scripts-hero-form -->
-    <script src='app/app.js'></script>
+    <!-- #docregion scripts, scripts-hero -->
+    <script src='app/app.component.js'></script>
     <script src='app/boot.js'></script>
     <!-- #enddocregion scripts, scripts-hero, scripts-hero-form -->
   </head>


### PR DESCRIPTION
In the forms example the file `app.js` has presumably be renamed to
`app.component.js`. While the text reflects those changes, the example
`index.html` file still used `app.js`. This commit changes the example to
`app.component.js` as well.