### PR TITLE
use local resource to replace google cdn

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -306,16 +306,16 @@ gulp.task('remove-example-boilerplate', function() {
     })
 });
 
-gulp.task('serve-and-sync', ['build-docs'], function (cb) {
+gulp.task('serve-and-sync', ['build-docs','_copy_angular_resource'], function (cb) {
   // watchAndSync({devGuide: true, apiDocs: true, apiExamples: true, localFiles: true}, cb);
   watchAndSync({devGuide: true, devGuideJade: true, apiDocs: true, apiExamples: true, localFiles: true}, cb);
 });
 
-gulp.task('serve-and-sync-api', ['build-docs'], function (cb) {
+gulp.task('serve-and-sync-api', ['build-docs','_copy_angular_resource'], function (cb) {
   watchAndSync({apiDocs: true, apiExamples: true}, cb);
 });
 
-gulp.task('serve-and-sync-devguide', ['build-devguide-docs', 'build-plunkers' ], function (cb) {
+gulp.task('serve-and-sync-devguide', ['build-devguide-docs', 'build-plunkers' ,'_copy_angular_resource'], function (cb) {
   watchAndSync({devGuide: true, devGuideJade: true, localFiles: true}, cb);
 });
 
@@ -323,7 +323,7 @@ gulp.task('_serve-and-sync-jade', function (cb) {
   watchAndSync({devGuideJade: true, localFiles: true}, cb);
 });
 
-gulp.task('build-and-serve', ['build-docs'], function (cb) {
+gulp.task('build-and-serve', ['build-docs','_copy_angular_resource'], function (cb) {
   watchAndSync({localFiles: true}, cb);
 });
 
@@ -489,6 +489,34 @@ gulp.task('_shred-clean-api', function(cb) {
 gulp.task('_zip-examples', function() {
   exampleZipper.zipExamples(_devguideShredOptions.examplesDir, _devguideShredOptions.zipDir);
   exampleZipper.zipExamples(_apiShredOptions.examplesDir, _apiShredOptions.zipDir);
+});
+
+gulp.task('_copy_angular_resource',function(){
+  var filesToCopy = ['./node_modules/angular/angular.min.js',
+  './node_modules/angular-animate/angular-animate.min.js',
+  './node_modules/angular-aria/angular-aria.min.js',
+  './node_modules/angular-material/angular-material.min.js',
+  './node_modules/angular-material/angular-material.min.css',
+  './node_modules/material-icons/css/material-icons.min.css'];
+  
+  var destPaths = ['./public/resources/js/vendor/angular.min.js',
+  './public/resources/js/vendor/angular-animate.min.js',
+  './public/resources/js/vendor/angular-aria.min.js',
+  './public/resources/js/vendor/angular-material.min.js',
+  './public/resources/css/vendor/angular-material.min.css',
+  './public/resources/css/vendor/material-icons.min.css'];
+  var copy = Q.denodeify(fsExtra.copy);
+  var copyPromises = [];
+  for(var i=0;i<filesToCopy.length;i++) {
+    copyPromises.push(copy(filesToCopy[i], destPaths[i], { clobber: true}))
+  }
+
+   Q.all(copyPromises).then(function(result){
+      console.log(result);
+   })
+   .fail(function(error){ 
+      console.log(error);
+   })
 });
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "harp": "harp",
     "live-server": "live-server",
     "test-api-builder": "jasmine-node tools/api-builder",
-
     "protractor": "protractor"
   },
   "repository": {
@@ -28,7 +27,7 @@
   "devDependencies": {
     "archiver": "^0.16.0",
     "assert-plus": "^0.1.5",
-    "broken-link-checker":"0.7.0",
+    "broken-link-checker": "0.7.0",
     "browser-sync": "^2.9.3",
     "canonical-path": "0.0.2",
     "cross-spawn": "^2.1.0",
@@ -70,6 +69,11 @@
     "yargs": "^3.23.0"
   },
   "dependencies": {
-    "jstransformer-marked": "^1.0.1"
+    "angular": "1.4.8",
+    "angular-animate": "1.4.8",
+    "angular-aria": "1.4.8",
+    "angular-material": "1.0.0",
+    "jstransformer-marked": "^1.0.1",
+    "material-icons": "^0.1.0"
   }
 }

--- a/public/_includes/_head-include.jade
+++ b/public/_includes/_head-include.jade
@@ -34,9 +34,10 @@ meta(itemprop="description" content="#{description}")
 meta(itemprop="image" content="https://angular.io/resources/images/logos/standard/shield-large.png")
 
 link(rel="icon" type="image/x-icon" href="/resources/images/icons/favicon.ico")
-link(rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0/angular-material.min.css")
+link(rel="stylesheet" href="/resources/css/vendor/angular-material.min.css")
+link(rel="stylesheet" href="/resources/css/vendor/material-icons.min.css")
 link(href="https://fonts.googleapis.com/css?family=Roboto:400,300,500,400italic,700" rel='stylesheet' type='text/css')
-link(href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet")
+
 link(rel="stylesheet" href="/resources/css/vendor/icomoon/style.css")
 link(rel="stylesheet" href="/resources/css/vendor/animate.css")
 link(rel="stylesheet" href="/resources/css/main.css")

--- a/public/_includes/_scripts-include.jade
+++ b/public/_includes/_scripts-include.jade
@@ -6,12 +6,11 @@ script(src="/resources/js/vendor/lodash.js")
 script(src="/resources/js/vendor/clipboard.min.js")
 
 
-<!-- Angular Material Dependencies -->
-script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.min.js")
-script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-animate.min.js")
-script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-aria.min.js")
-script(src="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0/angular-material.min.js")
-
+<!-- use local AngularJS lib -->
+script(src="/resources/js/vendor/angular.min.js")
+script(src="/resources/js/vendor/angular-animate.min.js")
+script(src="/resources/js/vendor/angular-aria.min.js")
+script(src="/resources/js/vendor/angular-material.min.js")
 
 
 <!-- Angular.io Site JS -->
@@ -49,8 +48,8 @@ if current.path[0] == "docs"
 
     _st('install','VsuU7kH5Hnnj9tfyNvfK');
 
-<!-- Google Feedback -->
-script(src="//www.gstatic.com/feedback/api.js" type="text/javascript")
+  <!-- Google Feedback -->
+  script(src="//www.gstatic.com/feedback/api.js" type="text/javascript")
 
 <!-- Twitter Widget -->
 script.


### PR DESCRIPTION
Googleapis is not available in China. So we can't get these lib files directly from googleapis. Instead, we have to use local lib files. 

I create this PR so that  angular.min.js angular-animate.min.js angular-aria.min.js angular-material.min.js angular-material.min.css material-icons.min.css are loaded from local server.

Please take these into consideration. Thx.