### PR TITLE
docs(server-communication): remove unreachable and confusing code chunk

### DIFF
--- a/public/docs/_examples/server-communication/ts/app/toh/hero.service.1.ts
+++ b/public/docs/_examples/server-communication/ts/app/toh/hero.service.1.ts
@@ -34,9 +34,6 @@ export class HeroService {
   }
 
   private extractData(res: Response) {
-    if (res.status < 200 || res.status >= 300) {
-      throw new Error('Bad response status: ' + res.status);
-    }
     let body = res.json();
     return body.data || { };
   }

--- a/public/docs/_examples/server-communication/ts/app/toh/hero.service.ts
+++ b/public/docs/_examples/server-communication/ts/app/toh/hero.service.ts
@@ -59,9 +59,6 @@ export class HeroService {
 
   // #docregion extract-data
   private extractData(res: Response) {
-    if (res.status < 200 || res.status >= 300) {
-      throw new Error('Bad response status: ' + res.status);
-    }
     let body = res.json();
     return body.data || { };
   }


### PR DESCRIPTION
Maybe I misunderstood something and the proposed change is entirely wrong, but I decide to create a pull request instead of an issue in case if I am right.

I think the removed (in this the proposed commit) chunk of code is unreachable because the callback passed to the Observable#map method will never be called, if the response status code is <200 or >=300. Its due to the current implementation of the backend (see here https://github.com/angular/angular/blob/master/modules/%40angular/http/src/backends/xhr_backend.ts).
If the status code is not within this "successful" range it will call observable error method anyway and the callback passed to the Observable#map will not be fired. So there is no sense (and it was confusing to me) in trying to handle non successful responses in the callback passed to the Observable#map.