### PR TITLE
docs(style-guide): rename heroes-list into hero-list for consistency

### DIFF
--- a/public/docs/_examples/style-guide/ts/05-17/app/heroes/hero-list/hero-list.component.avoid.ts
+++ b/public/docs/_examples/style-guide/ts/05-17/app/heroes/hero-list/hero-list.component.avoid.ts
@@ -6,7 +6,7 @@ import { Hero } from '../shared/hero.model';
 /* avoid */
 
 @Component({
-  selector: 'toh-heroes-list',
+  selector: 'toh-hero-list',
   template: `
     <section>
       Our list of heroes:
@@ -17,7 +17,7 @@ import { Hero } from '../shared/hero.model';
     </section>
   `
 })
-export class HeroesListComponent {
+export class HeroListComponent {
   heroes: Hero[];
   totalPowers: number;
 }

--- a/public/docs/_examples/style-guide/ts/05-17/app/heroes/hero-list/hero-list.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-17/app/heroes/hero-list/hero-list.component.ts
@@ -5,7 +5,7 @@ import { Hero } from '../shared/hero.model.ts';
 
 // #docregion example
 @Component({
-  selector: 'toh-heroes-list',
+  selector: 'toh-hero-list',
   template: `
     <section>
       Our list of heroes:
@@ -16,7 +16,7 @@ import { Hero } from '../shared/hero.model.ts';
     </section>
   `
 })
-export class HeroesListComponent {
+export class HeroListComponent {
   heroes: Hero[];
   totalPowers: number;
   avgPower: number;

--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -1520,10 +1520,10 @@ a(href="#toc") Back to top
   :marked
     **Why?** Keeping the logic of the components in their controller, instead of template will improve testability, maintability, reusability.
 
-+makeExample('style-guide/ts/05-17/app/heroes/hero-list/heroes-list.component.avoid.ts', '', 'app/heroes/hero-list/heroes-list.component.ts')(avoid=1)
++makeExample('style-guide/ts/05-17/app/heroes/hero-list/hero-list.component.avoid.ts', '', 'app/heroes/hero-list/hero-list.component.ts')(avoid=1)
 :marked
 
-+makeExample('style-guide/ts/05-17/app/heroes/hero-list/heroes-list.component.ts', 'example', 'app/heroes/hero-list/heroes-list.component.ts')
++makeExample('style-guide/ts/05-17/app/heroes/hero-list/hero-list.component.ts', 'example', 'app/heroes/hero-list/hero-list.component.ts')
 :marked
 
 a(href="#toc") Back to top


### PR DESCRIPTION
We are using `hero-list` all across the guide except in one case. For consistency let rename that one too. Also, I think it is better to call it `hero-list` in singular.