### PR TITLE
docs(toh): remove @Input decorator in part 5

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/hero-detail.component.ts
+++ b/public/docs/_examples/toh-5/ts/app/hero-detail.component.ts
@@ -2,7 +2,7 @@
 // #docregion
 // #docregion v2
 // #docregion import-oninit
-import { Component, Input, OnInit } from 'angular2/core';
+import { Component, OnInit } from 'angular2/core';
 // #enddocregion import-oninit
 // #docregion import-route-params
 import { RouteParams } from 'angular2/router';
@@ -27,7 +27,7 @@ import { HeroService } from './hero.service';
 // #docregion implement
 export class HeroDetailComponent implements OnInit {
 // #enddocregion implement
-  @Input() hero: Hero;
+  hero: Hero;
 
 // #docregion ctor
   constructor(

--- a/public/docs/_examples/tutorial/ts/app/hero-detail.component.ts
+++ b/public/docs/_examples/tutorial/ts/app/hero-detail.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from 'angular2/core';
+import {Component, OnInit} from 'angular2/core';
 import {RouteParams} from 'angular2/router';
 
 import {Hero} from './hero';
@@ -10,7 +10,7 @@ import {HeroService} from './hero.service';
   styleUrls: ['app/hero-detail.component.css']
 })
 export class HeroDetailComponent implements OnInit {
-  @Input() hero: Hero;
+  hero: Hero;
 
   constructor(private _heroService: HeroService,
     private _routeParams: RouteParams) {


### PR DESCRIPTION
Removes the @Input decorator in part 5 since it is not used and was added by mistake.

Fixes #1126 