### PR TITLE
docs(lifecycle-hooks): Fixed typo

### DIFF
--- a/public/docs/ts/latest/guide/lifecycle-hooks.jade
+++ b/public/docs/ts/latest/guide/lifecycle-hooks.jade
@@ -64,6 +64,7 @@ a(id="hooks-overview")
     Nonetheless, we strongly recommend adding interfaces to TypeScript directive classes
     in order to benefit from strong typing and editor tooling.  
   
+ :marked
   Here are the component lifecycle hook methods:
 
   ### Directives and Components


### PR DESCRIPTION
Added **:marked** keyword because **Here** word was interpreted as HTML element. 