### PR TITLE
[WIP] docs(style-guide): create examples

### DIFF
--- a/public/docs/_examples/style-guide/ts/02-07/app/hero.component.ts
+++ b/public/docs/_examples/style-guide/ts/02-07/app/hero.component.ts
@@ -1,0 +1,9 @@
+// #docregion
+import { Component } from 'angular2/core';
+
+// #docregion example
+@Component({
+  selector: 'toh-hero'
+})
+export class HeroComponent {}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/02-07/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/02-07/app/kitchen-sink.ts
@@ -1,0 +1,20 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+/*
+* HeroComponent is in the Tour of Heroes feature
+*/
+@Component({
+  selector: 'hero'
+})
+export class HeroComponent {}
+
+/*
+* UsersComponent is in an Admin feature
+*/
+@Component({
+  selector: 'users'
+})
+export class UsersComponent {}

--- a/public/docs/_examples/style-guide/ts/02-07/app/users.component.ts
+++ b/public/docs/_examples/style-guide/ts/02-07/app/users.component.ts
@@ -1,0 +1,9 @@
+// #docregion
+import { Component } from 'angular2/core';
+
+// #docregion example
+@Component({
+  selector: 'admin-users'
+})
+export class UsersComponent {}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/02-08/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/02-08/app/kitchen-sink.ts
@@ -1,0 +1,9 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+@Directive({
+  selector: '[validate]'
+})
+export class ValidateDirective {}

--- a/public/docs/_examples/style-guide/ts/02-08/app/validate.directive.ts
+++ b/public/docs/_examples/style-guide/ts/02-08/app/validate.directive.ts
@@ -1,0 +1,9 @@
+// #docregion
+import { Directive } from 'angular2/core';
+
+// #docregion example
+@Directive({
+  selector: '[tohValidate]'
+})
+export class ValidateDirective {}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-02/app/app.component.html
+++ b/public/docs/_examples/style-guide/ts/05-02/app/app.component.html
@@ -1,0 +1,2 @@
+<!-- #docregion -->
+<toh-hero-button></toh-hero-button>

--- a/public/docs/_examples/style-guide/ts/05-02/app/hero-button.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-02/app/hero-button.component.ts
@@ -1,0 +1,9 @@
+// #docregion
+import { Component } from 'angular2/core';
+
+// #docregion example
+@Component({
+  selector: 'toh-hero-button'
+})
+export class HeroButtonComponent {}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-02/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/05-02/app/kitchen-sink.ts
@@ -1,0 +1,9 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+@Component({
+  selector: 'tohHeroButton'
+})
+export class HeroButtonComponent {}

--- a/public/docs/_examples/style-guide/ts/05-03/app/app.component.html
+++ b/public/docs/_examples/style-guide/ts/05-03/app/app.component.html
@@ -1,0 +1,2 @@
+<!-- #docregion -->
+<toh-hero-button></toh-hero-button>

--- a/public/docs/_examples/style-guide/ts/05-03/app/hero-button.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-03/app/hero-button.component.ts
@@ -1,0 +1,9 @@
+// #docregion
+import { Component } from 'angular2/core';
+
+// #docregion example
+@Component({
+  selector: 'toh-hero-button'
+})
+export class HeroButtonComponent {}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-03/app/kitchen-sink.html
+++ b/public/docs/_examples/style-guide/ts/05-03/app/kitchen-sink.html
@@ -1,0 +1,3 @@
+<!-- #docregion -->
+<!-- AVOID THIS PATTERN -->
+<div tohHeroButton></div>

--- a/public/docs/_examples/style-guide/ts/05-03/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/05-03/app/kitchen-sink.ts
@@ -1,0 +1,9 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+@Component({
+  selector: '[tohHeroButton]'
+})
+export class HeroButtonComponent {}

--- a/public/docs/_examples/style-guide/ts/05-04/app/heroes.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-04/app/heroes.component.ts
@@ -1,0 +1,14 @@
+// #docregion
+import { Component } from 'angular2/core';
+
+// #docregion example
+@Component({
+  selector: 'toh-heroes',
+  templateUrl: 'heroes.component.html',
+  styleUrls:  ['heroes.component.css']
+})
+export class HeroesComponent implements OnInit {
+  heroes: Hero[];
+  selectedHero: Hero;
+}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-04/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/05-04/app/kitchen-sink.ts
@@ -1,0 +1,54 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+@Component({
+  selector: 'toh-heroes',
+  template: `
+    <div>
+      <h2>My Heroes</h2>
+      <ul class="heroes">
+        <li *ngFor="#hero of heroes">
+          <span class="badge">{{hero.id}}</span> {{hero.name}}
+        </li>
+      </ul>
+      <div *ngIf="selectedHero">
+        <h2>{{selectedHero.name | uppercase}} is my hero</h2>
+      </div>
+    </div>
+  `,
+  styleUrls:  [`
+    .heroes {
+      margin: 0 0 2em 0; list-style-type: none; padding: 0; width: 15em;
+    }
+    .heroes li {
+      cursor: pointer;
+      position: relative;
+      left: 0;
+      background-color: #EEE;
+      margin: .5em;
+      padding: .3em 0;
+      height: 1.6em;
+      border-radius: 4px;
+    }
+    .heroes .badge {
+      display: inline-block;
+      font-size: small;
+      color: white;
+      padding: 0.8em 0.7em 0 0.7em;
+      background-color: #607D8B;
+      line-height: 1em;
+      position: relative;
+      left: -1px;
+      top: -4px;
+      height: 1.8em;
+      margin-right: .8em;
+      border-radius: 4px 0 0 4px;
+    }
+  `]
+})
+export class HeroesComponent implements OnInit {
+  heroes: Hero[];
+  selectedHero: Hero;
+}

