### PR TITLE
docs(quickstart/js): add missing systemjs dependency

### DIFF
--- a/public/docs/_examples/quickstart/js/package.1.json
+++ b/public/docs/_examples/quickstart/js/package.1.json
@@ -8,6 +8,7 @@
   "license": "ISC",
   "dependencies": {
     "angular2": "2.0.0-beta.14",
+    "systemjs": "0.19.25",
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",


### PR DESCRIPTION
The [5 Min Quickstart js version](https://angular.io/docs/js/latest/quickstart.html#!#package-json) is missing a required dependency (`systemjs`) that _is_ present in the [ts version](https://angular.io/docs/ts/latest/quickstart.html#!#package-json).