### PR TITLE
docs(bugfix): remove mention of npm from Dart quickstart

### DIFF
--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -157,8 +157,7 @@ figure.image-display
     In fact, `NgFor` can repeat items for any [Iterable](https://api.dartlang.org/stable/dart-core/Iterable-class.html) object.
 
 :marked
-  Assuming we're still running under the `npm go` command,
-  we should see heroes appearing in an unordered list.
+  Now the heroes appear in an unordered list.
 
 figure.image-display
   img(src="/resources/images/devguide/displaying-data/hero-names-list.png" alt="After ngfor")


### PR DESCRIPTION
closes #862