### PR TITLE
docs(glossary): input decorator in same line

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -209,8 +209,7 @@ include _util-fns
     @Component({...})
     export class AppComponent {
       constructor(@Inject('SpecialFoo') public foo:Foo) {}
-      @Input()
-      name:string;
+      @Input() name:string;
     }
     ```
     The scope of a decorator is limited to the language feature


### PR DESCRIPTION
According to styleguide the `@Input()` decorator should be placed in the same line

> Do place the @Input() or @Output() on the same line as the property they decorate.
https://angular.io/styleguide#!#decorate-input-and-output-properties-inline