### PR TITLE
chore(not yet documented): remove placeholder to reduce noise

### DIFF
--- a/public/resources/css/module/_api.scss
+++ b/public/resources/css/module/_api.scss
@@ -98,6 +98,7 @@ input.api-filter {
 
   .h2-api-docs {
     font-size: 15px !important;
+    line-height: 20px;
     text-transform: uppercase !important;
     color: #78909C !important;
   }
@@ -137,6 +138,13 @@ input.api-filter {
     }
   }
 
+  .openParens {
+    margin-top: 15px;
+  }
+
+  .endParens {
+    margin-bottom: 20px !important;
+  }
 
   p {
 

--- a/tools/api-builder/angular.io-package/templates/class.template.html
+++ b/tools/api-builder/angular.io-package/templates/class.template.html
@@ -31,7 +31,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Overview
   div(flex="80" flex-xs="100")
-    code(class="no-bg api-doc-code") class {$ doc.name $} {
+    code(class="no-bg api-doc-code openParens") class {$ doc.name $} {
 
     {% if doc.statics.length %}
     .div(layout="column")
@@ -58,7 +58,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
           code(class="api-doc-code") {$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(member.returnType) $}
       {% endif %}{% endfor %}
     {% endif %}
-    p.selector
+    p(class="selector endParens")
       code(class="api-doc-code no-bg") }
 
 {% block additional %}
@@ -71,8 +71,6 @@ include {$ relativePath(doc.path, '_util-fns') $}
     :marked
     {%- if doc.description.length > 2 %}
 {$ doc.description | indentForMarkdown(6) | trimBlankLines $}
-    {% else %}
-      *Not yet documented*
     {% endif %}
 
 .div(layout="row" layout-xs="column" class="row-margin ng-cloak")
@@ -94,9 +92,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
         code(class="api-doc-code")
           @{$ decorator.name $}{$ paramList(decorator.arguments) | indent(10, false) $}
       :marked
-      {%- if decorator.notYetDocumented %}
-        *Not yet documented*
-      {% else %}
+      {%- if not decorator.notYetDocumented %}
         {$ decorator.description | indentForMarkdown(8) | trimBlankLines $}
       {% endif %}
     {% endfor %}
@@ -113,9 +109,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
       code(class="api-doc-code").
         {$ doc.constructorDoc.name $}{$ paramList(doc.constructorDoc.parameters) | indent(8, false) | trim $}
     :marked
-      {%- if doc.constructorDoc.notYetDocumented %}
-      *Not yet documented*
-      {% else %}
+      {%- if not doc.constructorDoc.notYetDocumented %}
 {$ doc.constructorDoc.description | indentForMarkdown(6) | replace('### Example', '') | replace('## Example', '') | replace('# Example', '') | trimBlankLines $}
       {% endif %}
 {% endif %}
@@ -131,9 +125,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
       code(class="api-doc-code").
         {$ member.name $}{$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(member.returnType) $}
     :marked
-      {%- if member.notYetDocumented %}
-      *Not yet documented*
-      {% else %}
+      {%- if not member.notYetDocumented %}
 {$ member.description | indentForMarkdown(6) | replace('### Example', '') | replace('## Example', '') | replace('# Example', '') | trimBlankLines $}
       {% endif %}
 
@@ -156,9 +148,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
         {$ member.name $}{$ paramList(member.parameters) | indent(8, false) | trim $}{$ returnType(member.returnType) $}
 
     :marked
-      {%- if member.notYetDocumented %}
-      *Not yet documented*
-      {% else %}
+      {%- if not member.notYetDocumented %}
 {$ member.description | indentForMarkdown(6) | replace('### Example', '') | replace('## Example', '') | replace('# Example', '') | trimBlankLines $}
       {% endif -%}
 

--- a/tools/api-builder/angular.io-package/templates/decorator.template.html
+++ b/tools/api-builder/angular.io-package/templates/decorator.template.html
@@ -13,9 +13,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
       code.
         export {$ doc.name $}(options : {@link {$ doc.decoratorType $} {$ doc.decoratorType | escape $}}){$ returnType(doc.returnType) $}
     :marked
-      {%- if doc.notYetDocumented %}
-      *Not yet documented*
-      {% else %}
+      {%- if not doc.notYetDocumented %}
 {$ doc.description | indentForMarkdown(6) | trimBlankLines $}
       {% endif %}
 

--- a/tools/api-builder/angular.io-package/templates/function.template.html
+++ b/tools/api-builder/angular.io-package/templates/function.template.html
@@ -13,9 +13,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
       code.
         export {$ doc.name $}{$ paramList(doc.parameters) | indent(8, true) | trim $}{$ returnType(doc.returnType) $}
     :marked
-      {%- if doc.notYetDocumented %}
-      *Not yet documented*
-      {% else %}
+      {%- if not doc.notYetDocumented %}
 {$ doc.description | indentForMarkdown(6) | trimBlankLines $}
       {% endif %}
 

--- a/tools/api-builder/angular.io-package/templates/var.template.html
+++ b/tools/api-builder/angular.io-package/templates/var.template.html
@@ -13,9 +13,7 @@ include {$ relativePath(doc.path, '_util-fns') $}
       code.
         export {$ doc.name $}{$ returnType(doc.returnType) $}
     :marked
-      {%- if doc.notYetDocumented %}
-      *Not yet documented*
-      {% else %}
+      {%- if not doc.notYetDocumented %}
 {$ doc.description | indentForMarkdown(6) | trimBlankLines $}
       {% endif %}
 

--- a/tools/api-builder/docs-package/processors/addNotYetDocumentedProperty.js
+++ b/tools/api-builder/docs-package/processors/addNotYetDocumentedProperty.js
@@ -23,6 +23,7 @@ module.exports = function addNotYetDocumentedProperty(EXPORT_DOC_TYPES, log, cre
         }
 
         if (doc.notYetDocumented) {
+          // TODO: (ericjim) should I remove this?
           log.warn(createDocMessage("Not yet documented", doc));
         }
       });


### PR DESCRIPTION
### Changes
* Remove `Not yet documented` from the api doc. With the exception of `how to use` and `what it does`

### Preview
* https://remove-not-yet-doc.firebaseapp.com/docs/ts/latest/api/
* ^Pick any api doc page (example: https://remove-not-yet-doc.firebaseapp.com/docs/ts/latest/api/common/AbstractControl-class.html)
* NOTE: @naomiblack you'll notice that `Class Description` is empty that's because it's an empty doc thing in the angular2 repo https://github.com/angular/angular/blob/2.0.0-beta.14/modules/angular2/src/common/forms/model.ts#L50-L252, the solution here is to remove that empty block in angular2 or actually document it.

CLOSES:
https://github.com/angular/angular.io/issues/1109

@naomiblack  @petebacondarwin 