### PR TITLE
docs(ts/tutorial/routing): fix a typo in a link

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -218,7 +218,7 @@ code-example(format="." language="bash").
   Looking back at the route configuration, we confirm that `'Heroes'` is the name of the route to the `HeroesComponent`.
 .l-sub-section
   :marked
-    Learn about the *link parameters array* in the [Routing](../guide/router.htmll#link-parameters-array) chapter.  
+    Learn about the *link parameters array* in the [Routing](../guide/router.html#link-parameters-array) chapter.
 :marked
   Refresh the browser.  We see only the app title. We don't see the heroes list. 
 .l-sub-section


### PR DESCRIPTION
Fix a small typo in a link to Router Guide in Routing chapter of the tutorial.