### PR TITLE
docs(badges): add experiment, stable, and deprecated badges to API doc.

### DIFF
--- a/public/_includes/_hero.jade
+++ b/public/_includes/_hero.jade
@@ -1,11 +1,25 @@
-- var textFormat = ''
+// Refer to jade.template.html and addJadeDataDocsProcessor to figure out where the context of this jade file originates
+- var textFormat = '';
 - var headerTitle = title + (typeof varType !== 'undefined' ? (': ' + varType) : '');
-
+- var capitalize = function capitalize(str) { return str.charAt(0).toUpperCase() + str.slice(1); }
+- var useBadges = docType || stability;
+  
 if current.path[4] && current.path[3] == 'api'
   - var textFormat = 'is-standard-case'
 
 header(class="hero background-sky")
-  h1(class="hero-title text-display-1 #{textFormat}") #{headerTitle}
+  span(class="hero-title-with-badges" layout="row" layout-align="start center")
+    h1(class="hero-title text-display-1 #{textFormat}") #{headerTitle}
+    if useBadges
+      span(class="badges")
+        if docType
+          span(class="status-badge").
+            #{capitalize(docType)}
+        if stability
+          span(layout="row" class="status-badge")
+            // badge circle is filled based on stability by matching a css selector in _hero.scss
+            span(class="status-circle status-#{stability}")
+            span Stability: #{capitalize(stability)}
 
   if subtitle
     h2.hero-subtitle.text-subhead #{subtitle}

--- a/public/resources/css/module/_example-title.scss
+++ b/public/resources/css/module/_example-title.scss
@@ -9,7 +9,7 @@
   background: #1976D2;
   box-shadow: none;
   // temporary hack to remove space between example title and code-example
-  margin-bottom: -18px;
+  margin-bottom: -5px;
   z-index: 1;
   position: relative;
   border-bottom-right-radius: 0;

--- a/public/resources/css/module/_hero.scss
+++ b/public/resources/css/module/_hero.scss
@@ -1,15 +1,44 @@
-$hero-padding: ($unit * 10) ($unit * 6) ($unit * 5);
+$hero-padding: ($unit * 10) ($unit * 6) ($unit * 7);
 
 .hero {
   position: relative;
   padding: $hero-padding;
-  height: $unit * 8;
+  height: $unit * 10;
+
+  .hero-title-with-badges {
+    margin-bottom: $unit;
+  }
+
+  .status-circle {
+    margin-right: 4px;
+    border-radius: 50%;
+    width: 10px;
+    height: 10px;
+    display: inline-block;
+  }
+
+  // status-*, will be matched by the results in addJadeDataDocsProcessor.js, and reflect in _hero.jade
+  .status-deprecated {
+    background: #E53935;
+  }
+
+  .status-stable {
+    background: #558b2f;
+  }
+
+  .status-experimental {
+    background: #9575cd;
+  }
 
   @media handheld and (max-width: $phone-breakpoint),
   screen and (max-device-width: $phone-breakpoint),
   screen and (max-width: $tablet-breakpoint) {
     height: auto;
     padding-top: 40px;
+
+    .badges {
+      margin-top: 48px;
+    }
   }
 
   &.is-large {
@@ -24,7 +53,28 @@ $hero-padding: ($unit * 10) ($unit * 6) ($unit * 5);
     }
   }
 
+  .badges {
+    padding-left: 8px;
+
+    .status-badge {
+      color: #0143A3;
+      margin-left: 4px;
+      padding-left: 8px;
+      padding-right: 8px;
+      background-color: rgba(255,255,255,0.5);
+      border-radius: 2px;
+      line-height: 20px;
+      display: inline-block;
+    }
+  }
+
+  button {
+    // Override md-button from angular material to align language select with hero title.
+    margin: 0 !important;
+  }
+
   .hero-title {
+    display: inline; // title will be inline with badges
     text-transform: uppercase;
     margin: 0;
     opacity: .87;

--- a/tools/api-builder/angular.io-package/processors/addJadeDataDocsProcessor.js
+++ b/tools/api-builder/angular.io-package/processors/addJadeDataDocsProcessor.js
@@ -58,12 +58,32 @@ module.exports = function addJadeDataDocsProcessor() {
           // GET DATA FOR EACH PAGE (CLASS, VARS, FUNCTIONS)
           var modulePageInfo  = _(doc.exports)
           .map(function(exportDoc) {
+
+            // STABILITY STATUS
+            // Supported tags:
+            // @stable
+            // @experimental
+            // @deprecated
+            // Default is the empty string (no badge)
+            // Do not capitalize the strings, they are intended for use in constructing a css class from _hero.scss
+            // and used in _hero.jade
+            var stability = '';
+            if (_.has(exportDoc, 'stable')) {
+              stability = 'stable';
+            } else if (_.has(exportDoc, 'experimental')) {
+              stability = 'experimental';
+            } else if (_.has(exportDoc, 'deprecated')) {
+              stability = 'deprecated';
+            }
+
             var dataDoc = {
               name: exportDoc.name + '-' + exportDoc.docType,
               title: exportDoc.name,
               docType: exportDoc.docType,
-              exportDoc: exportDoc
+              exportDoc: exportDoc,
+              stability: stability
             };
+
             if (exportDoc.symbolTypeName) dataDoc.varType = titleCase(exportDoc.symbolTypeName);
             if (exportDoc.originalModule) dataDoc.originalModule = exportDoc.originalModule;
             return dataDoc;

--- a/tools/api-builder/angular.io-package/tag-defs/docsNotRequired.js
+++ b/tools/api-builder/angular.io-package/tag-defs/docsNotRequired.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    name: 'docsNotRequired'
+  };
+};

--- a/tools/api-builder/angular.io-package/tag-defs/experimental.js
+++ b/tools/api-builder/angular.io-package/tag-defs/experimental.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    name: 'experimental'
+  };
+};

