### PR TITLE
Updated link on promises

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt4.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt4.jade
@@ -288,7 +288,7 @@ code-example(format="." language="html").
   It does that work (somewhere) and eventually it calls our function with the results of the work or an error.
 .l-sub-section
   :marked
-    We are simplifying. Learn about ES2015 Promises [here](http://www.2ality.com/2014/10/es6-promises-api.html) and elsewhere on the web.
+    We are simplifying. Learn about ES2015 Promises [here](http://exploringjs.com/es6/ch_promises.html) and elsewhere on the web.
 :marked
   Update the `HeroService` with this promise-returning `getHeroes` method:
 +makeExample('toh-4/ts/app/hero.service.ts', 'get-heroes', 'hero.service.ts (getHeroes)')(format=".")


### PR DESCRIPTION
The old link on the documentation lead to an article on promises that
contained outdated information, so this one leads to newer content.