### PR TITLE
docs(quickstart): fix typo, tsconfig.json -> package.json

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -520,7 +520,7 @@ code-example(format="").
   We installed the [typings](https://github.com/typings/typings/blob/master/README.md) tool 
   with npm (find it in the `package.json`) and added an npm script
   to run that tool automatically after *npm* installation completes.
-+makeJson('quickstart/ts/package.1.json', {paths: 'scripts.postinstall'}, 'tsconfig.json (postinstall)')(format=".")
++makeJson('quickstart/ts/package.1.json', {paths: 'scripts.postinstall'}, 'package.json (postinstall)')(format=".")
 :marked
   This *typings* tool command installs the *d.ts* files that we identified in `typings.json`:
 +makeJson('quickstart/ts/typings.1.json', null, 'typings.json')(format=".")


### PR DESCRIPTION
Docs referenced the postinstall script of `package.json` but the code window was entitled `tsconfig.json`. That was a mistake, right?