### PR TITLE
docs(sidenav reorg): reorganize sidenav

### DIFF
--- a/public/docs/_includes/_side-nav.jade
+++ b/public/docs/_includes/_side-nav.jade
@@ -3,7 +3,7 @@
 - var dir = current.path[4] ? current.path[3] + '/' : '';
 - var cur = current.path[4] || current.path[3];
 - cur = cur === 'index' ? '' : cur + '.html';
-- cur = base + dir + cur; 
+- cur = base + dir + cur;
 
 - var sections = function(dir, selector) {
 -    var secondaryPath = public.docs[current.path[1]][current.path[2]]
@@ -31,7 +31,7 @@
 -    }
 -    return section;
 -  }
-  
+
 - var tutorial = sections('tutorial');
 - var cookbook = sections('cookbook');
 - var basics = sections('guide', function(item) { return item.basics; });
@@ -42,10 +42,15 @@
 -   var selectedCount = items.filter(function(item) { return !!item.class; }).length;
 -   return selectedCount > 0 ? 'is-nav-title-selected' : '';
 - }
-- var isQuickstartSelected = function(_cur) {
+- var isQuickstartSelected = function() {
 -   var splitted = cur.split('/');
 -   var bit = splitted[splitted.length - 1].replace('.html', '');
 -   return bit === 'quickstart' ? 'is-nav-title-selected' : '';
+-}
+- var isApiReferenceSelected = function() {
+-   var splitted = cur.split('/');
+-   var bit = splitted[splitted.length - 2];
+-   return bit === 'api' ? 'is-nav-title-selected' : '';
 -}
 - var isCollapsed = function(titleStyle) {
 -   return titleStyle === 'is-nav-title-selected' ? '' : 'is-hidden';
@@ -99,21 +104,15 @@ nav.side-nav.l-pinned-left.l-layer-4.l-offset-nav
             li(class="nav-list-item #{item.class}"): a(href="#{item.href}" title="#{item.tooltip}") #{item.navTitle}
 
     .nav-blocks
-      a(class="nav-title #{anyItemSelected(reference)}" href="#{reference[0].href}" title="#{reference[0].tooltip}") Reference
-        img(class="inline-arrow-down-svg" src="/resources/images/icons/ic_keyboard_arrow_down_black_24px.svg")
-        
-      .nav-unordered-lists(class="#{isCollapsed(anyItemSelected(reference))}")
-        ul
-          each item in reference
-            li(class="nav-list-item #{item.class}"): a(href="#{item.href}" title="#{item.tooltip}") #{item.navTitle}
+      a(class="nav-title #{isApiReferenceSelected()}" href="#{reference[0].href}" title="#{reference[0].tooltip}") API Reference
 
 script.
   // Could put in appCtrl but only needed here and clear here
   (function scrollToSelectedLink() {
-    var sideNav = document.getElementsByClassName('side-nav')[0];    
+    var sideNav = document.getElementsByClassName('side-nav')[0];
     var link = sideNav.getElementsByClassName('is-selected')[0];
     if(link && link.offsetTop > window.innerHeight){
       sideNav.scrollTop = link.offsetTop - (window.innerHeight/2);
-      //alert("offsetTop: " + link.offsetTop + " side-nav top is " + sideNav.scrollTop);          
-    }    
+      //alert("offsetTop: " + link.offsetTop + " side-nav top is " + sideNav.scrollTop);
+    }
   })()

--- a/public/docs/dart/latest/_data.json
+++ b/public/docs/dart/latest/_data.json
@@ -39,13 +39,13 @@
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
     "intro": "A quick guide to Angular syntax.",
-    "reference": true
+    "reference": false
   },
 
   "glossary": {
     "title": "Glossary",
     "intro": "Brief definitions of the most important words in the Angular 2 vocabulary",
-    "reference": true
+    "reference": false
   },
 
   "resources": {

--- a/public/docs/dart/latest/glossary.jade
+++ b/public/docs/dart/latest/glossary.jade
@@ -1,14 +1,33 @@
 include _util-fns
-+includeShared('{ts}', 'intro')
-+includeShared('{ts}', 'a2')
-+includeShared('{ts}', 'b-c')
-+includeShared('{ts}', 'd1')
-+includeShared('{ts}', 'd2')
-+includeShared('{ts}', 'e1')
-+includeShared('{ts}', 'e2')
-+includeShared('{ts}', 'f-l')
-+includeShared('{ts}', 'm1')
-+includeShared('{ts}', 'n-s')
-+includeShared('{ts}', 't1')
+// From ts/glossary.jade, the folder ts/latest/_fragments is generated which contains a bunch of partial files.
+// These partials comprise the glossary,a subset of these partials should be used to generate the glossary for
+// __dart__ under BASICS.
+!=partial('../../ts/latest/_fragments/glossary-intro')
+!=partial('../../ts/latest/_fragments/glossary-a-2')
+!=partial('../../ts/latest/_fragments/glossary-b-c')
+!=partial('../../ts/latest/_fragments/glossary-d1')
+!=partial('../../ts/latest/_fragments/glossary-d2')
+!=partial('../../ts/latest/_fragments/glossary-e1')
+!=partial('../../ts/latest/_fragments/glossary-e2')
+!=partial('../../ts/latest/_fragments/glossary-f-l')
+!=partial('../../ts/latest/_fragments/glossary-m1')
+//!=partial('../../ts/latest/_fragments/glossary-m2') not needed in dart
+!=partial('../../ts/latest/_fragments/glossary-n-s')
+!=partial('../../ts/latest/_fragments/glossary-t1')
+//!=partial('../../ts/latest/_fragments/glossary-t2') notneeded in dart
+!=partial('../../ts/latest/_fragments/glossary-u-z')
 
-+includeShared('{ts}', 'u-z')
+// NOTE: (ericjim): I am almost certain these lines are doing nothing,
+// so instead I use `!=partial` to include the glossary fragments.
+//+includeShared('{ts}', 'intro')
+//+includeShared('{ts}', 'a2')
+//+includeShared('{ts}', 'b-c')
+//+includeShared('{ts}', 'd1')
+//+includeShared('{ts}', 'd2')
+//+includeShared('{ts}', 'e1')
+//+includeShared('{ts}', 'e2')
+//+includeShared('{ts}', 'f-l')
+//+includeShared('{ts}', 'm1')
+//+includeShared('{ts}', 'n-s')
+//+includeShared('{ts}', 't1')
+//+includeShared('{ts}', 'u-z')

--- a/public/docs/dart/latest/guide/_data.json
+++ b/public/docs/dart/latest/guide/_data.json
@@ -131,6 +131,6 @@
   "glossary": {
     "title": "Glossary",
     "intro": "Brief definitions of the most important words in the Angular 2 vocabulary",
-    "hide": true
+    "basics": true
   }
 }

