### PR TITLE
docs: add RxJs operators to hero.service.ts example

### DIFF
--- a/public/docs/_examples/server-communication/ts/app/toh/hero.service.ts
+++ b/public/docs/_examples/server-communication/ts/app/toh/hero.service.ts
@@ -10,7 +10,8 @@ import {Headers, RequestOptions} from 'angular2/http';
 // #enddocregion import-request-options
 // #docregion v1
 import {Hero}           from './hero';
-import {Observable}     from 'rxjs/Observable';
+// Enable RxJs operators for this example
+import {Observable}     from 'rxjs/Rx';
 
 @Injectable()
 export class HeroService {


### PR DESCRIPTION
Proposed change adds RxJs operator import to hero.service.ts example - my motivation for this pull request was this issue: https://github.com/angular/angular/issues/5632#issuecomment-200444642.

Since RxJs operators are not mentioned until after the code example, I figure that this would be useful for anyone skimming the docs.