### PR TITLE
devguide(http): fix two typos in description texts

### DIFF
--- a/public/docs/ts/latest/guide/server-communication.jade
+++ b/public/docs/ts/latest/guide/server-communication.jade
@@ -337,7 +337,7 @@ code-example(format="." language="javascript").
 .l-sub-section
   :marked
     While promises may be more familiar, observables have many advantages. 
-    Don't rush to promises until you've observables a chance.
+    Don't rush to promises until you gave observables a chance.
 :marked
   Let's rewrite the `HeroService` using promises , highlighting just the parts that are different.
 +makeTabs(
@@ -521,7 +521,7 @@ figure.image-display
 +makeExample('server-communication/ts/app/wiki/wiki-smart.component.ts', 'import-subject')
 :marked
   Each search term is a string, so we create a new `Subject` of type `string` called `_searchTermStream`.
-  After every keystroke, the `search` method adds the the search box value to that stream
+  After every keystroke, the `search` method adds the search box value to that stream
   via the subject's `next` method.
 +makeExample('server-communication/ts/app/wiki/wiki-smart.component.ts', 'subject')(format='.')
 :marked


### PR DESCRIPTION
devguide(http): fix two typos in description texts

'until you've observables a chance' -> 'until you gave observables a chance'
'method adds the the search box value' -> 'method adds the search box value'