### PR TITLE
chore: point VS Code to the examples's local version of typescript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
 	// Controls if the editor will insert spaces for tabs. Accepted values:  "auto", true, false. If set to "auto", the value will be guessed when a file is opened.
 	"editor.insertSpaces": true,
   // When enabled, will trim trailing whitespace when you save a file.
-	"files.trimTrailingWhitespace": false
+	"files.trimTrailingWhitespace": false,
+  // Specifies the folder path containing the tsserver and lib*.d.ts files to use.
+  "typescript.tsdk": "public/docs/_examples/node_modules/typescript/lib"
 }


### PR DESCRIPTION
VS Code will use the version of typescript installed locally for the docs samples