### PR TITLE
docs(examples): Fix deprecation warning in example package.json start scripts

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -4,7 +4,7 @@
   "description": "Master package.json, the superset of all dependencies for all of the _example package.json files.",
   "main": "index.js",
   "scripts": {
-    "start": "concurrent \"npm run tsc:w\" \"npm run lite\" ",
+    "start": "concurrently \"npm run tsc:w\" \"npm run lite\" ",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "lite": "lite-server",

--- a/public/docs/_examples/quickstart/ts/package.1.json
+++ b/public/docs/_examples/quickstart/ts/package.1.json
@@ -2,7 +2,7 @@
   "name": "angular2-quickstart",
   "version": "1.0.0",
   "scripts": {
-    "start": "concurrent \"npm run tsc:w\" \"npm run lite\" ",    
+    "start": "concurrently \"npm run tsc:w\" \"npm run lite\" ",    
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "lite": "lite-server",

--- a/public/docs/_examples/styleguide/package.1.json
+++ b/public/docs/_examples/styleguide/package.1.json
@@ -5,7 +5,7 @@
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "lite": "lite-server",
-    "start": "concurrent \"npm run tsc:w\" \"npm run lite\" "
+    "start": "concurrently \"npm run tsc:w\" \"npm run lite\" "
   },
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Stop the example start scripts from outputting deprecation warnings.
As suggested, replace `concurrent rnpm run` with `concurrently npm run`.

> angular2-quickstart@1.0.0 start /Users/mbuhot/source/angular2-quickstart
> concurrent "npm run tsc:w" "npm run lite" 
>
> "concurrent" command is deprecated, use "concurrently" instead.
