### PR TITLE
chore: add custom typings for examples

### DIFF
--- a/public/docs/_examples/custom.d.ts
+++ b/public/docs/_examples/custom.d.ts
@@ -1,0 +1,1 @@
+declare var module: {id: string};

--- a/public/docs/_examples/typings.json
+++ b/public/docs/_examples/typings.json
@@ -1,6 +1,7 @@
 {
   "ambientDependencies": {
     "es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654",
-    "jasmine": "registry:dt/jasmine#2.2.0+20160412134438"
+    "jasmine": "registry:dt/jasmine#2.2.0+20160412134438",
+    "custom": "file:./custom.d.ts"
   }
 }


### PR DESCRIPTION
Currently `component-style` is broken because it can't find the `module` thing.

I added a custom.d.ts that will be added to typings and then it will be available everywhere.