### PR TITLE
Small typo fixes (missing dashes, and double "the")

### DIFF
--- a/public/docs/dart/latest/guide/architecture.jade
+++ b/public/docs/dart/latest/guide/architecture.jade
@@ -94,7 +94,7 @@ figure
 
   The `HeroDetailComponent` is a *different* component than the `HeroListComponent` we've seen.
   The `HeroDetailComponent` (code not shown) presents facts about a particular hero, the
-  hero that the user selects from the list presented by the the `HeroListComponent`.
+  hero that the user selects from the list presented by the `HeroListComponent`.
   The `HeroDetailComponent` is a **child** of the `HeroListComponent`.
 
 figure

--- a/public/docs/dart/latest/tutorial/toh-pt3.jade
+++ b/public/docs/dart/latest/tutorial/toh-pt3.jade
@@ -62,7 +62,7 @@ code-example(format="." language="bash").
 
     All of our component names end in "Component".  All of our component file names end in "_component".
 
-    We spell our file names in lower dash case (AKA "kebab case") so we don't worry about
+    We spell our file names in lower dash case (AKA "kebab-case") so we don't worry about
     case sensitivity on the server or in source control.
 
     <!-- TODO

--- a/public/docs/js/latest/guide/forms.jade
+++ b/public/docs/js/latest/guide/forms.jade
@@ -472,8 +472,8 @@ figure.image-display
   'app/hero-form.component.html (excerpt)', 
   stylePattern)
 :marked
-  When we added the `ngControl` directive, we bound it to the the model's `name` property.
   
+  When we added the `ngControl` directive, we bound it to the model's `name` property.
   Here we initialize a template local variable (`name`) with the value "ngForm" (`#name="ngForm"`).
   Angular recognizes that syntax and re-sets the `name` local template variable to the
   `ngControl` directive instance.

--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -624,7 +624,7 @@ code-example(format, language="html").
   we want the singleton instance of `NewLogger` to handle it instead.
 
   The dependency injector should inject that singleton instance
-  when a component asks for either the new or the the old logger.
+  when a component asks for either the new or the old logger.
   The `OldLogger` should be an alias for `NewLogger`.
 
   We certainly do not want two different `NewLogger` instances in our app.

--- a/public/docs/ts/latest/guide/forms.jade
+++ b/public/docs/ts/latest/guide/forms.jade
@@ -379,7 +379,7 @@ figure.image-display
     We often ignore this technical distinction and refer to `NgControlName` more conveniently (albeit incorrectly) as the *NgControl* directive.
     
     While we're under the hood, we might as well note that the `ngModel` in the 
-    two-way binding syntax is now a property of the the `NgControlName` directive. 
+    two-way binding syntax is now a property of the `NgControlName` directive. 
     The `NgModel` directive is no longer involved. We only need one directive to manage the DOM element
     and there is no practical difference in the way either directive handles data binding.     
 

--- a/public/docs/ts/latest/guide/upgrade.jade
+++ b/public/docs/ts/latest/guide/upgrade.jade
@@ -1267,7 +1267,7 @@ code-example(format="").
   
   We can replace this implementation with an Angular 2 service class, while 
   keeping our controllers in Angular 1 land. In the new version we'll just use
-  the the `Http` service from Angular 2 instead of ngResource.
+  the `Http` service from Angular 2 instead of ngResource.
   
   The `Http` service isn't included in the main Angular 2 bundle, so we need to 
   include it in `index.html` separately. As the service uses RxJS Observables,

--- a/public/docs/ts/latest/tutorial/toh-pt3.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt3.jade
@@ -63,7 +63,7 @@ code-example(format="." language="bash").
     
     All of our component names end in "Component".  All of our component file names end in ".component".
     
-    We spell our file names in lower dash case (AKA "kebab case") so we don't worry about
+    We spell our file names in lower dash case (AKA "kebab-case") so we don't worry about
     case sensitivity on the server or in source control.
 
     <!-- TODO


### PR DESCRIPTION
'We spell our file names in lower dash case (AKA "kebab case") so we don't worry about' should read 'We spell our file names in lower dash case (AKA "kebab-case") so we don't worry about'