--- a/public/docs/_examples/style-guide/ts/05-12/app/button.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-12/app/button.component.ts
@@ -1,0 +1,13 @@
+// #docregion
+import { Component, Input, Output, EventEmitter } from 'angular2/core';
+
+// #docregion example
+@Component({
+  selector: 'toh-button',
+  template: `...`
+})
+export class ButtonComponent {
+  @Output() change = new EventEmitter<any>();
+  @Input() label: string;
+}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-12/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/05-12/app/kitchen-sink.ts
@@ -1,0 +1,19 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+@Component({
+  selector: 'toh-button',
+  template: `...`,
+  inputs: [
+    'label'
+  ],
+  outputs: [
+    'change'
+  ]
+})
+export class ButtonComponent {
+  change = new EventEmitter<any>();
+  label: string;
+}

--- a/public/docs/_examples/style-guide/ts/05-13/app/app.component.html
+++ b/public/docs/_examples/style-guide/ts/05-13/app/app.component.html
@@ -1,0 +1,3 @@
+<!-- #docregion -->
+<toh-button label="OK" (change)="doSomething()">
+</toh-button>

--- a/public/docs/_examples/style-guide/ts/05-13/app/button.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-13/app/button.component.ts
@@ -1,0 +1,13 @@
+// #docregion
+import { Component, Input, Output, EventEmitter } from 'angular2/core';
+
+// #docregion example
+@Component({
+  selector: 'toh-button',
+  template: `...`
+})
+export class ButtonComponent {
+  @Output() change = new EventEmitter<any>();
+  @Input() label: string;
+}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-13/app/kitchen-sink.html
+++ b/public/docs/_examples/style-guide/ts/05-13/app/kitchen-sink.html
@@ -1,0 +1,4 @@
+<!-- #docregion -->
+<!-- AVOID THIS PATTERN -->
+<toh-button labelAttribute="OK" (changeEvent)="doSomething()">
+</toh-button>

--- a/public/docs/_examples/style-guide/ts/05-13/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/05-13/app/kitchen-sink.ts
@@ -1,0 +1,13 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+@Component({
+  selector: 'toh-button',
+  template: `...`
+})
+export class ButtonComponent {
+  @Output('changeEvent') change = new EventEmitter<any>();
+  @Input('labelAttribute') label: string;
+}

--- a/public/docs/_examples/style-guide/ts/05-14/app/toast.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-14/app/toast.component.ts
@@ -1,0 +1,40 @@
+// #docregion
+import { Component, OnInit } from 'angular2/core';
+
+@Component({
+  selector: 'my-toast',
+  template: `...`
+})
+// #docregion example
+export class ToastComponent implements OnInit {
+  // public properties
+  message: string;
+  title: string;
+  // private fields
+  private defaults = {
+    title: '',
+    message: 'May the Force be with You'
+  };
+  private toastElement: any;
+  // public methods
+  activate(message = this.defaults.message, title = this.defaults.title) {
+    this.title = title;
+    this.message = message;
+    this.show();
+  }
+  ngOnInit() {
+    this.toastElement = document.getElementById('toh-toast');
+  }
+  // private methods
+  private hide() {
+    this.toastElement.style.opacity = 0;
+    window.setTimeout(() => this.toastElement.style.zIndex = 0, 400);
+  }
+  private show() {
+    console.log(this.message);
+    this.toastElement.style.opacity = 1;
+    this.toastElement.style.zIndex = 9999;
+    window.setTimeout(() => this.hide(), 2500);
+  }
+}
+// #endregion example

