### PR TITLE
docs(class, decorator, directive, function, var) improve doc styling

### DIFF
--- a/tools/api-builder/angular.io-package/templates/class.template.html
+++ b/tools/api-builder/angular.io-package/templates/class.template.html
@@ -5,7 +5,7 @@
 {% block body %}
 include {$ relativePath(doc.path, '_util-fns') $}
 
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") What it does
   div(flex="80" flex-xs="100")
@@ -16,7 +16,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
       *Not yet documented*
     {% endif %}
 
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") How to use
   div(flex="80" flex-xs="100")
@@ -27,7 +27,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
       *Not yet documented*
     {% endif %}
 
-.div(class="row-margin" layout="row" layout-xs="column")
+.div(layout="row" layout-xs="column" class="ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Overview
   div(flex="80" flex-xs="100")
@@ -64,7 +64,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 {% block additional %}
 {% endblock %}
 
-.div(class="row-margin" layout="row" layout-xs="column")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Description
   div(class="code-links" flex="80" flex-xs="100")
@@ -75,7 +75,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
       *Not yet documented*
     {% endif %}
 
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Export
   div(flex="80" flex-xs="100")
@@ -85,7 +85,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 
 {%- if doc.decorators.length %}
 {% block annotations %}
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Annotations
   div(flex="80" flex-xs="100")
@@ -104,7 +104,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 {% endif %}
 
 {%- if doc.constructorDoc and not doc.constructorDoc.internal %}
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Constructor
   div(flex="80" flex-xs="100")
@@ -121,7 +121,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 {% endif %}
 
 {% if doc.statics.length %}
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Static Members
   div(class="code-links" flex="80" flex-xs="100")
@@ -145,7 +145,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
 {% endif %}
 
 {% if doc.members.length %}
-.div(layout="row" layout-xs="column" class="instance-members" class="row-margin")
+.div(layout="row" layout-xs="column" class="instance-members" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Details
   div(class="code-links" flex="80" flex-xs="100")

--- a/tools/api-builder/angular.io-package/templates/decorator.template.html
+++ b/tools/api-builder/angular.io-package/templates/decorator.template.html
@@ -4,20 +4,22 @@
 
 {% block body %}
 include {$ relativePath(doc.path, '_util-fns') $}
-.l-main-section
-  h2(class="decorator export")
-    pre.prettyprint
+
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
+  div(flex="20" flex-xs="100")
+    h2(class="h2-api-docs") Variable Export
+  div(class="code-links" flex="80" flex-xs="100")
+    pre.prettyprint.no-bg
       code.
         export {$ doc.name $}(options : {@link {$ doc.decoratorType $} {$ doc.decoratorType | escape $}}){$ returnType(doc.returnType) $}
+    :marked
+      {%- if doc.notYetDocumented %}
+      *Not yet documented*
+      {% else %}
+{$ doc.description | indentForMarkdown(6) | trimBlankLines $}
+      {% endif %}
 
-  p.location-badge.
-    exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
-    defined in {$ githubViewLink(doc) $}
+p.location-badge.
+  exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} } defined in {$ githubViewLink(doc) $}
 
-  :marked
-{%- if doc.notYetDocumented %}
-    *Not yet documented*
-{% else %}
-{$ doc.description | indentForMarkdown(4) | trimBlankLines $}
-{% endif -%}
 {% endblock %}

--- a/tools/api-builder/angular.io-package/templates/directive.template.html
+++ b/tools/api-builder/angular.io-package/templates/directive.template.html
@@ -8,7 +8,7 @@
 {% block additional -%}
 
 {%- if doc.directiveOptions.selector.split(',').length %}
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Selectors
   div(flex="80" flex-xs="100")
@@ -19,7 +19,7 @@
 {% endif %}
 
 {% if doc.outputs %}
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Outputs
   div(flex="80" flex-xs="100")
@@ -34,7 +34,7 @@
 {% endif %}
 
 {% if doc.inputs %}
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Inputs
   div(flex="80" flex-xs="100")
@@ -49,7 +49,7 @@
 {% endif %}
 
 {%- if doc.directiveOptions.exportAs %}
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Exported as
   div(flex="80" flex-xs="100")

--- a/tools/api-builder/angular.io-package/templates/function.template.html
+++ b/tools/api-builder/angular.io-package/templates/function.template.html
@@ -4,20 +4,22 @@
 
 {% block body %}
 include {$ relativePath(doc.path, '_util-fns') $}
-.l-main-section
-  h2(class="function export")
-    pre.prettyprint
+
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
+  div(flex="20" flex-xs="100")
+    h2(class="h2-api-docs") Class Export
+  div(class="code-links" flex="80" flex-xs="100")
+    pre.prettyprint.no-bg
       code.
         export {$ doc.name $}{$ paramList(doc.parameters) | indent(8, true) | trim $}{$ returnType(doc.returnType) $}
+    :marked
+      {%- if doc.notYetDocumented %}
+      *Not yet documented*
+      {% else %}
+{$ doc.description | indentForMarkdown(6) | trimBlankLines $}
+      {% endif %}
 
-  p.location-badge.
-    exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
-    defined in {$ githubViewLink(doc) $}
+p.location-badge.
+  exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} } defined in {$ githubViewLink(doc) $}
 
-  :marked
-{%- if doc.notYetDocumented %}
-    *Not Yet Documented*
-{% else %}
-{$ doc.description | indentForMarkdown(4) | trimBlankLines $}
-{% endif %}
 {% endblock %}

--- a/tools/api-builder/angular.io-package/templates/var.template.html
+++ b/tools/api-builder/angular.io-package/templates/var.template.html
@@ -5,22 +5,22 @@
 {% block body %}
 include {$ relativePath(doc.path, '_util-fns') $}
 
-.div(layout="row" layout-xs="column" class="row-margin")
+.div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Variable Export
-  div(flex="80" flex-xs="100")
+  div(class="code-links" flex="80" flex-xs="100")
     pre.prettyprint.no-bg
       code.
         export {$ doc.name $}{$ returnType(doc.returnType) $}
+    :marked
+      {%- if doc.notYetDocumented %}
+      *Not yet documented*
+      {% else %}
+{$ doc.description | indentForMarkdown(6) | trimBlankLines $}
+      {% endif %}
 
 p.location-badge.
   exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
   defined in {$ githubViewLink(doc) $}
 
-:marked
-{%- if doc.notYetDocumented %}
-    *Not Yet Documented*
-{% else %}
-{$ doc.description | indentForMarkdown(2) | trimBlankLines $}
-{% endif -%}
 {% endblock %}


### PR DESCRIPTION
### Changes
* Apply new api doc styles to decorators and functions
* Add ngcloak to the api doc sections, this should prevent unstylized flashing within the api doc
* Add some code links where not marked as links, they should look like links now (under Class Description, and in Variables)

### Preview

#### Decorators
* https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/Component-decorator.html
* https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/Pipe-decorator.html
* https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/Injectable-decorator.html

#### Functions
* https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/createNgZone-function.html
* https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/Class-function.html
* https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/provide-function.html

#### Variables
* https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/Host-var.html
* https://api-doc-styling-1.firebaseapp.com/docs/ts/latest/api/core/Inject-var.html