--- a/tools/api-builder/angular.io-package/tag-defs/index.js
+++ b/tools/api-builder/angular.io-package/tag-defs/index.js
@@ -2,5 +2,8 @@ module.exports = [
   require('./deprecated'),
   require('./howToUse'),
   require('./whatItDoes'),
-  require('./internal')
+  require('./internal'),
+  require('./stable'),
+  require('./experimental'),
+  require('./docsNotRequired'),
 ];

--- a/tools/api-builder/angular.io-package/tag-defs/stable.js
+++ b/tools/api-builder/angular.io-package/tag-defs/stable.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    name: 'stable'
+  };
+};

--- a/tools/api-builder/angular.io-package/templates/jade-data.template.html
+++ b/tools/api-builder/angular.io-package/templates/jade-data.template.html
@@ -1,3 +1,4 @@
+{# Use this document to generate the _data.json files for harp.js. This acts as the link between dgeni, jade, and harp #}
 {
 {%- for item in doc.data %}
   "{$ item.name $}" : {
@@ -10,6 +11,9 @@
     {%- endif %}
     {%- if item.originalModule %}
     "originalModule" : "{$ item.originalModule $}",
+    {%- endif %}
+    {%- if item.stability %}
+    "stability" : "{$ item.stability $}",
     {%- endif %}
     "docType": "{$ item.docType $}"
   }{% if not loop.last %},{% endif %}

--- a/tools/api-builder/angular.io-package/templates/var.template.html
+++ b/tools/api-builder/angular.io-package/templates/var.template.html
@@ -4,20 +4,23 @@
 
 {% block body %}
 include {$ relativePath(doc.path, '_util-fns') $}
-.l-main-section
-  h2(class="variable export")
-    pre.prettyprint
+
+.div(layout="row" layout-xs="column" class="row-margin")
+  div(flex="20" flex-xs="100")
+    h2 Variable Export
+  div(flex="80" flex-xs="100")
+    pre.prettyprint.no-bg
       code.
         export {$ doc.name $}{$ returnType(doc.returnType) $}
 
-  p.location-badge.
-    exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
-    defined in {$ githubViewLink(doc) $}
+p.location-badge.
+  exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
+  defined in {$ githubViewLink(doc) $}
 
-  :marked
+:marked
 {%- if doc.notYetDocumented %}
     *Not Yet Documented*
 {% else %}
-{$ doc.description | indentForMarkdown(4) | trimBlankLines $}
+{$ doc.description | indentForMarkdown(2) | trimBlankLines $}
 {% endif -%}
 {% endblock %}


### PR DESCRIPTION
## Change log

* Add `@experimental`, `@stable`, and `@deprecated` for dgeni to process. 
* Add `@docsNotRequired` as well, not actually being used yet.
* Modify `jade.template`, which generates a `_data.json` (a harp.js data context for jade), to include a `stability` status
* Stylize `_hero.jade` and `_hero.scss` to add badges
* Fix an issue where the first line of code examples is overlapped, https://github.com/angular/angular.io/pull/1104, fix in `example-title.scss`
* Add inline documentation to make it easy to decipher where the data flows from dgeni to nunjucks to harpjs to jade

#### Preview
**For demonstration purposes**, I've included these tags in my local copy of the angular2 project, and hosted a test instance of angular.io. With the current state of angular2 docs, we will only see the doc type, and in some cases (such as FORM_BINDING) the deprecated badge.

* [Experimental] - https://badges-everywhere.firebaseapp.com/docs/ts/latest/api/common/NgFormControl-directive.html
* [Stable] - https://badges-everywhere.firebaseapp.com/docs/ts/latest/api/common/NgSwitch-directive.html
* [Deprecated] - https://badges-everywhere.firebaseapp.com/docs/ts/latest/api/common/FORM_BINDINGS-let.html
* [Undefined] - https://badges-everywhere.firebaseapp.com/docs/ts/latest/api/common/Form-interface.html

The logic which decides which badge to pick is the following:
```javascript
  // STABILITY STATUS
  // Supported tags:
  // @stable
  // @experimental
  // @deprecated
  // Default is the empty string (no badge)
  var stability = ''; 
  if (_.has(exportDoc, 'stable')) {
    stability = 'stable';
  } else if (_.has(exportDoc, 'experimental')) {
    stability = 'experimental';
  } else if (_.has(exportDoc, 'deprecated')) {
    stability = 'deprecated';
  }
```
@naomiblack @IgorMinar @petebacondarwin

CLOSES:
https://github.com/angular/angular.io/issues/1098
https://github.com/angular/angular.io/issues/1097
