### PR TITLE
docs(safari mobile): fixes issue with overlapping text in api docs with safari mobile.

### DIFF
--- a/public/resources/css/module/_api.scss
+++ b/public/resources/css/module/_api.scss
@@ -169,6 +169,15 @@ input.api-filter {
 }
 
 @media screen and (max-width: 600px) {
+  .docs-content {
+    // Overrides display flex from angular material.
+    // This was added because Safari doesn't play nice with layout="column".
+    // Look of API doc in Chrome and Firefox remains the same, and is fixed for Safari.
+    .layout-xs-column {
+      display: block !important;
+    }
+  }
+
   code {
     font-size: 12px;
   }


### PR DESCRIPTION
Test this fix with Safari, Chrome, and Firefox at 600px width or less using this link: https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/common/AbstractControl-class.html

CLOSES:
https://github.com/angular/angular.io/issues/1099