### PR TITLE
docs(dev guide): cleanup of deprecated Jade mixin

### DIFF
--- a/public/docs/dart/latest/_util-fns.jade
+++ b/public/docs/dart/latest/_util-fns.jade
@@ -12,12 +12,6 @@ mixin liveExampleLink2(linkText, exampleUrlPartName)
   - var liveExampleSourceLinkText = attributes.srcLinkText || 'view source'
   | #[+liveExampleLink(linkText, exampleUrlPartName)] 
   | (#[a(href='https://github.com/angular-examples/#{exampleUrlPartName}') #{liveExampleSourceLinkText}])
-    
-//- Deprecated
-mixin liveExLinks(exampleUrlPartName)
-  p.
-    #[+liveExampleLink('Run the live example', exampleUrlPartName)] |
-    #[a(href='https://github.com/angular-examples/#{exampleUrlPartName}') View its source code]
 
 - var adjustExamplePath = function(_path) {
 -   if(!_path) return _path;

--- a/public/docs/dart/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/dart/latest/guide/hierarchical-dependency-injection.jade
@@ -2,6 +2,3 @@ extends ../../../ts/latest/guide/hierarchical-dependency-injection.jade
 
 block includes
   include ../_util-fns
-
-block liveExample
-  +liveExLinks('hierarchical-dependency-injection')

--- a/public/docs/dart/latest/guide/structural-directives.jade
+++ b/public/docs/dart/latest/guide/structural-directives.jade
@@ -3,9 +3,6 @@ extends ../../../ts/latest/guide/structural-directives.jade
 block includes
   include ../_util-fns
 
-block liveExample
-  +liveExLinks('structural-directives')
-
 block unless-intro
   :marked
     Creating a directive is similar to creating a component.

--- a/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
@@ -12,10 +12,8 @@ block includes
   interesting and useful results.
 
   In this chapter we explore these points and write some code.
-
-block liveExample
-  :marked
-    [Live Example](/resources/live-examples/hierarchical-dependency-injection/ts/plnkr.html).
+p
+  | Try the #[+liveExampleLink2('live example', 'hierarchical-dependency-injection')].
 
 .l-main-section
 :marked

--- a/public/docs/ts/latest/guide/structural-directives.jade
+++ b/public/docs/ts/latest/guide/structural-directives.jade
@@ -14,10 +14,8 @@ block includes
   - [discover the &lt;template> element](#template)
   - [understand the asterisk (\*) in **ngFor*](#asterisk)
   - [write our own structural directive](#unless)
-
-block liveExample
-  :marked
-    [Live example](/resources/live-examples/structural-directives/ts/plnkr.html)
+p
+  | Try the #[+liveExampleLink2('live example', 'structural-directives')].
 
 <a id="definition"></a>
 .l-main-section


### PR DESCRIPTION
Replaced uses of `liveExLinks` mixin and then deleted its definition.