### PR TITLE
docs(guide): change angular2/angular2 to angular2/core

### DIFF
--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -316,7 +316,7 @@ include ../../../../_includes/_util-fns
 
   Here's a rewrite of `HeroService` with a new constructor that takes a `logger` parameter.
   ```
-  import {Injectable} from 'angular2/angular2';
+  import {Injectable} from 'angular2/core';
   import {Hero} from './hero';
   import {HEROES} from './mock-heroes';
   import {Logger} from './logger';


### PR DESCRIPTION

issue #6462: change angular2/angular2 to angular2/core
  import {Injectable} from 'angular2/angular2'; -> import {Injectable} from 'angular2/core';