### PR TITLE
fix(badge align): fix alignment of badges on smaller screens

### DIFF
--- a/public/_includes/_hero.jade
+++ b/public/_includes/_hero.jade
@@ -8,8 +8,9 @@ if current.path[4] && current.path[3] == 'api'
   - var textFormat = 'is-standard-case'
 
 header(class="hero background-sky")
-  h1(class="hero-title text-display-1 #{textFormat}") #{headerTitle}
-  if useBadges
+  div(class="inner-header")
+    h1(class="hero-title text-display-1 #{textFormat}") #{headerTitle}
+    if useBadges
     span(class="badges")
       if docType
         span(class="status-badge").

--- a/public/resources/css/module/_hero.scss
+++ b/public/resources/css/module/_hero.scss
@@ -35,10 +35,6 @@ $hero-padding: ($unit * 10) ($unit * 6) ($unit * 7);
   screen and (max-width: $tablet-breakpoint) {
     height: auto;
     padding-top: 40px;
-
-    .badges {
-      margin-top: $unit * 6;
-    }
   }
 
   &.is-large {
@@ -53,8 +49,18 @@ $hero-padding: ($unit * 10) ($unit * 6) ($unit * 7);
     }
   }
 
+  .inner-header {
+    display: flex;
+    justify-items: center;
+    flex-wrap: wrap;
+
+    @media screen and (max-width: 599px) {
+      margin: ($unit * 6) 0px 0px 0px;
+    }
+  }
+
   .badges {
-    padding-left: 8px;
+    margin-top: 4px;
 
     .status-badge {
       color: #0143A3;
@@ -73,10 +79,6 @@ $hero-padding: ($unit * 10) ($unit * 6) ($unit * 7);
   }
 
   @media screen and (max-width: 599px) {
-    .badges {
-      margin-top: $unit;
-      padding-left: 0;
-    }
 
     .hero-title-with-badges {
       margin-bottom: $unit * 2;
@@ -92,6 +94,7 @@ $hero-padding: ($unit * 10) ($unit * 6) ($unit * 7);
     display: inline; // title will be inline with badges
     text-transform: uppercase;
     margin: 0;
+    margin-right: 8px;
     opacity: .87;
 
     &.is-standard-case {
@@ -101,7 +104,8 @@ $hero-padding: ($unit * 10) ($unit * 6) ($unit * 7);
     @media handheld and (max-width: $phone-breakpoint),
     screen and (max-device-width: $phone-breakpoint),
     screen and (max-width: $tablet-breakpoint) {
-      margin: ($unit * 6) 0px 0px 0px;
+      // reduce size of api doc title on small screens, prevents cut text on long titles
+      font-size: 28px;
     }
   }
 


### PR DESCRIPTION
### Changes
* Badges should align more with the hero title of every api doc page
* Badges should re-align properly when viewed on smaller screens
* Reduce hero title in smaller screens to prevent cut off text

### Preview
Try this on your browser, and resize the the window for the full effect. It should work in both Chrome and Safari.
* https://badges-everywhere.firebaseapp.com/docs/ts/latest/api/common/NgSwitch-directive.html (Stable for demonstration purposes only, not actually in the docs)
* https://badges-everywhere.firebaseapp.com/docs/ts/latest/api/common/NgPluralCase-directive.html (Single badge)
* https://badges-everywhere.firebaseapp.com/docs/ts/latest/api/common/FORM_BINDINGS-let.html (two badges)

### Comments
I thought I had this fix from before, but some change somewhere affected the badges, hopefully this is a more permanent solution. @petebacondarwin @naomiblack 

CLOSES:
https://github.com/angular/angular.io/issues/1176
