### PR TITLE
Fix examples of typings npm script

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -538,7 +538,7 @@ code-example(format="").
     The following command installs the typings file for the Jasmine test library and updates the `typings.config` 
     so we that we get it automatically the next time.
 code-example(format="").
-  npm run typings -- install -- jasmine --ambient --save
+  npm run typings -- install jasmine --ambient --save
 .l-sub-section
   :marked
     Learn about the features of the *typings* tool at its [site on github](https://github.com/typings/typings/blob/master/README.md).

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -533,12 +533,12 @@ code-example(format="").
 
   We can also run the *typings* tool ourselves. The following command lists the locally installed typings files.
 code-example(format="").
-  npm run typings list
+  npm run typings -- list
 :marked
     The following command installs the typings file for the Jasmine test library and updates the `typings.config` 
     so we that we get it automatically the next time.
 code-example(format="").
-  npm run typings install -- jasmine --ambient --save
+  npm run typings -- install -- jasmine --ambient --save
 .l-sub-section
   :marked
     Learn about the features of the *typings* tool at its [site on github](https://github.com/typings/typings/blob/master/README.md).


### PR DESCRIPTION
To pass arguments to an npm script, a `--` separator is necessary.

This is resulting in incorrect bug reports on the typings project: https://github.com/typings/typings/issues/220