### PR TITLE
docs(testing): make tsc exclude node_modules

### DIFF
--- a/public/docs/ts/latest/testing/jasmine-testing-101.jade
+++ b/public/docs/ts/latest/testing/jasmine-testing-101.jade
@@ -114,7 +114,10 @@ figure.image-display
       "sourceMap": true,
       "emitDecoratorMetadata": true,
       "experimentalDecorators": true
-    }
+    },
+    "exclude": [
+      "node_modules"
+    ]
   }
   ```
   ## Compile and Run


### PR DESCRIPTION
The tsconfig.json file in chapter 1 did not exclude node_modules, so tsc
would attempt to compile the .ts files there. I've added an exclude
property.