--- a/public/docs/_examples/style-guide/ts/05-15/app/hero-list.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-15/app/hero-list.component.ts
@@ -1,0 +1,22 @@
+// #docregion
+import { Component, OnInit } from 'angular2/core';
+
+@Component({
+  selector: 'toh-hero-list',
+  template: `...`
+})
+// #docregion example
+export class HeroListComponent implements OnInit {
+  heroes: Hero[];
+  constructor(private heroService: HeroService) {}
+  getHeros() {
+    this.heroes = [];
+    this.heroService.getHeros()
+      .subscribe(heroes => this.heroes = heroes);
+  }
+  ngOnInit() {
+    this.getHeros();
+  }
+}
+// #enddocregion example
+

--- a/public/docs/_examples/style-guide/ts/05-15/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/05-15/app/kitchen-sink.ts
@@ -1,0 +1,28 @@
+// #docplaster
+// #docregion example
+/**
+ * AVOID THIS PATTERN
+ */
+// #enddocregion example
+
+@Component({
+  selector: 'toh-hero-list',
+  template: `...`
+})
+// #docregion example
+export class HeroListComponent implements OnInit {
+  heroes: Hero[];
+  constructor(private http: Http) {}
+  getHeros() {
+    this.heroes = [];
+    this.http.get(heroesUrl)
+      .map((response: Response) => <Hero[]>response.json().data)
+      .catch(this.exceptionService.catchBadResponse)
+      .finally(() => this.spinnerService.hide())
+      .subscribe(heroes => this.heroes = heroes);
+  }
+  ngOnInit() {
+    this.getHeros();
+  }
+}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-16/app/app.component.html
+++ b/public/docs/_examples/style-guide/ts/05-16/app/app.component.html
@@ -1,0 +1,2 @@
+<!-- #docregion -->
+<toh-hero (savedTheDay)="onSavedTheDay($event)"></toh-hero>

--- a/public/docs/_examples/style-guide/ts/05-16/app/hero.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-16/app/hero.component.ts
@@ -1,0 +1,14 @@
+// #docregion
+import { Component, Output, EventEmitter } from 'angular2/core';
+
+@Component({
+  selector: 'toh-hero',
+  template: `...`
+})
+// #docregion example
+export class HeroComponent {
+  @Output() savedTheDay = new EventEmitter<boolean>();
+}
+// #enddocregion example
+
+

--- a/public/docs/_examples/style-guide/ts/05-16/app/kitchen-sink.html
+++ b/public/docs/_examples/style-guide/ts/05-16/app/kitchen-sink.html
@@ -1,0 +1,3 @@
+<!-- #docregion -->
+<!-- AVOID THIS PATTERN -->
+<toh-hero (onSavedTheDay)="onSavedTheDay($event)"></toh-hero>

--- a/public/docs/_examples/style-guide/ts/05-16/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/05-16/app/kitchen-sink.ts
@@ -1,0 +1,16 @@
+// #docplaster
+// #docregion example
+/**
+ * AVOID THIS PATTERN
+ */
+// #enddocregion example
+
+@Component({
+  selector: 'toh-hero',
+  template: `...`
+})
+// #docregion example
+export class HeroComponent {
+  @Output() onSavedTheDay = new EventEmitter<boolean>();
+}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-17/app/heroes-list.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-17/app/heroes-list.component.ts
@@ -1,0 +1,22 @@
+// #docregion
+import { Component } from 'angular2/core';
+
+// #docregion example
+@Component({
+  selector: 'toh-heroes-list',
+  template: `
+    <section>
+      Our list of heroes:
+      <hero-profile *ngFor="#hero of heroes" [hero]="hero">
+      </hero-profile>
+      Total powers: {{totalPowers}}<br>
+      Average power: {{avgPower}}
+    </section>
+  `
+})
+export class HeroesListComponent {
+  heroes: Hero[];
+  totalPowers: number;
+  avgPower: number;
+}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/05-17/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/05-17/app/kitchen-sink.ts
@@ -1,0 +1,21 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+@Component({
+  selector: 'toh-heroes-list',
+  template: `
+    <section>
+      Our list of heroes:
+      <hero-profile *ngFor="#hero of heroes" [hero]="hero">
+      </hero-profile>
+      Total powers: {{totalPowers}}<br>
+      Average power: {{totalPowers / heroes.length}}
+    </section>
+  `
+})
+export class HeroesListComponent {
+  heroes: Hero[];
+  totalPowers: number;
+}

--- a/public/docs/_examples/style-guide/ts/07-01/app/hero.service.ts
+++ b/public/docs/_examples/style-guide/ts/07-01/app/hero.service.ts
@@ -1,0 +1,13 @@
+// #docregion
+import { Injectable } from 'angular2/core';
+import { Http, Response } from 'angular2/http';
+
+import { Hero } from './hero';
+
+@Injectable()
+export class HeroService {
+  getHeroes() {
+    return this.http.get('api/heroes')
+      .map((response: Response) => <Hero[]>response.json().data)
+  }
+}

