### PR TITLE
fix(quickref-cookbook): fix broken date test

### DIFF
--- a/public/docs/_examples/cb-a1-a2-quick-reference/e2e-spec.js
+++ b/public/docs/_examples/cb-a1-a2-quick-reference/e2e-spec.js
@@ -7,19 +7,19 @@ describe('Angular 1 to 2 Quick Reference Tests', function () {
   it('should display no poster images after bootstrap', function () {
     testImagesAreDisplayed(false);
   });
-  
+
   it('should display proper movie data', function () {
     // We check only a few samples
     var expectedSamples = [
       {row: 0, column: 0, element: 'img', attr: 'src', value: 'images/hero.png', contains: true},
       {row: 0, column: 2, value: 'Celeritas'},
-      {row: 1, column: 3, value: 'Dec 17, 2015'},
+      {row: 1, column: 3, matches: /Dec 1[678], 2015/}, // absorb timezone dif; we care about date format
       {row: 1, column: 5, value: '$14.95'},
       {row: 2, column: 4, value: 'PG-13'},
       {row: 2, column: 7, value: '100%'},
       {row: 2, column: 0, element: 'img', attr: 'src', value: 'images/ng-logo.png', contains: true},
     ];
-    
+
     // Go through the samples
     var movieRows = getMovieRows();
     for (var i = 0; i < expectedSamples.length; i++) {
@@ -27,18 +27,20 @@ describe('Angular 1 to 2 Quick Reference Tests', function () {
       var tableCell = movieRows.get(sample.row)
         .all(by.tagName('td')).get(sample.column);
       // Check the cell or its nested element
-      var elementToCheck = sample.element 
+      var elementToCheck = sample.element
         ? tableCell.element(by.tagName(sample.element))
         : tableCell;
-        
+
       // Check element attribute or text
       var valueToCheck = sample.attr
         ? elementToCheck.getAttribute(sample.attr)
         : elementToCheck.getText();
 
-      // Test for equals/contains
+      // Test for equals/contains/match
       if (sample.contains) {
         expect(valueToCheck).toContain(sample.value);
+      } else if (sample.matches) {
+        expect(valueToCheck).toMatch(sample.matches);
       } else {
         expect(valueToCheck).toEqual(sample.value);
       }
@@ -48,11 +50,11 @@ describe('Angular 1 to 2 Quick Reference Tests', function () {
   it('should display images after Show Poster', function () {
     testPosterButtonClick("Show Poster", true);
   });
-  
+
   it('should hide images after Hide Poster', function () {
     testPosterButtonClick("Hide Poster", false);
   });
-  
+
   it('should display no movie when no favorite hero is specified', function () {
     testFavoriteHero(null, "Please enter your favorite hero.");
   });
@@ -60,14 +62,14 @@ describe('Angular 1 to 2 Quick Reference Tests', function () {
   it('should display no movie for Magneta', function () {
     testFavoriteHero("Magneta", "No movie, sorry!");
   });
-  
+
   it('should display a movie for Mr. Nice', function () {
     testFavoriteHero("Mr. Nice", "Excellent choice!");
   });
-  
+
   function testImagesAreDisplayed(isDisplayed) {
     var expectedMovieCount = 3;
-    
+
     var movieRows = getMovieRows();
     expect(movieRows.count()).toBe(expectedMovieCount);
     for (var i = 0; i < expectedMovieCount; i++) {
@@ -75,26 +77,26 @@ describe('Angular 1 to 2 Quick Reference Tests', function () {
       expect(movieImage.isDisplayed()).toBe(isDisplayed);
     }
   }
-  
+
   function testPosterButtonClick(expectedButtonText, isDisplayed) {
     var posterButton = element(by.css('movie-list tr > th > button'));
     expect(posterButton.getText()).toBe(expectedButtonText);
-    
+
     posterButton.click().then(function () {
       testImagesAreDisplayed(isDisplayed);
     })
   }
-  
+
   function getMovieRows() {
     return element.all(by.css('movie-list tbody > tr'));
   }
-  
+
   function testFavoriteHero(heroName, expectedLabel) {
-    var movieListComp = element(by.tagName('movie-list')); 
+    var movieListComp = element(by.tagName('movie-list'));
     var heroInput = movieListComp.element(by.tagName('input'));
     var favoriteHeroLabel = movieListComp.element(by.tagName('h3'));
     var resultLabel = movieListComp.element(by.css('span > p'));
-      
+
     heroInput.clear().then(function () {
       sendKeys(heroInput, heroName || '').then(function () {
         expect(resultLabel.getText()).toBe(expectedLabel);


### PR DESCRIPTION
The date test was failing in different timezones due to dates being localized.

This fix makes the test slightly less robust, but guarantees that it will work in every timezone irrespective of differences between the node env timezone and browser timezone.

/cc @wardbell 