--- a/public/docs/js/latest/_data.json
+++ b/public/docs/js/latest/_data.json
@@ -39,13 +39,13 @@
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
     "intro": "A quick guide to Angular syntax.",
-    "reference": true
+    "reference": false
   },
 
   "glossary": {
     "title": "Glossary",
     "intro": "Brief definitions of the most important words in the Angular 2 vocabulary",
-    "reference": true
+    "reference": false
   },
 
   "resources": {

--- a/public/docs/js/latest/glossary.jade
+++ b/public/docs/js/latest/glossary.jade
@@ -1,14 +1,35 @@
 include _util-fns
-+includeShared('{ts}', 'intro')
-+includeShared('{ts}', 'a2')
-+includeShared('{ts}', 'b-c')
-+includeShared('{ts}', 'd1')
-+includeShared('{ts}', 'd2')
-+includeShared('{ts}', 'e1')
-+includeShared('{ts}', 'e2')
-+includeShared('{ts}', 'f-l')
-+includeShared('{ts}', 'm1')
-+includeShared('{ts}', 'n-s')
-+includeShared('{ts}', 't1')
-+includeShared('{ts}', 't2')
-+includeShared('{ts}', 'u-z')
+// From ts/glossary.jade, the folder ts/latest/_fragments is generated which contains a bunch of partial files.
+// These partials comprise the glossary,a subset of these partials should be used to generate the glossary for
+// __javascript__ under BASICS.
+!=partial('../../ts/latest/_fragments/glossary-intro')
+//!=partial('../../ts/latest/_fragments/glossary-a-1') not needed in javascript
+!=partial('../../ts/latest/_fragments/glossary-a-2')
+!=partial('../../ts/latest/_fragments/glossary-b-c')
+!=partial('../../ts/latest/_fragments/glossary-d1')
+!=partial('../../ts/latest/_fragments/glossary-d2')
+!=partial('../../ts/latest/_fragments/glossary-e1')
+!=partial('../../ts/latest/_fragments/glossary-e2')
+!=partial('../../ts/latest/_fragments/glossary-f-l')
+!=partial('../../ts/latest/_fragments/glossary-m1')
+!=partial('../../ts/latest/_fragments/glossary-m2')
+!=partial('../../ts/latest/_fragments/glossary-n-s')
+!=partial('../../ts/latest/_fragments/glossary-t1')
+!=partial('../../ts/latest/_fragments/glossary-t2')
+!=partial('../../ts/latest/_fragments/glossary-u-z')
+
+// NOTE: (ericjim): I am almost certain these lines are doing nothing,
+// so instead I use `!=partial` to include the glossary fragments.
+//+includeShared('{ts}', 'intro')
+//+includeShared('{ts}', 'a2')
+//+includeShared('{ts}', 'b-c')
+//+includeShared('{ts}', 'd1')
+//+includeShared('{ts}', 'd2')
+//+includeShared('{ts}', 'e1')
+//+includeShared('{ts}', 'e2')
+//+includeShared('{ts}', 'f-l')
+//+includeShared('{ts}', 'm1')
+//+includeShared('{ts}', 'n-s')
+//+includeShared('{ts}', 't1')
+//+includeShared('{ts}', 't2')
+//+includeShared('{ts}', 'u-z')

--- a/public/docs/js/latest/guide/_data.json
+++ b/public/docs/js/latest/guide/_data.json
@@ -126,10 +126,9 @@
     "intro": "Angular 1 applications can be incrementally upgraded to Angular 2."
   },
 
