### PR TITLE
chore(dart): updating to beta.16

### DIFF
--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/dependency-injection/dart/lib/car/car_injector.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/car/car_injector.dart
@@ -7,20 +7,20 @@ import 'car.dart';
 
 //#docregion injector
 Car useInjector() {
-  Injector injector;
+  ReflectiveInjector injector;
   //#enddocregion injector
 
   /*
 //#docregion injector-no-new
-  // Cannot 'new' an Injector like this!
-  var injector = new Injector([Car, Engine, Tires, Logger]);
+  // Cannot 'new' an ReflectiveInjector like this!
+  var injector = new ReflectiveInjector([Car, Engine, Tires, Logger]);
 //#enddocregion injector-no-new
 */
 
   //#docregion injector
 
   //#docregion injector-create-and-call
-  injector = Injector.resolveAndCreate([Car, Engine, Tires, Logger]);
+  injector = ReflectiveInjector.resolveAndCreate([Car, Engine, Tires, Logger]);
   //#docregion injector-call
   var car = injector.get(Car);
   //#enddocregion injector-call

--- a/public/docs/_examples/dependency-injection/dart/lib/injector_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/injector_component.dart
@@ -31,11 +31,12 @@ class InjectorComponent {
   Hero hero;
 
   String get rodent {
-    var rous = _injector.getOptional(ROUS);
-    if (rous != null) {
-      throw new Exception('Aaaargh!');
+    try {
+      _injector.get(ROUS);
+    } on NoProviderError {
+      return "R.O.U.S.'s? I don't think they exist!";
     }
-    return "R.O.U.S.'s? I don't think they exist!";
+    throw new Exception('Aaaargh!');
   }
 
   InjectorComponent(this._injector) {

--- a/public/docs/_examples/dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/displaying-data/dart/pubspec.yaml
+++ b/public/docs/_examples/displaying-data/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/pipes/dart/lib/exponential_strength_pipe.dart
+++ b/public/docs/_examples/pipes/dart/lib/exponential_strength_pipe.dart
@@ -3,24 +3,18 @@ import 'dart:math' as math;
 import 'package:angular2/angular2.dart';
 
 /*
-* Raise the value exponentially
-* Takes a value that defaults to 0 and an exponent argument that defaults to 1.
-* Checks for value to be a string or number.
-* Usage:
-*   value | exponentialStrength:exponent
-* Example:
-*   {{ 2 |  exponentialStrength:10}}
-*   formats to: 1024
-*/
-
+ * Raise the value exponentially
+ * Takes an exponent argument that defaults to 1.
+ * Usage:
+ *   value | exponentialStrength:exponent
+ * Example:
+ *   {{ 2 |  exponentialStrength:10}}
+ *   formats to: 1024
+ */
 @Pipe(name: 'exponentialStrength')
-@Injectable()
+@Injectable() // FIXME(chalin): unnecessary?
 class ExponentialStrengthPipe extends PipeTransform {
-  transform(dynamic value, [List<dynamic> args]) {
-    var v = int.parse(value.toString(), onError: (source) => 0);
-    var p = args.isEmpty
-        ? 1
-        : int.parse(args.first.toString(), onError: (source) => 1);
-    return math.pow(v, p);
-  }
+  num transform(num value, String exponent) =>
+    math.pow(value,
+      num.parse(exponent, onError: (_) => 1));
 }

--- a/public/docs/_examples/pipes/dart/lib/fetch_json_pipe.dart
+++ b/public/docs/_examples/pipes/dart/lib/fetch_json_pipe.dart
@@ -1,18 +1,22 @@
+// #docregion
 import 'dart:html';
 import 'dart:async';
 import 'dart:convert';
 
 import 'package:angular2/angular2.dart';
 
+// #docregion pipe-metadata
 @Pipe(name: 'fetch', pure: false)
-@Injectable()
+// #enddocregion pipe-metadata
+@Injectable() // FIXME(chalin): unnecessary?
 class FetchJsonPipe extends PipeTransform {
   dynamic _fetchedValue;
   Future<dynamic> _fetchPromise;
-  transform(dynamic value, [List<dynamic> args]) {
+
+  transform(String url) {
     if (_fetchPromise == null) {
       _fetchPromise = new Future(() async {
-        _fetchedValue = JSON.decode(await HttpRequest.getString(value));
+        _fetchedValue = JSON.decode(await HttpRequest.getString(url));
       });
     }
     return _fetchedValue;

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/quickstart/dart/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
 # #enddocregion no-rewriter
   dart_to_js_script_rewriter: ^1.0.1

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-1/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-1/dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-2/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-2/dart/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-3/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-3/dart/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-4/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-4/dart/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-5/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-5/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.16
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/dart/latest/_data.json
+++ b/public/docs/dart/latest/_data.json
@@ -3,7 +3,7 @@
     "icon": "home",
     "title": "Angular Docs",
     "menuTitle": "Docs Home",
-    "banner": "Welcome to <b>angular.io/dart</b>! The current Angular 2 release is <b>beta.15</b>. Consult the <a href='https://github.com/angular/angular/blob/master/CHANGELOG.md' target='_blank'>Change Log</a> about recent enhancements, fixes, and breaking changes."
+    "banner": "Welcome to <b>angular.io/dart</b>! The current Angular 2 release is <b>beta.16</b>. Consult the <a href='https://github.com/angular/angular/blob/master/CHANGELOG.md' target='_blank'>Change Log</a> about recent enhancements, fixes, and breaking changes."
   },
 
   "quickstart": {

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -41,7 +41,7 @@ p.
     specify the angular2 and browser packages as dependencies,
     as well as the angular2 transformer.
     Angular 2 is still changing, so provide an exact version:
-    <b>2.0.0-beta.15</b>.
+    <b>2.0.0-beta.16</b>.
 
   +makeExample('quickstart/dart/pubspec.yaml', 'no-rewriter', 'pubspec.yaml')
 


### PR DESCRIPTION
Updated docs and samples to beta.16.

For this first time, among other things, I payed particular attention to the changes that were made on the `ts` side of things (https://github.com/angular/angular.io/pull/1178). Since I wrote it up in my notes, here is the check list of `ts` updates with notes about how there might be corresponding changes on the Dart side:

- public/docs/_examples/cb-dependency-injection/ts/app/main.ts
- public/docs/_examples/cb-ts-to-js/ts/app/main.ts
  - cb not in Dart docs yet.
- public/docs/_examples/dependency-injection/ts/app/car/car-injector.ts
- public/docs/_examples/dependency-injection/ts/app/injector.component.ts
  - Updated Dart example code to avoid null argument.
- public/docs/_examples/homepage-hello-world/ts/index.1.html
- public/docs/_examples/homepage-tabs/ts/index.1.html
- public/docs/_examples/homepage-todo/ts/index.1.html
- public/docs/_examples/package.json
  - N/A for Dart.
- public/docs/_examples/pipes/ts/app/app.component.html
- public/docs/_examples/pipes/ts/app/app.component.ts
- public/docs/_examples/pipes/ts/app/exponential-strength.pipe.ts
- public/docs/_examples/pipes/ts/app/fetch-json.pipe.ts
- public/docs/_examples/pipes/ts/app/random-pipe.component.ts
  - Dart version of sample code is incomplete, but did run in beta.15.
  - Example no longer runs, see https://github.com/angular/angular/issues/8258
- public/docs/_examples/quickstart/js/package.1.json
- public/docs/_examples/quickstart/ts/package.1.json
- public/docs/_examples/router/ts/app/main.2.ts
- public/docs/_examples/testing/ts/app/mock-router.ts
  - N/A for Dart.
- public/docs/js/latest/_data.json
- public/docs/ts/latest/_data.json
  - Dart equivalent updated.
- public/docs/ts/latest/guide/dependency-injection.jade
  - No need to update since it imports the TS version.
- public/docs/ts/latest/guide/pipes.jade
  - Not in Dart prose yet.
- tools/plunker-builder/indexHtmlTranslator.js
  - N/A for Dart.