### PR TITLE
docs(style-guide): hide .avoid boilerplate

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -366,10 +366,10 @@ a(href="#toc") Back to top
   :marked
     **Why?** Makes it easier to promoted and share our feature in other apps. 
 
-+makeExample('style-guide/ts/02-07/app/heroes/hero.component.avoid.ts', '', 'app/heroes/hero.component.ts')(avoid=1)
++makeExample('style-guide/ts/02-07/app/heroes/hero.component.avoid.ts', 'example', 'app/heroes/hero.component.ts')(avoid=1)
 :marked
 
-+makeExample('style-guide/ts/02-07/app/users/users.component.avoid.ts', '', 'app/users/users.component.ts')(avoid=1)
++makeExample('style-guide/ts/02-07/app/users/users.component.avoid.ts', 'example', 'app/users/users.component.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/02-07/app/heroes/hero.component.ts', 'example', 'app/heroes/hero.component.ts')
@@ -395,7 +395,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** Our Directives are easily identified
 
-+makeExample('style-guide/ts/02-08/app/shared/validate.directive.avoid.ts', '', 'app/shared/validate.directive.ts')(avoid=1)
++makeExample('style-guide/ts/02-08/app/shared/validate.directive.avoid.ts', 'example', 'app/shared/validate.directive.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/02-08/app/shared/validate.directive.ts', 'example', 'app/shared/validate.directive.ts')
@@ -1240,7 +1240,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** Keeps the element names consistent with the specification for [Custom Elements](https://www.w3.org/TR/custom-elements/).
 
-+makeExample('style-guide/ts/05-02/app/heroes/shared/hero-button/hero-button.component.avoid.ts', '', 'app/heroes/shared/hero-button/hero-button.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-02/app/heroes/shared/hero-button/hero-button.component.avoid.ts', 'example', 'app/heroes/shared/hero-button/hero-button.component.ts')(avoid=1)
 :marked
 
 +makeTabs(
@@ -1275,7 +1275,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** It is easier to recognize that a symbol is a component vs a directive by looking at the template's html.
 
-+makeExample('style-guide/ts/05-03/app/heroes/shared/hero-button/hero-button.component.avoid.ts', '', 'app/heroes/hero-button/hero-button.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-03/app/heroes/shared/hero-button/hero-button.component.avoid.ts', 'example', 'app/heroes/hero-button/hero-button.component.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/05-03/app/heroes/shared/hero-button/hero-button.component.avoid.html', '', 'app/heroes/hero-button/hero-button.component.html')(avoid=1)
@@ -1317,7 +1317,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** A component file's logic is easier to read when not mixed with inline template and styles.
 
-+makeExample('style-guide/ts/05-04/app/heroes/heroes.component.avoid.ts', '', 'app/heroes/heroes.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-04/app/heroes/heroes.component.avoid.ts', 'example', 'app/heroes/heroes.component.ts')(avoid=1)
 :marked
 
 +makeTabs(
@@ -1362,7 +1362,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** Placing the decorator on the same line makes for shorter code and still easily identifies the property as an input or output.
 
-+makeExample('style-guide/ts/05-12/app/heroes/shared/hero-button/hero-button.component.avoid.ts', '', 'app/heroes/shared/hero-button/hero-button.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-12/app/heroes/shared/hero-button/hero-button.component.avoid.ts', 'example', 'app/heroes/shared/hero-button/hero-button.component.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/05-12/app/heroes/shared/hero-button/hero-button.component.ts', 'example', 'app/heroes/shared/hero-button/hero-button.component.ts')
@@ -1384,7 +1384,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** May lead to confusion when the output or the input properties of a given directive are named a given way but exported differently as a public API.
 
-+makeExample('style-guide/ts/05-13/app/heroes/shared/hero-button/hero-button.component.avoid.ts', '', 'app/heroes/shared/hero-button/hero-button.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-13/app/heroes/shared/hero-button/hero-button.component.avoid.ts', 'example', 'app/heroes/shared/hero-button/hero-button.component.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/05-13/app/app.component.avoid.html', '', 'app.component.html')(avoid=1)
@@ -1418,7 +1418,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** Placing members in a consistent sequence makes it easy to read and helps we instantly identify which members of the component serve which purpose.
 
-+makeExample('style-guide/ts/05-14/app/shared/toast/toast.component.avoid.ts', '', 'app/shared/toast/toast.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-14/app/shared/toast/toast.component.avoid.ts', 'example', 'app/shared/toast/toast.component.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/05-14/app/shared/toast/toast.component.ts', 'example', 'app/shared/toast/toast.component.ts')
@@ -1486,7 +1486,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** Angular allows for an [alternative syntax](https://angular.io/docs/ts/latest/guide/template-syntax.html#!#binding-syntax) `on-*`. If the event itself was prefixed with `on` this would result in an `on-onEvent` binding expression.
 
-+makeExample('style-guide/ts/05-16/app/heroes/hero.component.avoid.ts', '', 'app/heroes/hero.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-16/app/heroes/hero.component.avoid.ts', 'example', 'app/heroes/hero.component.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/05-16/app/app.component.avoid.html', '', 'app/app.component.html')(avoid=1)
@@ -1520,7 +1520,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** Keeping the logic of the components in their controller, instead of template will improve testability, maintability, reusability.
 
-+makeExample('style-guide/ts/05-17/app/heroes/hero-list/heroes-list.component.avoid.ts', '', 'app/heroes/hero-list/heroes-list.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-17/app/heroes/hero-list/heroes-list.component.avoid.ts', 'example', 'app/heroes/hero-list/heroes-list.component.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/05-17/app/heroes/hero-list/heroes-list.component.ts', 'example', 'app/heroes/hero-list/heroes-list.component.ts')
@@ -1663,7 +1663,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** When a service accepts only dependencies associated with type tokens, the `@Injectable()` syntax is much less verbose compared to using `@Inject()` on each individual constructor parameter.
 
-+makeExample('style-guide/ts/07-04/app/heroes/shared/hero-arena.service.avoid.ts', '', 'app/heroes/shared/hero-arena.service.ts')(avoid=1)
++makeExample('style-guide/ts/07-04/app/heroes/shared/hero-arena.service.avoid.ts', 'example', 'app/heroes/shared/hero-arena.service.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/07-04/app/heroes/shared/hero-arena.service.ts', 'example', 'app/heroes/shared/hero-arena.service.ts')
@@ -1723,7 +1723,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** We will avoid unintentionally not calling the hook if we misspell the method.
 
-+makeExample('style-guide/ts/09-01/app/heroes/shared/hero-button/hero-button.component.avoid.ts', '', 'app/heroes/shared/hero-button/hero-button.component.ts')(avoid=1)
++makeExample('style-guide/ts/09-01/app/heroes/shared/hero-button/hero-button.component.avoid.ts', 'example', 'app/heroes/shared/hero-button/hero-button.component.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/09-01/app/heroes/shared/hero-button/hero-button.component.ts', 'example', 'app/heroes/shared/hero-button/hero-button.component.ts')


### PR DESCRIPTION
/cc @johnpapa @wardbell 

This PR will hide all the boilerplate needed to make the .avoid to compile but that we don't need to see on the guide.