### PR TITLE
docs(dart): update to b12

### DIFF
--- a/public/docs/_examples/architecture/dart/lib/backend_service.dart
+++ b/public/docs/_examples/architecture/dart/lib/backend_service.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 import 'logger_service.dart';

--- a/public/docs/_examples/architecture/dart/lib/hero_detail_component.dart
+++ b/public/docs/_examples/architecture/dart/lib/hero_detail_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 

--- a/public/docs/_examples/architecture/dart/lib/hero_list_component.dart
+++ b/public/docs/_examples/architecture/dart/lib/hero_list_component.dart
@@ -1,5 +1,5 @@
 // #docplaster
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 import 'hero_detail_component.dart';

--- a/public/docs/_examples/architecture/dart/lib/hero_service.dart
+++ b/public/docs/_examples/architecture/dart/lib/hero_service.dart
@@ -1,4 +1,4 @@
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'backend_service.dart';
 import 'hero.dart';

--- a/public/docs/_examples/architecture/dart/lib/logger_service.dart
+++ b/public/docs/_examples/architecture/dart/lib/logger_service.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 /// A service for logging messages of various types.
 ///

--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'

--- a/public/docs/_examples/attribute-directives/dart/lib/app_component.dart
+++ b/public/docs/_examples/attribute-directives/dart/lib/app_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'highlight_directive.dart';
 

