### PR TITLE
docs(toh5): add better explanations for templateUrl

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/dashboard.component.ts
+++ b/public/docs/_examples/toh-5/ts/app/dashboard.component.ts
@@ -10,7 +10,9 @@ import { HeroService } from './hero.service';
 
 @Component({
   selector: 'my-dashboard',
+  // #docregion template-url
   templateUrl: 'app/dashboard.component.html',
+  // #enddocregion template-url
   // #docregion css
   styleUrls: ['app/dashboard.component.css']
   // #enddocregion css

--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -281,8 +281,13 @@ code-example(format="." language="bash").
   Let’s spice up the dashboard by displaying the top four heroes at a glance.
   
   Replace the `template` metadata with a `templateUrl` property that points to a new
-  template file, `dashboard.component.html`.
+  template file.
   
++makeExample('toh-5/ts/app/dashboard.component.ts', 'template-url', 'app/dashboard.component.ts (templateUrl)')(format=".")
+.l-sub-section
+  :marked
+    Even if the template sits on the same folder as the component, the path for the template will be root-relative.
+:marked
   Create that file with these contents:
 +makeExample('toh-5/ts/app/dashboard.component.html', null, 'dashboard.component.html')(format=".")
 :marked
@@ -581,6 +586,7 @@ figure.image-display
   :marked
     The `styleUrls` property is an array of style file names (with paths).
     We could list multiple style files from different locations if we needed them.
+    Like with `templateUrl`, the paths are root-relative.
 :marked
   ### Stylish Hero Details
   The designers also gave us CSS styles specifically for the `HeroDetailComponent`.


### PR DESCRIPTION
Since this tutorial is meant to explain each step, I think we should go the whole nine yards with it.

Paths are always complicated when first encountered and with the previous explanation it wasn't clear which path to use.

Also added a few blockquotes with explanations.

Perhaps the paths changes with the offline compiler, but you know what they say about beta: It worked. That day. On my computer.