--- a/public/docs/_examples/style-guide/ts/07-03/app/app.component.ts
+++ b/public/docs/_examples/style-guide/ts/07-03/app/app.component.ts
@@ -1,0 +1,15 @@
+// #docregion
+import { Component } from 'angular2/core';
+
+import { HeroListComponent } from './heroes/hero-list.component';
+import { HeroService } from './shared/hero.service';
+
+@Component({
+  selector: 'toh-app',
+  template: `
+      <toh-heroes></toh-heroes>
+    `,
+  directives: [HeroListComponent],
+  providers: [HeroService]
+})
+export class AppComponent {}

--- a/public/docs/_examples/style-guide/ts/07-03/app/hero-list.component.ts
+++ b/public/docs/_examples/style-guide/ts/07-03/app/hero-list.component.ts
@@ -1,0 +1,21 @@
+// #docregion
+import { Component, OnInit } from 'angular2/core';
+
+import { HeroService } from './shared/hero.service';
+import { Hero } from './shared/hero';
+
+@Component({
+  selector: 'toh-heroes',
+  template: `
+      <pre>{{heroes | json}}</pre>
+    `
+})
+export class HeroListComponent implements OnInit{
+  heroes: Hero[] = [];
+
+  constructor(private heroService: HeroService) {}
+  
+  ngOnInit() {
+    this.heroService.getHeroes().then(heroes => this.heroes = heroes);
+  }
+}

--- a/public/docs/_examples/style-guide/ts/07-04/app/hero-arena.service.ts
+++ b/public/docs/_examples/style-guide/ts/07-04/app/hero-arena.service.ts
@@ -1,0 +1,11 @@
+// #docregion
+import { Injectable } from 'angular2/core';
+
+// #docregion example
+@Injectable()
+export class HeroArena {
+  constructor(
+    private heroFactory: HeroFactory,
+    private http: Http) {}
+}
+// #enddocregion example

--- a/public/docs/_examples/style-guide/ts/07-04/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/07-04/app/kitchen-sink.ts
@@ -1,0 +1,10 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+export class HeroArena {
+  constructor(
+      @Inject(HeroFactory) private heroFactory: HeroFactory,
+      @Inject(Http) private http: Http) {}
+}

--- a/public/docs/_examples/style-guide/ts/09-01/app/button.component.ts
+++ b/public/docs/_examples/style-guide/ts/09-01/app/button.component.ts
@@ -1,0 +1,12 @@
+// #docregion
+import {Component, OnInit} from 'angular2/core';
+
+@Component({
+  selector: 'toh-button',
+  template: `<button>OK<button>`
+})
+export class ButtonComponent implements OnInit {
+  ngOnInit() {
+    console.log('The component is initialized');
+  }
+}

--- a/public/docs/_examples/style-guide/ts/09-01/app/kitchen-sink.ts
+++ b/public/docs/_examples/style-guide/ts/09-01/app/kitchen-sink.ts
@@ -1,0 +1,16 @@
+// #docregion
+/**
+ * AVOID THIS PATTERN
+ */
+
+import { Component } from 'angular2/core';
+
+@Component({
+  selector: 'toh-button',
+  template: `<button>OK<button>`
+})
+export class ButtonComponent {
+  onInit() { // mispelled
+    console.log('The component is initialized');
+  }
+}

--- a/public/docs/_examples/style-guide/ts/10-01/app/app.component.ts
+++ b/public/docs/_examples/style-guide/ts/10-01/app/app.component.ts
@@ -1,0 +1,23 @@
+// #docregion
+import { Component } from 'angular2/core';
+import { RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS } from 'angular2/router';
+
+import { HeroesComponent, HeroService } from './+heroes';
+import { DashboardComponent } from './+dashboard';
+import { NavComponent } from './layout/nav.component';
+
+@Component({
+  selector: 'toh-app',
+  templateUrl: 'app/app.component.html',
+  styleUrls: ['app/app.component.css'],
+  directives: [ROUTER_DIRECTIVES, NavComponent],
+  providers: [
+    ROUTER_PROVIDERS,
+    HeroService
+  ]
+})
+@RouteConfig([
+  { path: '/dashboard', name: 'Dashboard', component: DashboardComponent, useAsDefault: true },
+  { path: '/heroes/...', name: 'Heroes', component: HeroesComponent },
+])
+export class AppComponent {}


### PR DESCRIPTION
This PR creates all the examples in disk so when we finish the style guide, we can connect both.

I am creating the obvious examples until we figure out what to do with the complex ones (the ones that are incomplete).

So far I am creating a `kitchen-sink` file with the *avoid* part and then individual files for each *recommended* file.

I am not really sure if I need to put the `/* recommended */` comment at the top of each of the good ones or not.

I will update this PR with all the examples and rebase it with new versions of the style guide comes out or  if we change some conventions in how to create this files.