### PR TITLE
docs(books): removes redundant link

### DIFF
--- a/public/books.jade
+++ b/public/books.jade
@@ -33,8 +33,6 @@ div(class="resources")
       a(class="title text-body" href="http://www.oreilly.com/pub/e/3693") Angular 2 Web Development with TypeScript
     li(class="book")
       a(class="title text-body" href="http://shop.oreilly.com/product/0636920051824.do") Migrating to Angular 2
-    li(class="book")
-      a(class="title text-body" href="http://shop.oreilly.com/product/9781785886201.do") Switching to Angular 2
 
   h3 Self-published
   ul(class="publisher")


### PR DESCRIPTION
This link can already be found under the "Packt Publishing" subheading.