### PR TITLE
fix(directives): set copy directive z-index below nav

### DIFF
--- a/public/resources/js/directives/copy.js
+++ b/public/resources/js/directives/copy.js
@@ -25,7 +25,7 @@ angularIO.directive('copyContainer', function() {
     transclude: true,
     template:
       '<div style="position: relative">' +
-        '<copy-button style="position: absolute; top: 10px; right: 0px; z-index: 4" ></copy-button>' +
+        '<copy-button style="position: absolute; top: 10px; right: 0px; z-index: 1" ></copy-button>' +
         '<ng-transclude></ng-transclude>' +
       '</div>'
   };

--- a/public/resources/js/directives/copy.js
+++ b/public/resources/js/directives/copy.js
@@ -25,7 +25,7 @@ angularIO.directive('copyContainer', function() {
     transclude: true,
     template:
       '<div style="position: relative">' +
-        '<copy-button style="position: absolute; top: 10px; right: 0px; z-index: 1000" ></copy-button>' +
+        '<copy-button style="position: absolute; top: 10px; right: 0px; z-index: 4" ></copy-button>' +
         '<ng-transclude></ng-transclude>' +
       '</div>'
   };


### PR DESCRIPTION
Fixes: #768

Sets the z:index on the copy-button directive to 4 to be lower than the main navbar.