### PR TITLE
docs(guide): fix BAD FILENAME example imports

### DIFF
--- a/public/docs/_examples/router/ts/app/app.component.1.ts
+++ b/public/docs/_examples/router/ts/app/app.component.1.ts
@@ -3,14 +3,15 @@
 
 // #docregion
 import { Component } from '@angular/core';
+// #docregion import-router
 import { ROUTER_DIRECTIVES, Routes } from '@angular/router';
-
+// #enddocregion import-router
 import { CrisisListComponent } from './crisis-list.component';
 import { HeroListComponent }   from './hero-list.component';
 
 @Component({
   selector: 'my-app',
-// #docregion template
+  // #docregion template
   template: `
     <h1>Component Router</h1>
     <nav>
@@ -19,7 +20,7 @@ import { HeroListComponent }   from './hero-list.component';
     </nav>
     <router-outlet></router-outlet>
   `,
-// #enddocregion template
+  // #enddocregion template
   directives: [ROUTER_DIRECTIVES]
 })
 // #enddocregion
@@ -31,11 +32,11 @@ import { HeroListComponent }   from './hero-list.component';
 // #docregion
 // #docregion route-config
 @Routes([
-// #docregion route-defs
-  {path: '/crisis-center', component: CrisisListComponent},
-  {path: '/heroes',        component: HeroListComponent},
-  {path: '*',        component: CrisisListComponent}
-// #enddocregion route-defs
+  // #docregion route-defs
+  { path: '/crisis-center', component: CrisisListComponent },
+  { path: '/heroes', component: HeroListComponent },
+  { path: '*', component: CrisisListComponent }
+  // #enddocregion route-defs
 ])
 export class AppComponent { }
 // #enddocregion route-config

--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -620,6 +620,19 @@ code-example(format="." language="bash").
 :marked
   ### Getting the route parameter
 
+.alert.is-critical
+  :marked
+    This entire section is outdated.
+
+    HeroDetailComponent no longer implements OnInit,
+    nor are RouteParams still used.  The parameter
+    extraction is now the responsibility of RouteSegment
+    through an extension of the OnActivate interface.
+
+    (the BAD FILENAME error is the result of a doc region
+    that no longer exists in the referenced example file)
+
+:marked
   <a id="hero-detail-ctor"></a>
   How does the target `HeroDetailComponent` learn about that `id`?
   Certainly not by analyzing the URL!  That's the router's job.
@@ -845,10 +858,19 @@ code-example(format="").
 :marked
   ### Parent Route Configuration
   Here is the revised route configuration for the parent `AppComponent`:
-+makeExample('router/ts/app/app.component.ts', 'route-config', 'app/app.component.ts (routes only)' )
++makeExample('router/ts/app/app.component.ts', 'routes', 'app/app.component.ts (routes only)' )
 :marked
   The last two *Hero* routes haven't changed.
-  
+
+.alert.is-critical
+  :marked
+    This section is outdated. The discussion around the Crisis
+    Center route is incorrect.
+
+    (the BAD FILENAME error is the result of a doc region
+    that no longer exists in the referenced example file)
+
+:marked
   The first *Crisis Center* route has changed &mdash; *significantly* &mdash; and we've formatted it to draw attention to the differences:
 +makeExample('router/ts/app/app.component.ts', 'route-config-cc')(format=".")
 :marked
@@ -1106,7 +1128,16 @@ code-example(format="." language="bash").
     **Every parameter _not_ consumed by a route path goes in the query string.**
 :marked
   ### Query parameters in the *RouteParams* service
-  
+
+.alert.is-critical
+  :marked
+    *RouteParams* no longer exist.
+
+    Description and discussion below is no longer accurate.
+    (the BAD FILENAME is the result of a doc region that no longer
+    exists in the referenced example file)
+
+:marked
   The list of heroes is unchanged. No hero row is highlighted. 
 
 .l-sub-section


### PR DESCRIPTION
Fix incorrect doc regions (BAD FILENAME errors)

Mark sections containing BAD FILENAME errors
resulting from outdated examples and usage
with critical alerts

Closes #1307