--- a/public/docs/_examples/attribute-directives/dart/lib/highlight_directive.dart
+++ b/public/docs/_examples/attribute-directives/dart/lib/highlight_directive.dart
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion full
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Directive(selector: '[my-highlight]', host: const {
   '(mouseenter)': 'onMouseEnter()',

--- a/public/docs/_examples/attribute-directives/dart/lib/highlight_directive_1.dart
+++ b/public/docs/_examples/attribute-directives/dart/lib/highlight_directive_1.dart
@@ -1,7 +1,7 @@
 // #docregion
 library attribute_directives.highlight_directive;
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Directive(selector: '[my-highlight]')
 class Highlight {

--- a/public/docs/_examples/attribute-directives/dart/lib/highlight_directive_2.dart
+++ b/public/docs/_examples/attribute-directives/dart/lib/highlight_directive_2.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Directive(selector: '[my-highlight]',
 // #docregion host

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'

--- a/public/docs/_examples/dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/dependency-injection/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: 'package:angular2/common.dart#COMMON_DIRECTIVES'

--- a/public/docs/_examples/displaying-data/dart/lib/app_component.dart
+++ b/public/docs/_examples/displaying-data/dart/lib/app_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 

--- a/public/docs/_examples/displaying-data/dart/lib/app_component_1.dart
+++ b/public/docs/_examples/displaying-data/dart/lib/app_component_1.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Component(
     selector: 'my-app',

--- a/public/docs/_examples/displaying-data/dart/lib/app_component_2.dart
+++ b/public/docs/_examples/displaying-data/dart/lib/app_component_2.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 // #docregion mock-heroes
 const List<String> _heroes = const [

--- a/public/docs/_examples/displaying-data/dart/lib/app_component_3.dart
+++ b/public/docs/_examples/displaying-data/dart/lib/app_component_3.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 // #docregion heroes
 import 'hero.dart';
 

--- a/public/docs/_examples/displaying-data/dart/pubspec.yaml
+++ b/public/docs/_examples/displaying-data/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/displaying-data/dart/pubspec.yaml
+++ b/public/docs/_examples/displaying-data/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'

--- a/public/docs/_examples/forms/dart/lib/hero_form_component.dart
+++ b/public/docs/_examples/forms/dart/lib/hero_form_component.dart
@@ -1,7 +1,7 @@
 // #docplaster
 // #docregion
 // #docregion no-todo
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 

--- a/public/docs/_examples/forms/dart/lib/hero_form_component_initial.dart
+++ b/public/docs/_examples/forms/dart/lib/hero_form_component_initial.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Component(selector: 'hero-form', template: 'Hero form will go here')
 class HeroFormComponent {}

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives:

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 class Hero {
   String name;

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero_card_component.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero_card_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero_editor_component.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/hero_editor_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 import 'restore_service.dart';

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/heroes_list_component.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/heroes_list_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'edit_item.dart';
 import 'hero.dart';

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/heroes_service.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/heroes_service.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/lib/restore_service.dart
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/lib/restore_service.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Injectable()
 class RestoreService<T> {

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: 'package:angular2/common.dart#COMMON_DIRECTIVES'

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/after_content_parent.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/after_content_parent.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'child_component.dart';
 import 'logger_service.dart';

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/after_view_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/after_view_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'child_component.dart';
 import 'logger_service.dart';

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/app_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/app_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'after_content_parent.dart';
 import 'after_view_component.dart';

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/child_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/child_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Component(
     selector: 'my-child',

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/counter_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/counter_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'logger_service.dart';
 import 'spy_directive.dart';

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/logger_service.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/logger_service.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Injectable()
 class LoggerService {

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/on_changes_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/on_changes_component.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'dart:convert';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 class Hero {
   String name;

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/peek_a_boo_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/peek_a_boo_component.dart
@@ -1,6 +1,6 @@
 // #docregion
 // #docregion lc-imports
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'logger_service.dart';
 

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/peek_a_boo_parent_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/peek_a_boo_parent_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'logger_service.dart';
 import 'peek_a_boo_component.dart';

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/spy_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/spy_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'logger_service.dart';
 import 'spy_directive.dart';

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/spy_directive.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/spy_directive.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'logger_service.dart';
 

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives:

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: 'package:angular2/src/common/directives.dart#CORE_DIRECTIVES'

--- a/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex1/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
 transformers:
 - angular2:

--- a/public/docs/_examples/quickstart/dart/ex1/web/main.dart
+++ b/public/docs/_examples/quickstart/dart/ex1/web/main.dart
@@ -1,6 +1,6 @@
 // #docregion
-import 'package:angular2/angular2.dart';
 import 'package:angular2/bootstrap.dart';
+import 'package:angular2/core.dart';
 
 @Component(selector: 'my-app', template: '<h1>My First Angular 2 App</h1>')
 class AppComponent {}

--- a/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/ex2/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     entry_points: web/main.dart

--- a/public/docs/_examples/quickstart/dart/ex2/web/main.dart
+++ b/public/docs/_examples/quickstart/dart/ex2/web/main.dart
@@ -1,6 +1,6 @@
 // #docregion
-import 'package:angular2/angular2.dart';
 import 'package:angular2/bootstrap.dart';
+import 'package:angular2/core.dart';
 
 @Component(selector: 'my-app', template: '<h1>My First Angular 2 App</h1>')
 class AppComponent {}

--- a/public/docs/_examples/server-communication/dart/lib/toh/hero_list_component.dart
+++ b/public/docs/_examples/server-communication/dart/lib/toh/hero_list_component.dart
@@ -1,6 +1,8 @@
 // #docregion
 import 'dart:async';
-import 'package:angular2/angular2.dart';
+
+import 'package:angular2/core.dart';
+
 import 'hero.dart';
 import 'hero_service.dart';
 

--- a/public/docs/_examples/server-communication/dart/lib/toh/hero_service.dart
+++ b/public/docs/_examples/server-communication/dart/lib/toh/hero_service.dart
@@ -4,7 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 // #enddocregion v1
 // #docregion import-request-options
 import 'package:http/browser_client.dart';

--- a/public/docs/_examples/server-communication/dart/lib/toh/toh_component.dart
+++ b/public/docs/_examples/server-communication/dart/lib/toh/toh_component.dart
@@ -1,4 +1,4 @@
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 import 'package:http_in_memory_web_api/http_in_memory_web_api.dart';
 import 'package:http/browser_client.dart';
 import 'package:server_communication/hero_data.dart';

--- a/public/docs/_examples/server-communication/dart/lib/wiki/wiki_component.dart
+++ b/public/docs/_examples/server-communication/dart/lib/wiki/wiki_component.dart
@@ -1,6 +1,8 @@
 // #docregion
 import 'dart:async';
-import 'package:angular2/angular2.dart';
+
+import 'package:angular2/core.dart';
+
 import 'wikipedia_service.dart';
 
 @Component(

--- a/public/docs/_examples/server-communication/dart/lib/wiki/wiki_smart_component.dart
+++ b/public/docs/_examples/server-communication/dart/lib/wiki/wiki_smart_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 import 'package:stream_transformers/stream_transformers.dart';
 
 import 'wikipedia_service.dart';

--- a/public/docs/_examples/server-communication/dart/lib/wiki/wikipedia_service.dart
+++ b/public/docs/_examples/server-communication/dart/lib/wiki/wikipedia_service.dart
@@ -1,6 +1,7 @@
 // #docregion
 import 'dart:async';
-import 'package:angular2/angular2.dart';
+
+import 'package:angular2/core.dart';
 import 'package:jsonpadding/jsonpadding.dart';
 
 @Injectable()

--- a/public/docs/_examples/server-communication/dart/pubspec.yaml
+++ b/public/docs/_examples/server-communication/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
   http: ^0.11.3+3
   jsonpadding: ^0.1.0
   stream_transformers: ^0.3.0+3

--- a/public/docs/_examples/server-communication/dart/pubspec.yaml
+++ b/public/docs/_examples/server-communication/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
   http: ^0.11.3+3

--- a/public/docs/_examples/structural-directives/dart/lib/heavy_loader_component.dart
+++ b/public/docs/_examples/structural-directives/dart/lib/heavy_loader_component.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 int nextId = 1;
 

--- a/public/docs/_examples/structural-directives/dart/lib/structural_directives_component.dart
+++ b/public/docs/_examples/structural-directives/dart/lib/structural_directives_component.dart
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'heavy_loader_component.dart';
 import 'unless_directive.dart';

--- a/public/docs/_examples/structural-directives/dart/lib/unless_directive.dart
+++ b/public/docs/_examples/structural-directives/dart/lib/unless_directive.dart
@@ -1,7 +1,7 @@
 // #docplaster
 // #docregion
 // #docregion unless-declaration
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 // #enddocregion unless-declaration
 
 // #docregion unless-declaration

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'

--- a/public/docs/_examples/template-syntax/dart/lib/app_component.dart
+++ b/public/docs/_examples/template-syntax/dart/lib/app_component.dart
@@ -2,7 +2,7 @@
 import 'dart:convert';
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 import 'hero_detail_component.dart';

--- a/public/docs/_examples/template-syntax/dart/lib/hero_detail_component.dart
+++ b/public/docs/_examples/template-syntax/dart/lib/hero_detail_component.dart
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 

--- a/public/docs/_examples/template-syntax/dart/lib/my_click_directive.dart
+++ b/public/docs/_examples/template-syntax/dart/lib/my_click_directive.dart
@@ -1,7 +1,7 @@
 // #docplaster
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Directive(selector: '[myClick]')
 class MyClickDirective {

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_pipes: 'package:angular2/common.dart#COMMON_PIPES'

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -16,5 +16,3 @@ transformers:
     - 'package:angular2/common.dart#FORM_DIRECTIVES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter
-- $dart2js:
-    checked: true

--- a/public/docs/_examples/toh-5/dart/lib/app_component.dart
+++ b/public/docs/_examples/toh-5/dart/lib/app_component.dart
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 import 'package:angular2/router.dart';
 
 import 'package:angular2_tour_of_heroes/heroes_component.dart';

--- a/public/docs/_examples/toh-5/dart/lib/app_component_1.dart
+++ b/public/docs/_examples/toh-5/dart/lib/app_component_1.dart
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 // #enddocregion
 import 'package:angular2/router.dart'; // for testing only
 // #docregion

--- a/public/docs/_examples/toh-5/dart/lib/app_component_2.dart
+++ b/public/docs/_examples/toh-5/dart/lib/app_component_2.dart
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 // #docregion import-router
 import 'package:angular2/router.dart';
 // #enddocregion import-router

--- a/public/docs/_examples/toh-5/dart/lib/dashboard_component.dart
+++ b/public/docs/_examples/toh-5/dart/lib/dashboard_component.dart
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 // #docregion import-router
 import 'package:angular2/router.dart';
 // #enddocregion import-router

--- a/public/docs/_examples/toh-5/dart/lib/dashboard_component_1.dart
+++ b/public/docs/_examples/toh-5/dart/lib/dashboard_component_1.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Component(
     selector: 'my-dashboard',

--- a/public/docs/_examples/toh-5/dart/lib/dashboard_component_2.dart
+++ b/public/docs/_examples/toh-5/dart/lib/dashboard_component_2.dart
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion imports
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 import 'hero_service.dart';

--- a/public/docs/_examples/toh-5/dart/lib/hero_detail_component.dart
+++ b/public/docs/_examples/toh-5/dart/lib/hero_detail_component.dart
@@ -4,7 +4,7 @@
 import 'dart:html';
 
 // #docregion import-oninit
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 // #enddocregion import-oninit
 // #docregion import-route-params
 import 'package:angular2/router.dart';

--- a/public/docs/_examples/toh-5/dart/lib/hero_service.dart
+++ b/public/docs/_examples/toh-5/dart/lib/hero_service.dart
@@ -3,7 +3,7 @@
 // #docregion
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'hero.dart';
 import 'mock_heroes.dart';

--- a/public/docs/_examples/toh-5/dart/lib/heroes_component.dart
+++ b/public/docs/_examples/toh-5/dart/lib/heroes_component.dart
@@ -2,7 +2,7 @@
 // #docregion
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 import 'package:angular2/router.dart';
 
 import 'hero.dart';

--- a/public/docs/_examples/toh-5/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-5/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0+4
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: package:angular2/common.dart#COMMON_DIRECTIVES

--- a/public/docs/_examples/toh-5/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-5/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0+4
 transformers:
@@ -14,5 +14,3 @@ transformers:
     platform_pipes: package:angular2/common.dart#COMMON_PIPES
     entry_points: web/main.dart
 - dart_to_js_script_rewriter
-- $dart2js:
-    checked: true

--- a/public/docs/_examples/user-input/dart/lib/app_component.dart
+++ b/public/docs/_examples/user-input/dart/lib/app_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 import 'click_me_component.dart';
 import 'click_me_component_2.dart';

--- a/public/docs/_examples/user-input/dart/lib/click_me_component.dart
+++ b/public/docs/_examples/user-input/dart/lib/click_me_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 // #docregion click-me-component
 @Component(

--- a/public/docs/_examples/user-input/dart/lib/click_me_component_2.dart
+++ b/public/docs/_examples/user-input/dart/lib/click_me_component_2.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 @Component(
     selector: 'click-me2',

--- a/public/docs/_examples/user-input/dart/lib/keyup_components.dart
+++ b/public/docs/_examples/user-input/dart/lib/keyup_components.dart
@@ -2,7 +2,7 @@
 // #docregion
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 // #docregion key-up-component-1
 @Component(

--- a/public/docs/_examples/user-input/dart/lib/little_tour_component.dart
+++ b/public/docs/_examples/user-input/dart/lib/little_tour_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 // #docregion little-tour
 @Component(

--- a/public/docs/_examples/user-input/dart/lib/loop_back_component.dart
+++ b/public/docs/_examples/user-input/dart/lib/loop_back_component.dart
@@ -1,5 +1,5 @@
 // #docregion
-import 'package:angular2/angular2.dart';
+import 'package:angular2/core.dart';
 
 // #docregion loop-back-component
 @Component(

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.11
+  angular2: 2.0.0-beta.12
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^0.1.0
 transformers:

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.12
   browser: ^0.10.0
-  dart_to_js_script_rewriter: ^0.1.0
+  dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
     platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'

--- a/public/docs/dart/latest/guide/displaying-data.jade
+++ b/public/docs/dart/latest/guide/displaying-data.jade
@@ -43,7 +43,7 @@ figure.image-display
 
   In `main.dart`, importing `app_component.dart` lets us implement part
   of the app in a different Dart file. The QuickStart version of `main.dart`
-  imported `angular2.dart`, but we don't need that import here because
+  imported `core.dart`, but we don't need that import here because
   this version of `main.dart` is so basic: it only bootstraps the app,
   and doesn't implement any components or other injectable types.
 

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -106,7 +106,7 @@ p.
     consist of more components arising in tree-like fashion from this root.
 
     The top lines import two libraries.
-    *All* Dart files that use Angular APIs import `angular2.dart`.
+    *All* Dart files that use Angular APIs import `core.dart`.
     Only files that call `bootstrap()` import `bootstrap.dart`.
 
 //-  ##########################

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -41,7 +41,7 @@ p.
     specify the angular2 and browser packages as dependencies,
     as well as the angular2 transformer.
     Angular 2 is still changing, so provide an exact version:
-    <b>2.0.0-beta.11</b>.
+    <b>2.0.0-beta.12</b>.
 
   +makeExample('quickstart/dart/ex1/pubspec.yaml', null, 'pubspec.yaml')
 


### PR DESCRIPTION
Also update dart_to_js_script_rewriter dependency to ^1.0.1, and change most angular2.dart imports to be core.dart instead.

The pipes example broke without the angular2.dart import, so I let it be.

The server-communication sample has never worked for me, so I changed it but might have broken it further.