### PR TITLE
Add additional meta tags to the angular.io dgeni package

### DIFF
--- a/tools/api-builder/angular.io-package/index.js
+++ b/tools/api-builder/angular.io-package/index.js
@@ -34,8 +34,8 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
   };
 })
 
-.config(function(parseTagsProcessor) {
-  parseTagsProcessor.tagDefinitions.push({ name: 'internal', transforms: function() { return true; } });
+.config(function(parseTagsProcessor, getInjectables) {
+  parseTagsProcessor.tagDefinitions = parseTagsProcessor.tagDefinitions.concat(getInjectables(require('./tag-defs')));
 })
 
 .config(function(readTypeScriptModules, writeFilesProcessor, readFilesProcessor) {
@@ -139,5 +139,4 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
     'IMPLEMENTS',
     'ABSTRACT'
   ];
-})
-
+});

--- a/tools/api-builder/angular.io-package/tag-defs/deprecated.js
+++ b/tools/api-builder/angular.io-package/tag-defs/deprecated.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    name: 'deprecated'
+  };
+};

--- a/tools/api-builder/angular.io-package/tag-defs/howToUse.js
+++ b/tools/api-builder/angular.io-package/tag-defs/howToUse.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    name: 'howToUse'
+  };
+};

--- a/tools/api-builder/angular.io-package/tag-defs/index.js
+++ b/tools/api-builder/angular.io-package/tag-defs/index.js
@@ -1,0 +1,6 @@
+module.exports = [
+  require('./deprecated'),
+  require('./howToUse'),
+  require('./whatItIs'),
+  require('./internal')
+];

--- a/tools/api-builder/angular.io-package/tag-defs/internal.js
+++ b/tools/api-builder/angular.io-package/tag-defs/internal.js
@@ -1,0 +1,8 @@
+module.exports = function() {
+  return {
+    name: 'internal',
+    transforms: function() {
+      return true;
+    }
+  }
+};

--- a/tools/api-builder/angular.io-package/tag-defs/whatItIs.js
+++ b/tools/api-builder/angular.io-package/tag-defs/whatItIs.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    name: 'whatItIs'
+  };
+};

--- a/tools/api-builder/angular.io-package/templates/class.template.html
+++ b/tools/api-builder/angular.io-package/templates/class.template.html
@@ -1,3 +1,6 @@
+<!-- TODO: API design proposal section will use doc.howToUse and doc.whatItIs -->
+<!-- TODO: API design proposal badges will use doc.deprecated -->
+
 {% include "lib/githubLinks.html" -%}
 {% include "lib/paramList.html" -%}
 {% extends 'layout/base.template.html' -%}


### PR DESCRIPTION
In order to fulfill the [api doc design proposal](https://github.com/angular/angular.io/issues/964), additional meta tags need to be added to the jsdoc strings of the angular repo. This pull request pre-emptively adds support for `@deprecated`, `@howToUse`, and `@WhatItIs` to be used in any of the `angular.io-package` dgeni templates.

https://github.com/angular/angular.io/issues/1028