### PR TITLE
docs(class export): Fix lack of spacing between words in class export

### DIFF
--- a/public/resources/css/module/_api.scss
+++ b/public/resources/css/module/_api.scss
@@ -159,9 +159,9 @@ input.api-filter {
     font-size: 14px;
     color: #1a2326;
 
-    // Override highlight.js
+    // the last .pln (white space) creates additional spacing between sections of the api doc. Remove it.
     &.no-pln {
-      .pln {
+      .pln:last-child {
         display: none;
       }
     }


### PR DESCRIPTION
You may preview the changes here: 

https://api-doc-styling-2.firebaseapp.com/docs/ts/latest/api/core/ElementRef-class.html
https://api-doc-styling-2.firebaseapp.com/docs/ts/latest/api/core/EventEmitter-class.html

CLOSES:
https://github.com/angular/angular.io/issues/1102