### PR TITLE
Fix incorrect gulp task name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For example, all of the TypeScript docs are in `public/docs/ts/latest`, e.g.
 If you are only going to work on a specific part of the docs, such as the dev guide, then you can use one of the more specific gulp tasks to only watch those parts of the file system:
 
 * `gulp serve-and-sync` : watch all the local Jade/Sass files, the API source and examples, and the dev guide files
-* `gulp serve-and-sync-api-docs` : watch only the API source and example files
+* `gulp serve-and-sync-api` : watch only the API source and example files
 * `gulp serve-and-sync-devguide` : watch only the dev guide files
 * `gulp build-and-serve` : watch only the local Jade/Sass files
 


### PR DESCRIPTION
On line 65 of the README it references the `serve-and-sync-api-docs` gulp task.

Looking at the `gulpfile.js` there is a task named `serve-and-sync-api`, so I am assuming the desired change would be to update the README and not the gulp task name.

This PR updates the reference in README from `serve-and-sync-api-docs` to `serve-and-sync-api`.