### PR TITLE
docs(style-guide): fix 06-03

### DIFF
--- a/public/docs/_examples/style-guide/ts/06-03/app/shared/validate.directive.avoid.ts
+++ b/public/docs/_examples/style-guide/ts/06-03/app/shared/validate.directive.avoid.ts
@@ -2,15 +2,20 @@
 import { Directive, HostBinding, HostListener } from 'angular2/core';
 
 // #docregion example
+/* avoid */
+
 @Directive({
-  selector: '[tohValidator]'
+  selector: '[tohValidator]',
+  host: {
+    '(mouseenter)': 'onMouseEnter()',
+    'attr.role': 'button'
+  }
 })
 export class ValidatorDirective {
-  @HostBinding('attr.role') role = 'button';
-  @HostListener('mouseenter') onMouseEnter() {
+  role = 'button';
+  onMouseEnter() {
     // do work
   }
 }
 export class ValidateDirective { }
 // #enddocregion example
-

--- a/public/docs/_examples/style-guide/ts/06-03/app/shared/validate.directive.ts
+++ b/public/docs/_examples/style-guide/ts/06-03/app/shared/validate.directive.ts
@@ -2,18 +2,12 @@
 import { Directive, HostBinding, HostListener } from 'angular2/core';
 
 // #docregion example
-/* avoid */
-
 @Directive({
-  selector: '[tohValidator]',
-  host: {
-    '(mouseenter)': 'onMouseEnter()',
-    'attr.role': 'button'
-  }
+  selector: '[tohValidator]'
 })
 export class ValidatorDirective {
-  role = 'button';
-  onMouseEnter() {
+  @HostBinding('attr.role') role = 'button';
+  @HostListener('mouseenter') onMouseEnter() {
     // do work
   }
 }

--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -1552,7 +1552,7 @@ a(href="#toc") Back to top
   :marked
     **Why?** The metadata declaration attached to the directive is shorter and thus more readable.
 
-+makeExample('style-guide/ts/06-03/app/shared/validate.directive.ts', 'example', 'app/shared/validate.directive.ts')(avoid=1)
++makeExample('style-guide/ts/06-03/app/shared/validate.directive.avoid.ts', 'example', 'app/shared/validate.directive.ts')(avoid=1)
 :marked
 
 +makeExample('style-guide/ts/06-03/app/shared/validate.directive.ts', 'example', 'app/shared/validate.directive.ts')


### PR DESCRIPTION
/cc @johnpapa @wardbell 

Somehow the .avoid was the good one and the good one was the avoid. Also the guide was showing only one as good and bad.