### PR TITLE
docs(dart): proposed text for linking to Dart samples

### DIFF
--- a/public/docs/dart/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/dart/latest/guide/hierarchical-dependency-injection.jade
@@ -12,8 +12,8 @@ include ../_util-fns
 
   In this chapter we explore these points and write some code.
 
-  The source code for the example app in this chapter is 
-  [in GitHub](https://github.com/angular/angular.io/tree/master/public/docs/_examples/hierarchical-dependency-injection/dart).
+  [Run the live example](https://angular-examples.github.io/hierarchical-dependency-injection/) |
+  [View its source code](https://github.com/angular-examples/hierarchical-dependency-injection)
 
 .l-main-section
 :marked


### PR DESCRIPTION
This PR uses hierarchical-dependency-injection as the guinea pig. The text is similar to what's used in copyedited TS pages such as https://angular.io/docs/ts/latest/guide/displaying-data.html.

@chalin and @thso, what do you think?