### PR TITLE
Wrong folder structure

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -657,14 +657,14 @@ code-example(format="." language="bash").
   .children
     .file app
     .children
+      .file app.component.ts
+      .file crisis-list.component.ts
       .file heroes
       .children
-        .file app.component.ts
-        .file crisis-list.component.ts
         .file hero-detail.component.ts
         .file hero-list.component.ts
         .file hero.service.ts
-        .file main.ts
+      .file main.ts
     .file node_modules ...
     .file typings ...
     .file index.html


### PR DESCRIPTION
Seems like the tabs are wrong in the folder structure after this "After these changes, the folder structure looks like this:" in https://angular.io/docs/ts/latest/guide/router.html.

app.component.ts, crisis-list.component.ts and main.ts should stay in the app folder.