### PR TITLE
docs(displaying-data): add table of contents

### DIFF
--- a/public/docs/ts/latest/guide/displaying-data.jade
+++ b/public/docs/ts/latest/guide/displaying-data.jade
@@ -14,9 +14,18 @@ include ../_util-fns
 
 figure.image-display
   img(src="/resources/images/devguide/displaying-data/final.png" alt="Final UI")
-
+  
 :marked
-  [Run the live example](/resources/live-examples/displaying-data/ts/plnkr.html)
+  # Table Of Contents
+  
+  * [Showing component properties with interpolation](#interpolation)
+  * [Showing an array property with NgFor](#ngFor)
+  * [Conditional display with NgIf](#ngIf)
+  
+.l-sub-section
+  :marked
+    The [live example](/resources/live-examples/displaying-data/ts/plnkr.html)
+    demonstrates all of the syntax and code snippets described in this chapter.
 
 <a id="interpolation"></a>
 .l-main-section


### PR DESCRIPTION
This is the first step for closing #935 

The big image before the TOC gives a weird visualization, but I think that it should be there or perhaps delete it.