### PR TITLE
docs(styleguide): escape app.js script example

### DIFF
--- a/public/docs/_includes/styleguide/_code-examples.jade
+++ b/public/docs/_includes/styleguide/_code-examples.jade
@@ -160,10 +160,10 @@ include ../../../_includes/_util-fns
         HTML files can also contain #docregion comments:
 
     code-example(format="linenums" language="html" escape="html").
-      <!-- #docregion -->
+      &lt;!-- #docregion -->
       ...
-      <script src="https://code.angularjs.org/2.0.0-alpha.34/angular2.sfx.dev.js"></script>
-      <script src="app.js"></script>
+      &lt;script src="https://code.angularjs.org/2.0.0-beta.7/angular2.sfx.dev.js">&lt;/script>
+      &lt;script src="app.js">&lt;/script>
       ...
 
     :marked


### PR DESCRIPTION
Was actually trying to load `app.js` when that was just an illustration