### PR TITLE
[WIP] Add link to AngularDart API docs

### DIFF
--- a/public/docs/dart/latest/index.jade
+++ b/public/docs/dart/latest/index.jade
@@ -28,3 +28,6 @@ div.card-row(layout='row')
         footer
           a(href="/docs/#{current.path[1]}/#{current.path[2]}/api/" class="button" md-button) View API
 
+.alert.is-helpful.
+  Not using Angular 2 yet? Perhaps you need the
+  <a href="https://www.dartdocs.org/documentation/angular/latest" target="_blank">API docs for the original AngularDart</a>.


### PR DESCRIPTION
@naomiblack the formatting is crappola, but perhaps we could add something like this?