### PR TITLE
(bug) Code copy icon floats over website header

### DIFF
--- a/public/_includes/_main-nav.jade
+++ b/public/_includes/_main-nav.jade
@@ -1,4 +1,4 @@
-md-toolbar(class="main-nav background-regal l-pinned-top l-layer-5",scroll-y-offset-element)
+md-toolbar(class="main-nav background-regal l-pinned-top",scroll-y-offset-element)
   nav
     h1 <a href="/" md-button>Angular <sup>by Google</sup></a>
 

--- a/public/resources/css/module/_main-nav.scss
+++ b/public/resources/css/module/_main-nav.scss
@@ -3,6 +3,7 @@
   min-height: 56px;
   padding: 0px ($unit * 2);
   box-shadow: 0px 2px 5px 0 rgba($coal, 0.26);
+  z-index: 1001;
 
   @media handheld and (max-width: $phone-breakpoint),
   screen and (max-device-width: $phone-breakpoint),


### PR DESCRIPTION
Code copy icon floats over the website header because `z-index: 1000` is hardcoded in `<copy-button>` directive. The fix is to remove `.l-layer-5` from .main-nav and add `z-index: 1001` to it.