### PR TITLE
docs: (template-syntax) Fixed typo

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -542,7 +542,7 @@ table
 // #docregion property-binding-7
 :marked
   ### Binding target
-  a id between enclosing square brackets identifies the target property. The target property in the following code is the image element’s `src` property.
+  An element property between enclosing square brackets identifies the target property. The target property in the following code is the image element’s `src` property.
 
 // #enddocregion property-binding-7
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-1')(format=".")


### PR DESCRIPTION
Fixed typo error in Template Syntax chapter of Basics section.