### PR TITLE
docs(toh-pt4): Fix order of methods

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt4.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt4.jade
@@ -384,7 +384,7 @@ code-example(format="." language="html").
   Like `getHeroes`, it also returns a promise. 
   But this promise waits 2 seconds before resolving the promise with mock heroes.
   
-  Back in the `AppComponent`, swap `_heroService.getHeroesSlowly` for `_heroService.getHeroes`
+  Back in the `AppComponent`, swap `_heroService.getHeroes` for `_heroService.getHeroesSlowly`
   and see how the app behaves.
   
 .l-main-section


### PR DESCRIPTION
Change the ordering of the methods `getHeroes` and `getHeroesSlowly` in the "Take it slow" appendix.
The original ordering incorrectly suggested that the reader should swap the new `getHeroesSlowly`
method for the existing `getHeroes` method, rather than the other way around.