### PR TITLE
docs(samples & quickstart): update Dart code to be more uniform, use b2

### DIFF
--- a/public/docs/_examples/architecture/dart/lib/backend_service.dart
+++ b/public/docs/_examples/architecture/dart/lib/backend_service.dart
@@ -1,9 +1,8 @@
 // #docregion
-library developer_guide_intro.backend_service;
-
 import 'package:angular2/angular2.dart';
-import 'package:developer_guide_intro/logger_service.dart';
-import 'package:developer_guide_intro/hero.dart';
+
+import 'hero.dart';
+import 'logger_service.dart';
 
 @Injectable()
 class BackendService {

--- a/public/docs/_examples/architecture/dart/lib/hero.dart
+++ b/public/docs/_examples/architecture/dart/lib/hero.dart
@@ -1,6 +1,4 @@
 // #docregion
-library developer_guide_intro.hero;
-
 class Hero {
   static int _nextId = 1;
   int id;

--- a/public/docs/_examples/architecture/dart/lib/hero_detail_component.dart
+++ b/public/docs/_examples/architecture/dart/lib/hero_detail_component.dart
@@ -1,8 +1,7 @@
 // #docregion
-library developer_guide_intro.hero_detail_component;
-
 import 'package:angular2/angular2.dart';
-import 'package:developer_guide_intro/hero.dart';
+
+import 'hero.dart';
 
 @Component(selector: 'hero-detail', templateUrl: 'hero_detail_component.html')
 class HeroDetailComponent {

--- a/public/docs/_examples/architecture/dart/lib/hero_list_component.dart
+++ b/public/docs/_examples/architecture/dart/lib/hero_list_component.dart
@@ -1,10 +1,9 @@
 // #docplaster
-library developer_guide_intro.hero_list_component;
-
 import 'package:angular2/angular2.dart';
-import 'package:developer_guide_intro/hero.dart';
-import 'package:developer_guide_intro/hero_detail_component.dart';
-import 'package:developer_guide_intro/hero_service.dart';
+
+import 'hero.dart';
+import 'hero_detail_component.dart';
+import 'hero_service.dart';
 
 // #docregion metadata
 // #docregion providers

--- a/public/docs/_examples/architecture/dart/lib/hero_service.dart
+++ b/public/docs/_examples/architecture/dart/lib/hero_service.dart
@@ -1,9 +1,8 @@
-library developer_guide_intro.hero_service;
-
 import 'package:angular2/angular2.dart';
-import 'package:developer_guide_intro/hero.dart';
-import 'package:developer_guide_intro/backend_service.dart';
-import 'package:developer_guide_intro/logger_service.dart';
+
+import 'backend_service.dart';
+import 'hero.dart';
+import 'logger_service.dart';
 
 // #docregion class
 @Injectable()

--- a/public/docs/_examples/architecture/dart/lib/logger_service.dart
+++ b/public/docs/_examples/architecture/dart/lib/logger_service.dart
@@ -1,6 +1,4 @@
 // #docregion
-library developer_guide_intro.logger_service;
-
 import 'dart:html';
 
 import 'package:angular2/angular2.dart';

--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -1,10 +1,15 @@
+# #docregion
 name: developer_guide_intro
 description: Developer Guide Intro
 version: 0.0.1
+environment:
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.0
   browser: ^0.10.0
+  dart_to_js_script_rewriter: ^0.1.0
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/src/common/directives.dart#CORE_DIRECTIVES'
+    platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'
     entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/public/docs/_examples/architecture/dart/web/main.dart
+++ b/public/docs/_examples/architecture/dart/web/main.dart
@@ -1,9 +1,9 @@
 // #docregion
 import 'package:angular2/bootstrap.dart';
 import 'package:developer_guide_intro/backend_service.dart';
+import 'package:developer_guide_intro/hero_list_component.dart';
 import 'package:developer_guide_intro/hero_service.dart';
 import 'package:developer_guide_intro/logger_service.dart';
-import 'package:developer_guide_intro/hero_list_component.dart';
 
 main() {
   // #docregion bootstrap

--- a/public/docs/_examples/attribute-directives/dart/lib/app_component.dart
+++ b/public/docs/_examples/attribute-directives/dart/lib/app_component.dart
@@ -1,8 +1,7 @@
 // #docregion
-library attribute_directives.app_component;
-
 import 'package:angular2/angular2.dart';
-import 'package:attribute_directives/highlight_directive.dart';
+
+import 'highlight_directive.dart';
 
 @Component(
     selector: 'my-app',

--- a/public/docs/_examples/attribute-directives/dart/lib/highlight_directive.dart
+++ b/public/docs/_examples/attribute-directives/dart/lib/highlight_directive.dart
@@ -1,7 +1,5 @@
 // #docplaster
 // #docregion full
-library attribute_directives.highlight_directive;
-
 import 'package:angular2/angular2.dart';
 
 @Directive(selector: '[my-highlight]', host: const {

--- a/public/docs/_examples/attribute-directives/dart/lib/highlight_directive_2.dart
+++ b/public/docs/_examples/attribute-directives/dart/lib/highlight_directive_2.dart
@@ -1,6 +1,4 @@
 // #docregion
-library attribute_directives.highlight_directive;
-
 import 'package:angular2/angular2.dart';
 
 @Directive(selector: '[my-highlight]',

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -1,10 +1,15 @@
+# #docregion
 name: attribute_directives
-description: Attribute Directives
+description: Attribute directives example
 version: 0.0.1
+environment:
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.0
   browser: ^0.10.0
+  dart_to_js_script_rewriter: ^0.1.0
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/src/common/directives.dart#CORE_DIRECTIVES'
+    platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'
     entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/public/docs/_examples/attribute-directives/dart/web/index.html
+++ b/public/docs/_examples/attribute-directives/dart/web/index.html
@@ -8,6 +8,6 @@
     <script defer src="packages/browser/dart.js"></script>
   </head>
   <body>
-    <my-app>loading...</my-app>
+    <my-app>Loading...</my-app>
   </body>
 </html>

--- a/public/docs/_examples/forms/dart/lib/hero.dart
+++ b/public/docs/_examples/forms/dart/lib/hero.dart
@@ -1,6 +1,4 @@
 // #docregion all
-library hero_form.hero;
-
 class Hero {
   int number;
   String name;

--- a/public/docs/_examples/forms/dart/lib/hero_form_component.dart
+++ b/public/docs/_examples/forms/dart/lib/hero_form_component.dart
@@ -1,10 +1,9 @@
 // #docplaster
 // #docregion
 // #docregion no-todo
-library hero_form.hero_form_component;
-
 import 'package:angular2/angular2.dart';
-import 'package:hero_form/hero.dart';
+
+import 'hero.dart';
 
 const List<String> _powers = const [
   'Really Smart',

--- a/public/docs/_examples/forms/dart/lib/hero_form_component_initial.dart
+++ b/public/docs/_examples/forms/dart/lib/hero_form_component_initial.dart
@@ -1,6 +1,4 @@
 // #docregion
-library hero_form.hero_form_component;
-
 import 'package:angular2/angular2.dart';
 
 @Component(selector: 'hero-form', template: 'Hero form will go here')

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -2,13 +2,16 @@
 name: hero_form
 description: Form example
 version: 0.0.1
+environment:
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.0
   browser: ^0.10.0
+  dart_to_js_script_rewriter: ^0.1.0
 transformers:
 - angular2:
     platform_directives:
     - 'package:angular2/common.dart#CORE_DIRECTIVES'
     - 'package:angular2/common.dart#FORM_DIRECTIVES'
     entry_points: web/main.dart
-
+- dart_to_js_script_rewriter

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero_card_component.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero_card_component.dart
@@ -1,6 +1,7 @@
 // #docregion
 import 'package:angular2/angular2.dart';
-import 'package:hierarchical_di/hero.dart';
+
+import 'hero.dart';
 
 @Component(
     selector: 'hero-card',

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero_editor_component.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero_editor_component.dart
@@ -1,7 +1,8 @@
 // #docregion
 import 'package:angular2/angular2.dart';
-import 'package:hierarchical_di/restore_service.dart';
-import 'package:hierarchical_di/hero.dart';
+
+import 'hero.dart';
+import 'restore_service.dart';
 
 @Component(
     selector: 'hero-editor',

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/heroes_list_component.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/heroes_list_component.dart
@@ -1,10 +1,11 @@
 // #docregion
 import 'package:angular2/angular2.dart';
-import 'package:hierarchical_di/hero.dart';
-import 'package:hierarchical_di/heroes_service.dart';
-import 'package:hierarchical_di/hero_editor_component.dart';
-import 'package:hierarchical_di/hero_card_component.dart';
-import 'package:hierarchical_di/edit_item.dart';
+
+import 'edit_item.dart';
+import 'hero.dart';
+import 'hero_card_component.dart';
+import 'hero_editor_component.dart';
+import 'heroes_service.dart';
 
 @Component(
     selector: 'heroes-list',
@@ -41,12 +42,12 @@ class HeroesListComponent {
         .toList();
   }
 
-  onSaved(EditItem<Hero> editItem, Hero updatedHero) {
-    editItem.item = updatedHero;
+  onCanceled(EditItem<Hero> editItem) {
     editItem.editing = false;
   }
 
-  onCanceled(EditItem<Hero> editItem) {
+  onSaved(EditItem<Hero> editItem, Hero updatedHero) {
+    editItem.item = updatedHero;
     editItem.editing = false;
   }
 }

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/heroes_service.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/heroes_service.dart
@@ -1,5 +1,7 @@
+// #docregion
 import 'package:angular2/angular2.dart';
-import 'package:hierarchical_di/hero.dart';
+
+import 'hero.dart';
 
 @Injectable()
 class HeroesService {

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -1,19 +1,15 @@
 # #docregion
 name: 'hierarchical_di'
+description: Hierarchical dependency injection example
 version: 0.0.1
-description: hierarchical dependency injection example
-
 environment:
-  sdk: '>=1.0.0 <2.0.0'
-
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: '2.0.0-beta.1'
+  angular2: 2.0.0-beta.0
   browser: ^0.10.0
-  dart_to_js_script_rewriter: '^0.1.0'
-
+  dart_to_js_script_rewriter: ^0.1.0
 transformers:
 - angular2:
-    platform_directives:
-    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_directives: 'package:angular2/common.dart#COMMON_DIRECTIVES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/web/main.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/web/main.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'package:angular2/bootstrap.dart';
-import 'package:hierarchical_di/heroes_service.dart';
 import 'package:hierarchical_di/heroes_list_component.dart';
+import 'package:hierarchical_di/heroes_service.dart';
 
 void main() {
   bootstrap(HeroesListComponent, [HeroesService]);

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/after_content_parent.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/after_content_parent.dart
@@ -1,7 +1,8 @@
 // #docregion
 import 'package:angular2/angular2.dart';
-import 'logger_service.dart';
+
 import 'child_component.dart';
+import 'logger_service.dart';
 
 @Component(
     selector: 'after-content',
@@ -33,18 +34,13 @@ class AfterContentComponent
     _logger.log('AfterContent ctor: $message');
   }
 
-  ///// Hooks
-  ngAfterContentInit() {
-    // contentChild is set after the content has been initialized
-    _logger.log('AfterContentInit: $message');
-  }
+  bool get hasContentChild => contentChild != null;
 
   get hasViewChild => viewChild != null;
 
-  ngAfterViewInit() {
-    _logger
-        .log('AfterViewInit: There is ${hasViewChild ? 'a' : 'no'} view child');
-  }
+  String get message => hasContentChild
+      ? '"${contentChild.hero}" child content'
+      : 'no child content';
 
   ngAfterContentChecked() {
     // contentChild is updated after the content has been checked
@@ -54,11 +50,16 @@ class AfterContentComponent
     _logger.log('AfterContentChecked: $message');
   }
 
-  bool get hasContentChild => contentChild != null;
+  ///// Hooks
+  ngAfterContentInit() {
+    // contentChild is set after the content has been initialized
+    _logger.log('AfterContentInit: $message');
+  }
 
-  String get message => hasContentChild
-      ? '"${contentChild.hero}" child content'
-      : 'no child content';
+  ngAfterViewInit() {
+    _logger
+        .log('AfterViewInit: There is ${hasViewChild ? 'a' : 'no'} view child');
+  }
 }
 
 @Component(

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/after_content_parent.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/after_content_parent.dart
@@ -34,13 +34,18 @@ class AfterContentComponent
     _logger.log('AfterContent ctor: $message');
   }
 
-  bool get hasContentChild => contentChild != null;
+  ///// Hooks
+  ngAfterContentInit() {
+    // contentChild is set after the content has been initialized
+    _logger.log('AfterContentInit: $message');
+  }
 
   get hasViewChild => viewChild != null;
 
-  String get message => hasContentChild
-      ? '"${contentChild.hero}" child content'
-      : 'no child content';
+  ngAfterViewInit() {
+    _logger
+        .log('AfterViewInit: There is ${hasViewChild ? 'a' : 'no'} view child');
+  }
 
   ngAfterContentChecked() {
     // contentChild is updated after the content has been checked
@@ -50,16 +55,11 @@ class AfterContentComponent
     _logger.log('AfterContentChecked: $message');
   }
 
-  ///// Hooks
-  ngAfterContentInit() {
-    // contentChild is set after the content has been initialized
-    _logger.log('AfterContentInit: $message');
-  }
+  bool get hasContentChild => contentChild != null;
 
-  ngAfterViewInit() {
-    _logger
-        .log('AfterViewInit: There is ${hasViewChild ? 'a' : 'no'} view child');
-  }
+  String get message => hasContentChild
+      ? '"${contentChild.hero}" child content'
+      : 'no child content';
 }
 
 @Component(

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/after_view_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/after_view_component.dart
@@ -1,5 +1,6 @@
 // #docregion
 import 'package:angular2/angular2.dart';
+
 import 'child_component.dart';
 import 'logger_service.dart';
 
@@ -49,18 +50,16 @@ class AfterViewParentComponent
     _logger.log('AfterView ctor: $message');
   }
 
+  String get message =>
+      _hasViewChild ? '"${viewChild.hero}" child view' : 'no child view';
   bool get _hasContentChild => contentChild != null;
+
   bool get _hasViewChild => viewChild != null;
 
   ///// Hooks
   ngAfterContentInit() {
     _logger.log(
         'AfterContentInit: There is ${ _hasContentChild ? 'a' : 'no'} content child');
-  }
-
-  ngAfterViewInit() {
-    // viewChild is set after the view has been initialized
-    _logger.log('AfterViewInit: $message');
   }
 
   ngAfterViewChecked() {
@@ -71,6 +70,8 @@ class AfterViewParentComponent
     _logger.log('AfterViewChecked: $message');
   }
 
-  String get message =>
-      _hasViewChild ? '"${viewChild.hero}" child view' : 'no child view';
+  ngAfterViewInit() {
+    // viewChild is set after the view has been initialized
+    _logger.log('AfterViewInit: $message');
+  }
 }

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/after_view_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/after_view_component.dart
@@ -50,16 +50,18 @@ class AfterViewParentComponent
     _logger.log('AfterView ctor: $message');
   }
 
-  String get message =>
-      _hasViewChild ? '"${viewChild.hero}" child view' : 'no child view';
   bool get _hasContentChild => contentChild != null;
-
   bool get _hasViewChild => viewChild != null;
 
   ///// Hooks
   ngAfterContentInit() {
     _logger.log(
         'AfterContentInit: There is ${ _hasContentChild ? 'a' : 'no'} content child');
+  }
+
+  ngAfterViewInit() {
+    // viewChild is set after the view has been initialized
+    _logger.log('AfterViewInit: $message');
   }
 
   ngAfterViewChecked() {
@@ -70,8 +72,6 @@ class AfterViewParentComponent
     _logger.log('AfterViewChecked: $message');
   }
 
-  ngAfterViewInit() {
-    // viewChild is set after the view has been initialized
-    _logger.log('AfterViewInit: $message');
-  }
+  String get message =>
+      _hasViewChild ? '"${viewChild.hero}" child view' : 'no child view';
 }

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/app_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/app_component.dart
@@ -1,11 +1,12 @@
 // #docregion
 import 'package:angular2/angular2.dart';
-import 'peek_a_boo_parent_component.dart';
-import 'on_changes_component.dart';
-import 'after_view_component.dart';
+
 import 'after_content_parent.dart';
-import 'spy_component.dart';
+import 'after_view_component.dart';
 import 'counter_component.dart';
+import 'on_changes_component.dart';
+import 'peek_a_boo_parent_component.dart';
+import 'spy_component.dart';
 
 @Component(
     selector: 'my-app',

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/counter_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/counter_component.dart
@@ -5,6 +5,39 @@ import 'logger_service.dart';
 import 'spy_directive.dart';
 
 @Component(
+    selector: 'my-counter',
+    template: '''
+    <div class="counter">
+      Counter = {{counter}}
+
+      <h5>-- Counter Change Log --</h5>
+      <div *ngFor="#chg of changeLog" mySpy>{{chg}}</div>
+    </div>
+    ''',
+    styles: const [
+      '.counter {background: LightYellow; padding: 8px; margin-top: 8px}'
+    ],
+    directives: const [Spy])
+class MyCounter implements OnChanges {
+  @Input() num counter;
+  List<String> changeLog = [];
+
+  ngOnChanges(Map<String, SimpleChange> changes) {
+    // Empty the changeLog whenever counter goes to zero
+    // hint: this is a way to respond programmatically to external value changes.
+    if (this.counter == 0) {
+      changeLog.clear();
+    }
+
+    // A change to `counter` is the only change we care about
+    SimpleChange prop = changes['counter'];
+    var prev = prop.isFirstChange() ? "{}" : prop.previousValue;
+    changeLog.add(
+        'counter: currentValue = ${prop.currentValue}, previousValue = $prev');
+  }
+}
+
+@Component(
     selector: 'counter-parent',
     template: '''
     <div class="parent">
@@ -35,43 +68,10 @@ class CounterParentComponent {
     reset();
   }
 
+  updateCounter() => value += 1;
+
   reset() {
     _logger.log('-- reset --');
     value = 0;
-  }
-
-  updateCounter() => value += 1;
-}
-
-@Component(
-    selector: 'my-counter',
-    template: '''
-    <div class="counter">
-      Counter = {{counter}}
-
-      <h5>-- Counter Change Log --</h5>
-      <div *ngFor="#chg of changeLog" mySpy>{{chg}}</div>
-    </div>
-    ''',
-    styles: const [
-      '.counter {background: LightYellow; padding: 8px; margin-top: 8px}'
-    ],
-    directives: const [Spy])
-class MyCounter implements OnChanges {
-  @Input() num counter;
-  List<String> changeLog = [];
-
-  ngOnChanges(Map<String, SimpleChange> changes) {
-    // Empty the changeLog whenever counter goes to zero
-    // hint: this is a way to respond programmatically to external value changes.
-    if (this.counter == 0) {
-      changeLog.clear();
-    }
-
-    // A change to `counter` is the only change we care about
-    SimpleChange prop = changes['counter'];
-    var prev = prop.isFirstChange() ? "{}" : prop.previousValue;
-    changeLog.add(
-        'counter: currentValue = ${prop.currentValue}, previousValue = $prev');
   }
 }

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/counter_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/counter_component.dart
@@ -1,40 +1,8 @@
 // #docregion
 import 'package:angular2/angular2.dart';
-import 'spy_directive.dart';
+
 import 'logger_service.dart';
-
-@Component(
-    selector: 'my-counter',
-    template: '''
-    <div class="counter">
-      Counter = {{counter}}
-
-      <h5>-- Counter Change Log --</h5>
-      <div *ngFor="#chg of changeLog" mySpy>{{chg}}</div>
-    </div>
-    ''',
-    styles: const [
-      '.counter {background: LightYellow; padding: 8px; margin-top: 8px}'
-    ],
-    directives: const [Spy])
-class MyCounter implements OnChanges {
-  @Input() num counter;
-  List<String> changeLog = [];
-
-  ngOnChanges(Map<String, SimpleChange> changes) {
-    // Empty the changeLog whenever counter goes to zero
-    // hint: this is a way to respond programmatically to external value changes.
-    if (this.counter == 0) {
-      changeLog.clear();
-    }
-
-    // A change to `counter` is the only change we care about
-    SimpleChange prop = changes['counter'];
-    var prev = prop.isFirstChange() ? "{}" : prop.previousValue;
-    changeLog.add(
-        'counter: currentValue = ${prop.currentValue}, previousValue = $prev');
-  }
-}
+import 'spy_directive.dart';
 
 @Component(
     selector: 'counter-parent',
@@ -67,10 +35,43 @@ class CounterParentComponent {
     reset();
   }
 
-  updateCounter() => value += 1;
-
   reset() {
     _logger.log('-- reset --');
     value = 0;
+  }
+
+  updateCounter() => value += 1;
+}
+
+@Component(
+    selector: 'my-counter',
+    template: '''
+    <div class="counter">
+      Counter = {{counter}}
+
+      <h5>-- Counter Change Log --</h5>
+      <div *ngFor="#chg of changeLog" mySpy>{{chg}}</div>
+    </div>
+    ''',
+    styles: const [
+      '.counter {background: LightYellow; padding: 8px; margin-top: 8px}'
+    ],
+    directives: const [Spy])
+class MyCounter implements OnChanges {
+  @Input() num counter;
+  List<String> changeLog = [];
+
+  ngOnChanges(Map<String, SimpleChange> changes) {
+    // Empty the changeLog whenever counter goes to zero
+    // hint: this is a way to respond programmatically to external value changes.
+    if (this.counter == 0) {
+      changeLog.clear();
+    }
+
+    // A change to `counter` is the only change we care about
+    SimpleChange prop = changes['counter'];
+    var prev = prop.isFirstChange() ? "{}" : prop.previousValue;
+    changeLog.add(
+        'counter: currentValue = ${prop.currentValue}, previousValue = $prev');
   }
 }

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/logger_service.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/logger_service.dart
@@ -1,5 +1,6 @@
-import 'package:angular2/angular2.dart';
 import 'dart:async';
+
+import 'package:angular2/angular2.dart';
 
 @Injectable()
 class LoggerService {

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/on_changes_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/on_changes_component.dart
@@ -1,6 +1,7 @@
 // #docregion
-import 'package:angular2/angular2.dart';
 import 'dart:convert';
+
+import 'package:angular2/angular2.dart';
 
 class Hero {
   String name;

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/peek_a_boo_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/peek_a_boo_component.dart
@@ -1,7 +1,8 @@
 // #docregion
 // #docregion lc-imports
 import 'package:angular2/angular2.dart';
-import 'package:lifecycle_hooks/logger_service.dart';
+
+import 'logger_service.dart';
 
 int nextId = 1;
 

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/peek_a_boo_parent_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/peek_a_boo_parent_component.dart
@@ -1,7 +1,8 @@
 // #docregion
 import 'package:angular2/angular2.dart';
-import 'package:lifecycle_hooks/logger_service.dart';
-import 'package:lifecycle_hooks/peek_a_boo_component.dart';
+
+import 'logger_service.dart';
+import 'peek_a_boo_component.dart';
 
 @Component(
     selector: 'peek-a-boo-parent',

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/spy_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/spy_component.dart
@@ -1,5 +1,6 @@
 // #docregion
 import 'package:angular2/angular2.dart';
+
 import 'logger_service.dart';
 import 'spy_directive.dart';
 

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/spy_directive.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/spy_directive.dart
@@ -1,5 +1,6 @@
 // #docregion
 import 'package:angular2/angular2.dart';
+
 import 'logger_service.dart';
 
 int nextId = 1;

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -1,10 +1,11 @@
+# #docregion
 name: lifecycle_hooks
 description: Lifecycle Hooks
 version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.1
+  angular2: 2.0.0-beta.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
@@ -6,8 +6,6 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.0
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
 transformers:
 - angular2:
     entry_points: web/main.dart
-- dart_to_js_script_rewriter

--- a/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
@@ -1,9 +1,13 @@
 # #docregion
 name: angular2_getting_started
 version: 0.0.1
+environment:
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.0
   browser: ^0.10.0
+  dart_to_js_script_rewriter: ^0.1.0
 transformers:
 - angular2:
     entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
 transformers:
 - angular2:

--- a/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
@@ -1,6 +1,8 @@
 # #docregion
 name: angular2_getting_started
 version: 0.0.1
+environment:
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.0
   browser: ^0.10.0

--- a/public/docs/_examples/structural-directives/dart/lib/heavy_loader_component.dart
+++ b/public/docs/_examples/structural-directives/dart/lib/heavy_loader_component.dart
@@ -1,6 +1,7 @@
 // #docregion
-import 'package:angular2/angular2.dart';
 import 'dart:async';
+
+import 'package:angular2/angular2.dart';
 
 int nextId = 1;
 

--- a/public/docs/_examples/structural-directives/dart/lib/structural_directives_component.dart
+++ b/public/docs/_examples/structural-directives/dart/lib/structural_directives_component.dart
@@ -1,8 +1,9 @@
 // #docplaster
 // #docregion
 import 'package:angular2/angular2.dart';
-import 'unless_directive.dart';
+
 import 'heavy_loader_component.dart';
+import 'unless_directive.dart';
 
 @Component(
     selector: 'structural-directives',
@@ -18,4 +19,3 @@ class StructuralDirectivesComponent {
 
   get hero => heroes[0];
 }
-//#enddocregion

--- a/public/docs/_examples/structural-directives/dart/lib/structural_directives_component.html
+++ b/public/docs/_examples/structural-directives/dart/lib/structural_directives_component.html
@@ -106,4 +106,3 @@
   <div>{{ hero }}</div>
 </template>
 <!-- #enddocregion ngFor-template -->
-<!-- #enddocregion -->

--- a/public/docs/_examples/structural-directives/dart/lib/unless_directive.dart
+++ b/public/docs/_examples/structural-directives/dart/lib/unless_directive.dart
@@ -29,4 +29,3 @@ class UnlessDirective {
   // #docregion unless-declaration
 }
 // #enddocregion unless-declaration
-// #enddocregion

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -1,10 +1,11 @@
+# #docregion
 name: structural_directives
 description: Structural directives example
 version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.1
+  angular2: 2.0.0-beta.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/user-input/dart/lib/app_component.dart
+++ b/public/docs/_examples/user-input/dart/lib/app_component.dart
@@ -3,9 +3,9 @@ import 'package:angular2/angular2.dart';
 
 import 'click_me_component.dart';
 import 'click_me_component_2.dart';
-import 'loop_back_component.dart';
 import 'keyup_components.dart';
 import 'little_tour_component.dart';
+import 'loop_back_component.dart';
 
 @Component(
     selector: 'my-app',

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.0
+  angular2: 2.0.0-beta.2
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -1,10 +1,15 @@
+# #docregion
 name: user_input
-description: User Input
+description: User input example
 version: 0.0.1
+environment:
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.0
   browser: ^0.10.0
+  dart_to_js_script_rewriter: ^0.1.0
 transformers:
 - angular2:
     platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'
     entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -41,7 +41,7 @@ p.
     specify the angular2 and browser packages as dependencies,
     as well as the angular2 transformer.
     Angular 2 is still changing, so provide an exact version:
-    <b>2.0.0-beta.0</b>.
+    <b>2.0.0-beta.2</b>.
 
   +makeExample('quickstart/dart/ex1/pubspec.yaml', null, 'pubspec.yaml')
 


### PR DESCRIPTION
Small changes to a bunch of samples:

* Delete library directives.
* Within lib, use relative imports.
* Order imports alphabetically, within groups (https://www.dartlang.org/effective-dart/style/#ordering).
* Make pubspec.yaml files more consistent.
* Change beta 1 samples to beta 0.

Updated samples: architecture, attribute-directives, forms, hierarchical-dependency-injection, lifecycle-hooks, quickstart, structural-directives, and user-input.

Not updated because they're in other PRs or require more than tweaks: displaying-data (#666), pipes, template-syntax (#758). 