### PR TITLE
docs: fix typos

### DIFF
--- a/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
@@ -4,7 +4,7 @@ include ../../../../_includes/_util-fns
   We learned the basics of Angular Dependency injection in the
   [Dependency Injection](./dependency-injection.html) chapter.
 
-  Angular has an  Hierarchical Dependency Injection system.
+  Angular has a Hierarchical Dependency Injection system.
   There is actually a tree of injectors
   that parallel an application's component tree.
   We can re-configure the injectors at any level of that component tree with
@@ -74,7 +74,7 @@ figure.image-display
   The ability to configure one or more providers at different levels opens up interesting and useful possibilities.
 
   Let’s return to our Car example.
-  Suppose configured the root injector (marked as A) with providers for `Car`, `Engine` and `Tires`.
+  Suppose we configured the root injector (marked as A) with providers for `Car`, `Engine` and `Tires`.
   We create a child component (B) that defines its own providers for `Car` and `Engine`
   This child is the parent of another component (C) that defines its own provider for `Car`.
 


### PR DESCRIPTION
1. *H* in *Hierarchical* is not silent, so *an* is incorrect (a higher-archical rather than an eye-archical).
2. Missing *we* between Suppose & configured.