### PR TITLE
docs: change packageNames in systemjs.config.1.js

### DIFF
--- a/public/docs/_examples/quickstart/ts/systemjs.config.1.js
+++ b/public/docs/_examples/quickstart/ts/systemjs.config.1.js
@@ -29,7 +29,7 @@
     '@angular/http',
     '@angular/platform-browser',
     '@angular/platform-browser-dynamic',
-    '@angular/router',
+    '@angular/router-deprecated',
     '@angular/testing',
     '@angular/upgrade',
   ];


### PR DESCRIPTION
Change @angular/router to @angular/router-deprecated to make tutorial work.