### PR TITLE
docs: switch to commonjs module generation

### DIFF
--- a/public/docs/_examples/component-styles/ts/app/quest-summary.component.ts
+++ b/public/docs/_examples/component-styles/ts/app/quest-summary.component.ts
@@ -1,29 +1,21 @@
+/* tslint:disable:no-unused-variable */
 // #docplaster
 import {Component, ViewEncapsulation} from '@angular/core';
 
 // #docregion
-// Let TypeScript know about the special SystemJS __moduleName variable
-declare var __moduleName: string;
-// #enddocregion
-// moduleName is not set in some module loaders; set it explicitly
-if (!__moduleName) {
-  __moduleName = `http://${location.host}/${location.pathname}/app/`;
-}
-console.log(`The __moduleName is ${__moduleName} `);
-// #docregion
 
 @Component({
-  moduleId: __moduleName,
+  moduleId: module.id,
   selector: 'quest-summary',
   // #docregion urls
   templateUrl: 'quest-summary.component.html',
   styleUrls:  ['quest-summary.component.css']
-  // #enddocregion urls  
+  // #enddocregion urls
 // #enddocregion
 /*
   // #docregion encapsulation.native
   // warning: few browsers support shadow DOM encapsulation at this time
-  encapsulation: ViewEncapsulation.Native 
+  encapsulation: ViewEncapsulation.Native
   // #enddocregion encapsulation.native
 */
 // #docregion

--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -34,7 +34,7 @@
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12",
 
-    "angular2-in-memory-web-api": "0.0.5",
+    "angular2-in-memory-web-api": "0.0.6",
     "bootstrap": "^3.3.6"
   },
   "devDependencies": {

--- a/public/docs/_examples/quickstart/ts/systemjs.config.1.js
+++ b/public/docs/_examples/quickstart/ts/systemjs.config.1.js
@@ -1,3 +1,4 @@
+// #docregion
 /**
  * System configuration for Angular 2 samples
  * Adjust as necessary for your application needs.

--- a/public/docs/_examples/quickstart/ts/tsconfig.1.json
+++ b/public/docs/_examples/quickstart/ts/tsconfig.1.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "system",
+    "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
     "emitDecoratorMetadata": true,

--- a/public/docs/_examples/style-guide/ts/03-05/app/shared/toast/toast.component.ts
+++ b/public/docs/_examples/style-guide/ts/03-05/app/shared/toast/toast.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from 'angular2/core';
 import { ToastService } from './toast.service';
 
 @Component({
-  moduleId: __moduleName,
+  moduleId: module.id,
   selector: 'toh-toast',
   templateUrl: '<div>toast</div>'
 })

--- a/public/docs/_examples/style-guide/ts/03-06/app/shared/toast/toast.component.ts
+++ b/public/docs/_examples/style-guide/ts/03-06/app/shared/toast/toast.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from 'angular2/core';
 import { ToastService } from './toast.service';
 
 @Component({
-  moduleId: __moduleName,
+  moduleId: module.id,
   selector: 'toh-toast',
   templateUrl: '<div>toast</div>'
 })

--- a/public/docs/_examples/style-guide/ts/04-10/app/shared/filter-text/filter-text.component.ts
+++ b/public/docs/_examples/style-guide/ts/04-10/app/shared/filter-text/filter-text.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Output } from 'angular2/core';
 
 @Component({
-  moduleId: __moduleName,
+  moduleId: module.id,
   selector: 'toh-filter-text',
   template: '<div>filter</div>'
 })

--- a/public/docs/_examples/style-guide/ts/04-10/app/shared/modal/modal.component.ts
+++ b/public/docs/_examples/style-guide/ts/04-10/app/shared/modal/modal.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from 'angular2/core';
 import { ModalService } from './modal.service';
 
 @Component({
-  moduleId: __moduleName,
+  moduleId: module.id,
   selector: 'toh-modal-confirm',
   template: '<div>modal</div>'
 })

--- a/public/docs/_examples/style-guide/ts/04-10/app/shared/nav/nav.component.ts
+++ b/public/docs/_examples/style-guide/ts/04-10/app/shared/nav/nav.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from 'angular2/core';
 import { ModalService } from '../';
 
 @Component({
-  moduleId: __moduleName,
+  moduleId: module.id,
   selector: 'toh-nav',
   template: '<div>nav</div>'
 })

--- a/public/docs/_examples/style-guide/ts/04-10/app/shared/toast/toast.component.ts
+++ b/public/docs/_examples/style-guide/ts/04-10/app/shared/toast/toast.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from 'angular2/core';
 import { ToastService } from './toast.service';
 
 @Component({
-  moduleId: __moduleName,
+  moduleId: module.id,
   selector: 'toh-toast',
   templateUrl: '<div>toast</div>'
 })

--- a/public/docs/_examples/style-guide/ts/04-10/app/typings.d.ts
+++ b/public/docs/_examples/style-guide/ts/04-10/app/typings.d.ts
@@ -1,1 +1,1 @@
-declare var __moduleName: any;
+declare var module.id: any;

--- a/public/docs/_examples/testing/ts/app/bag.ts
+++ b/public/docs/_examples/testing/ts/app/bag.ts
@@ -5,17 +5,6 @@ import { Component, EventEmitter, Injectable, Input, Output,
 
 import { Observable }     from 'rxjs/Rx';
 
-// Let TypeScript know about the special SystemJS __moduleName variable
-declare var __moduleName: string;
-
-// moduleName is not set in some module loaders; set it explicitly
-if (!__moduleName) {
-  __moduleName = `http://${location.host}/${location.pathname}/app/`;
-}
-// console.log(`The __moduleName is ${__moduleName} `);
-
-
-
 ////////// The App: Services and Components for the tests. //////////////
 
 ////////// Services ///////////////
@@ -136,7 +125,7 @@ export class TestViewProvidersComp {
 
 
 @Component({
-  moduleId: __moduleName,
+  moduleId: module.id,
   selector: 'external-template-comp',
   templateUrl: 'bag-external-template.html'
 })

--- a/public/docs/_examples/tsconfig.json
+++ b/public/docs/_examples/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "system",
+    "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
     "emitDecoratorMetadata": true,

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -475,14 +475,19 @@ figure.image-display
       .file app.component.ts
       .file main.ts
     .file node_modules ...
-    .file typings ...
+    .file typings    
+    .children
+      .file typings.d.ts
+      .file ...
     .file index.html
     .file package.json
     .file styles.css
+    .file system.config.js
     .file tsconfig.json
     .file typings.json
 :marked
-  And here are the files:
+  And here are the files:,
+    quickstart/ts/typings/typings.d.1.ts
 +makeTabs(`
     quickstart/ts/app/app.component.ts,
     quickstart/ts/app/main.ts,
@@ -490,14 +495,17 @@ figure.image-display
     quickstart/ts/package.1.json,
     quickstart/ts/tsconfig.1.json,
     quickstart/ts/typings.1.json,
-    quickstart/ts/styles.1.css    
-  `,null,
+    quickstart/ts/styles.1.css,
+    quickstart/ts/system.config.1.js`
+  ,null,
   `app/app.component.ts, 
   app/main.ts, 
-  index.html,package.json, 
+  index.html,
+  package.json, 
   tsconfig.json, 
   typings.json,
-  styles.css`)
+  styles.css,
+  system.config.js`)
 :marked
 
 .l-main-section


### PR DESCRIPTION
as the CLI does. Also adds `typings.d.ts` declaring common js `module.id` object