### PR TITLE
docs(quickstart): put systemjs configuration outside verbose section

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -345,38 +345,38 @@ code-example(format="").
     become more concerned about production qualities such as
     load times and memory footprint.
 
-  a(id="systemjs")
-  :marked
-    ### SystemJS Configuration
+a(id="systemjs")
+:marked
+  ### SystemJS Configuration
 
-    The QuickStart uses <a href="https://github.com/systemjs/systemjs" target="_blank">SystemJS</a>
-      to load application and library modules. 
-    There are alternatives that work just fine including the well-regarded 
-    <a href="https://webpack.github.io/" target="_blank">webpack</a>.
-    SystemJS happens to be a good choice but we want to be clear that it was a choice and not a preference.
-    
-    All module loaders require configuration and all loader configuration 
-    becomes complicated rather quickly as soon as the file structure diversifies and
-    we start thinking about building for production and performance.
-    
-    We suggest becoming well-versed in the loader of your choice.
-    Learn more about SystemJS configuration
-    <a href="https://github.com/systemjs/systemjs/blob/master/docs/config-api.md" target="_blank">here</a>.
+  The QuickStart uses <a href="https://github.com/systemjs/systemjs" target="_blank">SystemJS</a>
+    to load application and library modules. 
+  There are alternatives that work just fine including the well-regarded 
+  <a href="https://webpack.github.io/" target="_blank">webpack</a>.
+  SystemJS happens to be a good choice but we want to be clear that it was a choice and not a preference.
+  
+  All module loaders require configuration and all loader configuration 
+  becomes complicated rather quickly as soon as the file structure diversifies and
+  we start thinking about building for production and performance.
+  
+  We suggest becoming well-versed in the loader of your choice.
+  Learn more about SystemJS configuration
+  <a href="https://github.com/systemjs/systemjs/blob/master/docs/config-api.md" target="_blank">here</a>.
 
-    With those cautions in mind, what are we doing in this QuickStart configuration?
-  +makeExample('quickstart/ts/systemjs.config.1.js', null, 'systemjs.config.js')(format=".")
+  With those cautions in mind, what are we doing in this QuickStart configuration?
++makeExample('quickstart/ts/systemjs.config.1.js', null, 'systemjs.config.js')(format=".")
+:marked
+  First, we create a map to tell SystemJS where to look when we import some module.
+  
+  Then, we give all our packages to SystemJS. That means all the project dependencies and our application package, `app`.
+  
+.l-sub-section
   :marked
-    First, we create a map to tell SystemJS where to look when we import some module.
-    
-    Then, we give all our packages to SystemJS. That means all the project dependencies and our application package, `app`.
-    
-  .l-sub-section
-    :marked
-      Our QuickStart doesn't use the Reactive Extensions 
-      but any substantial application will want them
-      when working with observables.
-      We added the library here in QuickStart so we don't forget later.
-      
+    Our QuickStart doesn't use the Reactive Extensions 
+    but any substantial application will want them
+    when working with observables.
+    We added the library here in QuickStart so we don't forget later.
+.l-verbose-section
   :marked
     The `app` package tells SystemJS what to do when it sees a request for a 
     module from the `app/` folder. 


### PR DESCRIPTION
As it sits right now, if we hide the explanations, we hide the systemjs configuration and that is not good.

Fixes #1321 