### PR TITLE
docs(toh5): fix indentation on a method

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-5/ts/app/hero.service.ts
@@ -18,7 +18,7 @@ export class HeroService {
   }
 
   //#docregion get-hero
-	getHero(id: number) {
+  getHero(id: number) {
     return Promise.resolve(HEROES).then(
       heroes => heroes.filter(hero => hero.id === id)[0]
     );


### PR DESCRIPTION
Ping @wardbell (that is the kind of little stuff I was talking about).

Just one character can make the docs to feel weird

![](http://puu.sh/nyd6i/665ab54aa5.png)

Easy fix :)