### PR TITLE
fix static methods to have proper indentation and anchoring

### DIFF
--- a/public/resources/css/module/_api.scss
+++ b/public/resources/css/module/_api.scss
@@ -129,7 +129,7 @@ input.api-filter {
     }
   }
 
-  .class-description-content {
+  .code-links {
     a {
       code, .api-doc-code {
         color: #1E88E5 !important;

--- a/tools/api-builder/angular.io-package/templates/class.template.html
+++ b/tools/api-builder/angular.io-package/templates/class.template.html
@@ -8,7 +8,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 .div(layout="row" layout-xs="column" class="row-margin")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") What it does
-  div(flex="80" flex-xs="100")
+  div(class="code-links" flex="80" flex-xs="100")
     :marked
     {%- if doc.whatItDoes %}
 {$ doc.whatItDoes | indentForMarkdown(6) $}
@@ -19,7 +19,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 .div(layout="row" layout-xs="column" class="row-margin")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") How to use
-  div(flex="80" flex-xs="100")
+  div(class="code-links" flex="80" flex-xs="100")
     :marked
     {%- if doc.howToUse %}
 {$ doc.howToUse | indentForMarkdown(6) $}
@@ -37,7 +37,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
     .div(layout="column")
       {% for member in doc.statics %}{% if not member.internal %}
         pre(class="prettyprint no-bg-with-indent")
-          a(class="code-anchor" href="#{$ member.name $}-anchor")
+          a(class="code-anchor" href="#{$ member.name $}")
             code(class="code-background api-doc-code") {$ member.name | indent(6, false) | trim $}
           code(class="api-doc-code") {$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(member.returnType) $}
       {% endif %}{% endfor %}
@@ -53,7 +53,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
     .div(layout="column")
       {% for member in doc.members %}{% if not member.internal %}
         pre(class="prettyprint no-bg-with-indent")
-          a(class="code-anchor" href="#{$ member.name $}-anchor")
+          a(class="code-anchor" href="#{$ member.name $}")
             code(class="code-background api-doc-code") {$ member.name | indent(6, false) | trim $}
           code(class="api-doc-code") {$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(member.returnType) $}
       {% endif %}{% endfor %}
@@ -67,7 +67,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 .div(class="row-margin" layout="row" layout-xs="column")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Description
-  div(class="class-description-content" flex="80" flex-xs="100")
+  div(class="code-links" flex="80" flex-xs="100")
     :marked
     {%- if doc.description.length > 2 %}
 {$ doc.description | indentForMarkdown(6) | trimBlankLines $}
@@ -124,9 +124,9 @@ include {$ relativePath(doc.path, '_util-fns') $}
 .div(layout="row" layout-xs="column" class="row-margin")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Static Members
-  div(flex="80" flex-xs="100")
+  div(class="code-links" flex="80" flex-xs="100")
   {% for member in doc.statics %}{% if not member.internal %}
-    a(name="{$ member.name $}-anchor" class="anchor-offset")
+    a(name="{$ member.name $}" class="anchor-offset")
     pre(class="prettyprint no-bg" ng-class="{ 'anchor-focused': appCtrl.isApiDocMemberFocused('{$ member.name $}') }")
       code(class="api-doc-code").
         {$ member.name $}{$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(member.returnType) $}
@@ -148,9 +148,9 @@ include {$ relativePath(doc.path, '_util-fns') $}
 .div(layout="row" layout-xs="column" class="instance-members" class="row-margin")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Details
-  div(flex="80" flex-xs="100")
+  div(class="code-links" flex="80" flex-xs="100")
     {% for member in doc.members %}{% if not member.internal %}
-    a(name="{$ member.name $}-anchor" class="anchor-offset")
+    a(name="{$ member.name $}" class="anchor-offset")
     pre(class="prettyprint no-bg" ng-class="{ 'anchor-focused': appCtrl.isApiDocMemberFocused('{$ member.name $}') }")
       code(class="api-doc-code").
         {$ member.name $}{$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(member.returnType) $}


### PR DESCRIPTION
### Changelog:
* static methods have proper anchoring and styling
* removed unnecessary *-anchor suffix for anchors. It reduces url noise.
* fixes some links missing proper styling in class details

### Preview
* Before: https://angular.io/docs/ts/latest/api/core/Injector-class.html
* After: https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/Injector-class.html


For example, https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/Provider-class.html
`token` now has a blue link for `Type` before it looked like https://angular.io/docs/ts/latest/api/core/Provider-class.html

@naomiblack @petebacondarwin 

CLOSES:
https://github.com/angular/angular.io/issues/1138