### PR TITLE
chore: exclude all fragment files from shred watchers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -640,10 +640,10 @@ function apiExamplesWatch(postShredAction) {
 
 function devGuideExamplesWatch(shredOptions, postShredAction) {
   var includePattern = path.join(shredOptions.examplesDir, '**/*.*');
-  var excludePattern = '!' + path.join(shredOptions.examplesDir, '**/node_modules/**/*.*');
-  // removed this version because gulp.watch has the same glob issue that dgeni has.
+  // removed this version because gulp.watch has the same glob issue that dgeni has.  
+  // var excludePattern = '!' + path.join(shredOptions.examplesDir, '**/node_modules/**/*.*');
   // gulp.watch([includePattern, excludePattern], {readDelay: 500}, function (event, done) {
-  var files = globby.sync( [includePattern], { ignore: [ '**/node_modules/**']});
+  var files = globby.sync( [includePattern], { ignore: [ '**/node_modules/**', '**/_fragments/**']});
   gulp.watch([files], {readDelay: 500}, function (event, done) {
     gutil.log('Dev Guide example changed')
     gutil.log('Event type: ' + event.type); // added, changed, or deleted
@@ -657,7 +657,7 @@ function devGuideSharedJadeWatch(shredOptions, postShredAction) {
   // removed this version because gulp.watch has the same glob issue that dgeni has.
   // var excludePattern = '!' + path.join(shredOptions.jadeDir, '**/node_modules/**/*.*');
   // gulp.watch([includePattern, excludePattern], {readDelay: 500}, function (event, done) {
-  var files = globby.sync( [includePattern], { ignore: [ '**/node_modules/**', '**/guide/_fragments/**']});
+  var files = globby.sync( [includePattern], { ignore: [ '**/node_modules/**', '**/_fragments/**']});
   gulp.watch([files], {readDelay: 500}, function (event, done) {
     gutil.log('Dev Guide jade file changed')
     gutil.log('Event type: ' + event.type); // added, changed, or deleted


### PR DESCRIPTION
Makes the authoring process faster although we may have to kick the browser more frequently with F5 because the refresh timing isn't quite right.