### PR TITLE
docs(glossary): export in barrels

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -72,8 +72,8 @@ include _util-fns
   :marked
     We can add a barrel to the `heroes` folder (called `index` by convention) that exports all of these items:
   code-example(format='').
-    import * from './hero.model.ts';   // re-export all of its exports
-    import * from './hero.service.ts'; // re-export all of its exports
+    export * from './hero.model.ts';   // re-export all of its exports
+    export * from './hero.service.ts'; // re-export all of its exports
     export { HeroComponent } from './hero.component.ts'; // re-export the named thing
   :marked
     Now a consumer can import what it needs from the barrel.


### PR DESCRIPTION
The example is about exports, so `import` statements are wrong here, I suppose