-
   "glossary": {
     "title": "Glossary",
     "intro": "Brief definitions of the most important words in the Angular 2 vocabulary",
-    "hide": true
+    "basics": true
   }
 }

--- a/public/docs/ts/latest/_data.json
+++ b/public/docs/ts/latest/_data.json
@@ -39,13 +39,13 @@
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
     "intro": "A quick guide to Angular syntax.",
-    "reference": true
+    "reference": false
   },
 
   "glossary": {
     "title": "Glossary",
     "intro": "Brief definitions of the most important words in the Angular 2 vocabulary",
-    "reference": true
+    "reference": false
   },
 
   "resources": {

--- a/public/docs/ts/latest/guide/_data.json
+++ b/public/docs/ts/latest/guide/_data.json
@@ -127,6 +127,6 @@
   "glossary": {
     "title": "Glossary",
     "intro": "Brief definitions of the most important words in the Angular 2 vocabulary",
-    "hide": true
+    "basics": true
   }
 }

--- a/tools/api-builder/angular.io-package/templates/class.template.html
+++ b/tools/api-builder/angular.io-package/templates/class.template.html
@@ -148,7 +148,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 .div(layout="row" layout-xs="column" class="instance-members" class="row-margin")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Details
-  div(flex="80" flex-xs="100")
+  div(class="code-links" flex="80" flex-xs="100")
     {% for member in doc.members %}{% if not member.internal %}
     a(name="{$ member.name $}-anchor" class="anchor-offset")
     pre(class="prettyprint no-bg" ng-class="{ 'anchor-focused': appCtrl.isApiDocMemberFocused('{$ member.name $}') }")


### PR DESCRIPTION
### Changes
* Remove glossary and cheatsheet from REFERENCE
* Rename REFERENCE to API REFERENCE 
* Put Glossary under BASICS, for all three languages
* Add code links for Class Details

### Preview
* API REFERENCE https://sidenav-restyle.firebaseapp.com/docs/ts/latest/api/
* Glossary under Basics https://sidenav-restyle.firebaseapp.com/docs/ts/latest/guide/glossary.html
* Code links for class details: https://sidenav-restyle.firebaseapp.com/docs/ts/latest/api/core/Injector-class.html, for `NoProviderError` is now a link

@naomiblack @petebacondarwin 

CLOSES:
https://github.com/angular/angular.io/issues/1143