### PR TITLE
doc(quickstart): add bootstrap warning

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -101,6 +101,13 @@ a(id="package-json")
   Add a **package.json** file to the project folder and copy/paste the following:
 +makeJson('quickstart/ts/package.1.json', null, 'package.json')(format=".")
 
+.l-sub-section
+  :marked
+    The `bootstrap` in **package.json** refers to `Twitter's Bootstrap` framework. It is not to be
+    confused with the Angular 2 `bootstrap` function discussed later in this document. We use this framework in a number
+    of examples to provide a bit of style, but Angular 2 requires no styling framework and you are free to substitute 
+    it with one of your own, or use none at all.
+
 .l-verbose-section
   :marked
     ### Adding the libraries we need with *npm*


### PR DESCRIPTION
While going through the quickstart as a refresher I noticed that `Twitter Bootstrap` is being loaded in the `package.json`.

There is no further mention or use of it in the rest of the document **BUT** an explanation follows later on the `bootstrap` function of Angular 2.

I think beginners may link up the two and think that loading `Twitter Bootstrap` is mandatory.

So I added a small message to clarify it.