### PR TITLE
docs(contribute): fix link to Angular Material; close #780

### DIFF
--- a/public/contribute.jade
+++ b/public/contribute.jade
@@ -23,7 +23,7 @@
 
     p Our goal is to deliver a lean, lightweight set of Angular-based UI elements that implement the material design specification for use in Angular single-page applications (SPAs).
 
-    a(href="https://github.com/angular/material/blob/master/docs/guides/CONTRIBUTING.md" class="button" md-button) Contribute to Angular Material
+    a(href="https://github.com/angular/material/blob/master/CONTRIBUTING.md" class="button" md-button) Contribute to Angular Material
 
   .l-sub-section
     h3 AngularFire


### PR DESCRIPTION
The fix in #780 that we want to keep