### PR TITLE
docs(displaying-data): fix typo

### DIFF
--- a/public/docs/ts/latest/guide/displaying-data.jade
+++ b/public/docs/ts/latest/guide/displaying-data.jade
@@ -155,7 +155,7 @@ figure.image-display
     In fact, `NgFor` can repeat items for any [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
     object.
 :marked
-  Assuming we're still running under the `npm go` command,
+  Assuming we're still running under the `npm start` command,
   we should see heroes appearing in an unordered list.
 
 figure.image-display


### PR DESCRIPTION
On line 158, the referenced command should be `npm start`, rather than
`npm go` to be consistant with the quickstart guide.