### PR TITLE
Modify"Typescript type definition file" link up-to-date url

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -89,7 +89,7 @@ a(id="typings")
   :marked
     Many JavaScript libraries extend the JavaScript environment with features and syntax
     that the TypeScript compiler doesn't recognize natively. We teach it about these capabilities with
-    <a href="http://www.typescriptlang.org/Handbook#writing-dts-files" target="_blank">TypeScript type definition files</a>
+    <a href="http://www.typescriptlang.org/docs/handbook/writing-declaration-files.html" target="_blank">TypeScript type definition files</a>
     &mdash; *d.ts files* &mdash; which we identify in a `typings.json` file.
     
     We go a little deeper into *typings* in the 


### PR DESCRIPTION
Typescript official site is changed.
Therefore, there is a miss link in quickstart guide.