### PR TITLE
chore: make protractor report failed suites

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -174,7 +174,7 @@ function runE2eTests(appDir, protractorConfigFilename, outputFile ) {
     // Ugh... proc.kill does not work properly on windows with child processes.
     // appRun.proc.kill();
     treeKill(appRunSpawnInfo.proc.pid);
-    return true;
+    return !data;
   }).fail(function(err) {
     // Ugh... proc.kill does not work properly on windows with child processes.
     // appRun.proc.kill();


### PR DESCRIPTION
So I broke a test, so sorry, protractor deceived me with:

![](http://puu.sh/oDnwa/710f348ca8.png)

So I debugged it and we were giving the "ok" for each suite, no matter what, so the failed suite array was never used. The function was already receiving the result, I just needed to return it. Now we get:

![](http://puu.sh/oDoGx/1846612903.png)

/cc @naomiblack @wardbell 