### PR TITLE
chore(dart): pipes example rolled back to beta.15

### DIFF
--- a/public/docs/_examples/pipes/dart/lib/exponential_strength_pipe.dart
+++ b/public/docs/_examples/pipes/dart/lib/exponential_strength_pipe.dart
@@ -12,9 +12,12 @@ import 'package:angular2/angular2.dart';
  *   formats to: 1024
  */
 @Pipe(name: 'exponentialStrength')
-@Injectable() // FIXME(chalin): unnecessary?
 class ExponentialStrengthPipe extends PipeTransform {
-  num transform(num value, String exponent) =>
-    math.pow(value,
-      num.parse(exponent, onError: (_) => 1));
+  transform(dynamic value, [List<dynamic> args]) {
+    var v = int.parse(value.toString(), onError: (source) => 0);
+    var p = args.isEmpty
+        ? 1
+        : int.parse(args.first.toString(), onError: (source) => 1);
+    return math.pow(v, p);
+  }
 }

--- a/public/docs/_examples/pipes/dart/lib/fetch_json_pipe.dart
+++ b/public/docs/_examples/pipes/dart/lib/fetch_json_pipe.dart
@@ -8,12 +8,11 @@ import 'package:angular2/angular2.dart';
 // #docregion pipe-metadata
 @Pipe(name: 'fetch', pure: false)
 // #enddocregion pipe-metadata
-@Injectable() // FIXME(chalin): unnecessary?
 class FetchJsonPipe extends PipeTransform {
   dynamic _fetchedValue;
   Future<dynamic> _fetchPromise;
 
-  transform(String url) {
+  transform(dynamic url, [List<dynamic> args]) {
     if (_fetchPromise == null) {
       _fetchPromise = new Future(() async {
         _fetchedValue = JSON.decode(await HttpRequest.getString(url));

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.16
+  angular2: 2.0.0-beta.15
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:


### PR DESCRIPTION
Dev guide pipes stopped working in beta.16; this rolls it back to the last known working version (beta.15).