### PR TITLE
docs(style-guide): make examples comply with the linter

### DIFF
--- a/public/docs/_examples/style-guide/ts/03-05/app/+heroes/shared/hero.service.ts
+++ b/public/docs/_examples/style-guide/ts/03-05/app/+heroes/shared/hero.service.ts
@@ -9,6 +9,7 @@ import { ExceptionService, SpinnerService, ToastService } from '../../../app/sha
 
 @Injectable()
 export class HeroService {
+  cachedHeroes: Hero[];
 
   constructor(
     private exceptionService: ExceptionService,

--- a/public/docs/_examples/style-guide/ts/03-06/app/+heroes/shared/hero.service.ts
+++ b/public/docs/_examples/style-guide/ts/03-06/app/+heroes/shared/hero.service.ts
@@ -9,6 +9,7 @@ import { ExceptionService, SpinnerService, ToastService } from '../../../app/sha
 
 @Injectable()
 export class HeroService {
+  cachedHeroes: Hero[];
 
   constructor(
     private exceptionService: ExceptionService,

--- a/public/docs/_examples/style-guide/ts/04-10/app/+heroes/heroes.component.ts
+++ b/public/docs/_examples/style-guide/ts/04-10/app/+heroes/heroes.component.ts
@@ -1,3 +1,4 @@
+// #docplaster
 // #docregion
 // #docregion example
 import { Component, OnInit } from 'angular2/core';
@@ -13,10 +14,18 @@ import {
 } from '../../app/shared';
 
 @Component({
+  // #enddocregion example
+  providers: [EntityService, ExceptionService, SpinnerService, ToastService],
+  directives: [FilterTextComponent],
+  pipes: [InitCapsPipe],
+  // #docregion example
   selector: 'toh-heroes',
   templateUrl: 'app/+heroes/heroes.component.html'
 })
 export class HeroesComponent implements OnInit {
+  // #enddocregion example
+  urls = CONFIG.baseUrls;
+  // #docregion example
   constructor() { }
 
   ngOnInit() { }

--- a/public/docs/_examples/style-guide/ts/04-10/app/app.component.ts
+++ b/public/docs/_examples/style-guide/ts/04-10/app/app.component.ts
@@ -7,6 +7,7 @@ import { HeroesComponent } from './+heroes/index';
 
 @Component({
   selector: 'toh-app',
-  template: '<div>app</div>'
+  template: '<div>app</div>',
+  directives: [HeroesComponent]
 })
 export class AppComponent { }

--- a/public/docs/_examples/style-guide/ts/04-14/app/heroes/heroes.component.ts
+++ b/public/docs/_examples/style-guide/ts/04-14/app/heroes/heroes.component.ts
@@ -9,7 +9,8 @@ import { Logger } from '../shared/logger.service';
 @Component({
   selector: 'toh-heroes',
   templateUrl: 'heroes.component.html',
-  styleUrls:  ['heroes.component.css']
+  styleUrls:  ['heroes.component.css'],
+  providers: [Logger]
 })
 export class HeroesComponent implements OnInit {
   heroes: Hero[];

--- a/tslint.json
+++ b/tslint.json
@@ -94,8 +94,6 @@
     "component-selector-name": [true, "kebab-case"],
     "directive-selector-type": [true, "attribute"],
     "component-selector-type": [true, "element"],
-    "directive-selector-prefix": [true, "toh"],
-    "component-selector-prefix": [true, "toh"],
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,


### PR DESCRIPTION
/cc @johnpapa @wardbell 

For this I had to remove two rules from our linter. They don't make sense for the style-guide.

All the issues where "This is imported, never used" so I used my imagination to use those stuff but still hide it from the guide. So there are no visual changes.

I put some providers and stuff in components too. When we do testing here, we will see if we need to move this providers around, but for now this works.