### PR TITLE
chore(glossary): fix broken links

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -170,16 +170,16 @@ include _util-fns
     operations and supporting declaration syntax.
 
      The many forms of binding include:
-     * [Interpolation](template-syntax.html#interpolation)
-     * [Property Binding](template-syntax.html#property-binding)
-     * [Event Binding](template-syntax.html#event-binding)
-     * [Attribute Binding](template-syntax.html#attribute-binding)
-     * [Class Binding](template-syntax.html#class-binding)
-     * [Style Binding](template-syntax.html#style-binding)
-     * [Two-way data binding with ngModel](template-syntax.html#ng-model)
+     * [Interpolation](guide/template-syntax.html#interpolation)
+     * [Property Binding](guide/template-syntax.html#property-binding)
+     * [Event Binding](guide/template-syntax.html#event-binding)
+     * [Attribute Binding](guide/template-syntax.html#attribute-binding)
+     * [Class Binding](guide/template-syntax.html#class-binding)
+     * [Style Binding](guide/template-syntax.html#style-binding)
+     * [Two-way data binding with ngModel](guide/template-syntax.html#ng-model)
 
     Learn more about data binding in the
-    [Template Syntax](template-syntax.html#data-binding) chapter.
+    [Template Syntax](guide/template-syntax.html#data-binding) chapter.
 
 // #enddocregion d1
 <a id="decorator"></a> <a id="decoration"></a>
@@ -270,7 +270,7 @@ include _util-fns
     is when we [bootstrap](#bootstrap) the application.
     There are other opportunities to register as well.
 
-    Learn more in the [Dependency Injection](dependency-injection.html) chapter.
+    Learn more in the [Dependency Injection](guide/dependency-injection.html) chapter.
 :marked
   ## Directive
 .l-sub-section
@@ -375,7 +375,7 @@ include _util-fns
     Data values flow *into* this property from the data source identified
     in the template expression to the right of the equal sign.
 
-    See the [Template Syntax](template-syntax.html#inputs-outputs) chapter.
+    See the [Template Syntax](guide/template-syntax.html#inputs-outputs) chapter.
 
 :marked
   ## Interpolation
@@ -392,7 +392,7 @@ include _util-fns
 
   :marked
     Learn more about interpolation in the
-    [Template Syntax](template-syntax.html#interpolation) chapter.
+    [Template Syntax](guide/template-syntax.html#interpolation) chapter.
 
 
 <a id="J"></a>
@@ -434,7 +434,7 @@ include _util-fns
     * `ngAfterViewChecked` - after every check of a component's view(s)
     * `ngOnDestroy` - just before the directive is destroyed.
 
-    Learn more in the [Lifecycle Hooks](lifecycle-hooks.html) chapter.
+    Learn more in the [Lifecycle Hooks](guide/lifecycle-hooks.html) chapter.
 // #enddocregion f-l
 
 // #docregion m1
@@ -494,7 +494,7 @@ include _util-fns
     Events stream *out* of this property to the receiver identified
     in the template expression to the right of the equal sign.
 
-    See the [Template Syntax](template-syntax.html#inputs-outputs) chapter.
+    See the [Template Syntax](guide/template-syntax.html#inputs-outputs) chapter.
 
 .l-main-section
 <a id="P"></a>
@@ -523,7 +523,7 @@ include _util-fns
   code-example(language="html" escape="html").
     <label>Price: </label>{{product.price | currency}}
   :marked
-    Learn more in the chapter on [pipes](pipes.html) .
+    Learn more in the chapter on [pipes](guide/pipes.html) .
 
 :marked
   ## Provider
@@ -550,7 +550,7 @@ include _util-fns
     and taking other similar actions that cause the application to
     replace one view with another.
 
-    The Angular [Component Router](router.html) is a richly featured mechanism for configuring
+    The Angular [Component Router](guide/router.html) is a richly featured mechanism for configuring
     and managing the entire view navigation process including the creation and destruction
     of views.
 :marked
@@ -591,7 +591,7 @@ include _util-fns
     the support and continuing guidance of an Angular [Directive](#directive),
     most notably a [Component](#component).
 
-    We write templates in a special [Template Syntax](template-syntax.html).
+    We write templates in a special [Template Syntax](guide/template-syntax.html).
 
 :marked
   ## Template Expression
@@ -599,7 +599,7 @@ include _util-fns
   :marked
     An expression in a JavaScript-like syntax that Angular evaluates within
     a [data binding](#data-binding).  Learn how to write template expressions
-    in the [Template Syntax](template-syntax.html#template-expressions) chapter.
+    in the [Template Syntax](guide/template-syntax.html#template-expressions) chapter.
 
 // #enddocregion t1
 // #docregion t2


### PR DESCRIPTION
I guess that the glossary was moved outside the guide so that explains the broken links.

PS: Didn't we have a tool to verify broken links?

Fixes #1078 