### PR TITLE
Add CSS to the JavaScript Quick Start Tutorial

### DIFF
--- a/public/docs/_examples/quickstart/js/styles.1.css
+++ b/public/docs/_examples/quickstart/js/styles.1.css
@@ -1,0 +1,25 @@
+/* #docregion */
+/* Master Styles */
+h1 {
+  color: #369; 
+  font-family: Arial, Helvetica, sans-serif;   
+  font-size: 250%;
+}
+h2, h3 { 
+  color: #444;
+  font-family: Arial, Helvetica, sans-serif;   
+  font-weight: lighter;
+}
+body { 
+  margin: 2em; 
+}
+body, input[text], button { 
+  color: #888; 
+  font-family: Cambria, Georgia; 
+}
+
+/* 
+ * See https://github.com/angular/angular.io/blob/master/public/docs/_examples/styles.css
+ * for the full set of master styles used by the documentation samples
+ */
+ 

--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -265,7 +265,7 @@ code-example(format="").
     a stylesheet called `styles.css`.
      
     Create a `styles.css` in the root folder and start styling, perhaps with this set:
-  +makeExample('quickstart/ts/styles.1.css', null, 'styles.css (excerpt)')(format=".")
+  +makeExample('quickstart/js/styles.1.css', null, 'styles.css (excerpt)')(format=".")
 
 .l-main-section
 :marked
@@ -323,7 +323,7 @@ figure.image-display
     quickstart/js/app/app.component.js,
     quickstart/js/app/main.js,
     quickstart/js/index.html,
-    quickstart/js/styles.css,
+    quickstart/js/styles.1.css,
     quickstart/js/package.1.json
   `,null,
   `app/app.component.js, app/main.js, index.html, styles.css, package.json`)

--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -31,6 +31,7 @@ figure.image-display
       .file app.component.js
       .file main.js
     .file index.html
+    .file styles.css
     .file license.md
 :marked
   Functionally, it's an `index.html` and two JavaScript files in an `app/` folder.
@@ -256,6 +257,15 @@ code-example(format="").
   When Angular calls the `bootstrap` function in `main.js`, it reads the `AppComponent`
   metadata, finds the `my-app` selector, locates an element tag named `my-app`,
   and loads our application between those tags.
+  
+.l-main-section
+  :marked
+    ## Add some style
+    Styles aren't essential but they're nice and the `index.html` assumes we have
+    a stylesheet called `styles.css`.
+     
+    Create a `styles.css` in the root folder and start styling, perhaps with this set:
+  +makeExample('quickstart/ts/styles.1.css', null, 'styles.css (excerpt)')(format=".")
 
 .l-main-section
 :marked
@@ -305,6 +315,7 @@ figure.image-display
       .file app.component.js
       .file main.js
     .file index.html
+    .file styles.css
     .file package.json
 :marked
   And here are the files:
@@ -312,9 +323,10 @@ figure.image-display
     quickstart/js/app/app.component.js,
     quickstart/js/app/main.js,
     quickstart/js/index.html,
+    quickstart/js/styles.css,
     quickstart/js/package.1.json
   `,null,
-  `app/app.component.js, app/main.js, index.html,package.json`)
+  `app/app.component.js, app/main.js, index.html, styles.css, package.json`)
 :marked
 
 .l-main-section


### PR DESCRIPTION
Noticed the styles.css file was missing from the JavaScript tutorial.  This branch adds the file to the file tree and the code editor.