### PR TITLE
docs(quickstart) Images to be responsive on all devices

### DIFF
--- a/public/resources/css/module/_images.scss
+++ b/public/resources/css/module/_images.scss
@@ -9,5 +9,6 @@
   img {
     border-radius: 4px;
     display: inline-block;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
I just saw this on my iPhone and thought it should be fixed :smile: 

![bug quickstart](https://cloud.githubusercontent.com/assets/2327532/13887127/56d85fe6-ecf7-11e5-96fd-2f6eae30af1c.png)
