### PR TITLE
docs(toh): link to deprecated router

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -15,7 +15,7 @@ figure.image-display
   We'll add Angular’s *Component Router* to our app to satisfy these requirements.
 .l-sub-section
   :marked
-    The [Routing and Navigation](../guide/router.html) chapter covers the router in more detail
+    The [Routing and Navigation](../guide/router-deprecated.html) chapter covers the router in more detail
     than we will in this tour.  
 :marked
   [Run the live example](/resources/live-examples/toh-5/ts/plnkr.html). 
@@ -145,7 +145,7 @@ code-example(format="." language="bash").
 .callout.is-important
   header base href is essential
   :marked
-    See the *base href* section of the [Router](../guide/router.html#!#base-href) chapter to learn why this matters.
+    See the *base href* section of the [Router](../guide/router-deprecated.html#!#base-href) chapter to learn why this matters.
 :marked
   ### Make the router available.
   The *Component Router* is a service. Like any service, we have to import it and make it
@@ -185,7 +185,7 @@ code-example(format="." language="bash").
 
 .l-sub-section
   :marked
-    Learn more about defining routes with @RouteConfig in the [Routing](../guide/router.html) chapter.
+    Learn more about defining routes with @RouteConfig in the [Routing](../guide/router-deprecated.html) chapter.
 :marked
   ### Router Outlet
 
@@ -213,7 +213,7 @@ code-example(format="." language="bash").
   Looking back at the route configuration, we confirm that `'Heroes'` is the name of the route to the `HeroesComponent`.
 .l-sub-section
   :marked
-    Learn about the *link parameters array* in the [Routing](../guide/router.html#link-parameters-array) chapter.
+    Learn about the *link parameters array* in the [Routing](../guide/router-deprecated.html#link-parameters-array) chapter.
 :marked
   Refresh the browser.  We see only the app title. We don't see the heroes list. 
 .l-sub-section


### PR DESCRIPTION
For the time being, we needs this to avoid redirection to a work in progress page that is confusing the readers.