### PR TITLE
First run 404 issue fixed for QuickStart

### DIFF
--- a/public/docs/_examples/quickstart/ts/package.1.json
+++ b/public/docs/_examples/quickstart/ts/package.1.json
@@ -2,6 +2,7 @@
   "name": "angular2-quickstart",
   "version": "1.0.0",
   "scripts": {
+    "prestart": "tsc",
     "start": "concurrently \"npm run tsc:w\" \"npm run lite\" ",    
     "tsc": "tsc",
     "tsc:w": "tsc -w",


### PR DESCRIPTION
There is `404 GET /app/main.js` during initial `npm start` because of this file is not yet compiled. You have to hit _Reload page_ to make the demo work. Quick and dirty workaround could be adding `"prestart": "tsc"`. **Dirty** because it causes multiple file reloads then (but fixes the initial issue).