### PR TITLE
docs(architecture): double-'the' typos plus others

### DIFF
--- a/public/docs/ts/latest/guide/architecture.jade
+++ b/public/docs/ts/latest/guide/architecture.jade
@@ -58,7 +58,7 @@ figure
      Angular itself doesn't require a modular approach nor this particular syntax. Don't use it if you don't want it.
      Each chapter has plenty to offer after you steer clear of the `import` and `export` statements.
      
-     Find setup and organization clues in the JavaScript track (select it from the combobox at the top of this page) 
+     Find setup and organization clues in the JavaScript track (select it from the combo-box at the top of this page) 
      which demonstrates Angular 2 development with plain old JavaScript and no module system. 
 :marked
   Perhaps the first module we meet is a module that exports a *component* class. 
@@ -86,7 +86,7 @@ figure
   Some modules are libraries of other modules.
   
   Angular itself ships as a collection of library modules called "barrels". 
-  Each Angular library is actually a public facade over several logically related private modules.
+  Each Angular library is actually a public façade over several logically related private modules.
   
   The `angular2/core` library is the primary Angular library module from which we get most of what we need.
   <br clear="all">
@@ -123,7 +123,7 @@ figure
     While we're focused on our application, *import* and *export*
     is about all we need to know.
 :marked
-  The key take aways are:
+  The key take-aways are:
   * Angular apps are composed of modules.
   * Modules export things &mdash; classes, function, values &mdash; that other modules import.
   * We prefer to write our application as a collection of modules, each module exporting one thing.
@@ -189,8 +189,8 @@ figure
   
   The `HeroDetailComponent` is a *different* component than the `HeroListComponent` we've been reviewing.
   The `HeroDetailComponent` (code not shown) presents facts about a particular hero, the
-  hero that the user selects from the list presented by the the `HeroListComponent`.
-  The `HeroDetailComponent` is a **child** of the the `HeroListComponent`.
+  hero that the user selects from the list presented by the `HeroListComponent`.
+  The `HeroDetailComponent` is a **child** of the `HeroListComponent`.
 
 figure
   img(src="/resources/images/devguide/architecture/component-tree.png" alt="Metadata" align="left" style="width:300px; margin-left:-40px;margin-right:10px" )
@@ -368,7 +368,7 @@ figure
   It modifies the behavior of an existing element (typically an `<input>`) 
   by setting its display value property and responding to change events.
   
-  Angular ships with a small number of other directives that either alter the layout structure 
+  Angular ships with a few other directives that either alter the layout structure 
   (e.g. [ngSwitch](template-syntax.html#ngSwitch))
   or modify aspects of DOM elements and components 
   (e.g. [ngStyle](template-syntax.html#ngStyle) and [ngClass](template-syntax.html#ngClass)).
@@ -420,7 +420,7 @@ figure
   Angular doesn't *enforce* these principles. 
   It won't complain if we write a "kitchen sink" component with 3000 lines.
   
-  Angular does help us *follow* these principles ... by making it easy to factor our
+  Angular does help us *follow* these principles by making it easy to factor our
   application logic into services and make those services available to components through *dependency injection*.
 
 .l-main-section


### PR DESCRIPTION
See #866. Some other tweaks too.