### PR TITLE
fix(docs landing): make docs landing responsive

### DIFF
--- a/public/resources/css/module/_docs-landing.scss
+++ b/public/resources/css/module/_docs-landing.scss
@@ -1,3 +1,9 @@
+.card-row {
+  @media screen and (max-width: 1200px) {
+    flex-direction: column !important;
+  }
+}
+
 .docs-landing {
   .button {
     margin: 0;
@@ -15,6 +21,19 @@
     width: 100%;
     height: 100%;
     min-height: 250px;
+    width: 300px;
+
+    @media screen and (max-width: 1200px) {
+      width: 400px;
+    }
+
+    @media screen and (max-width: 600px) {
+      width: 300px;
+    }
+
+    @media screen and (max-width: 321px) {
+      width: 270px;
+    }
   }
 
   md-card-content {


### PR DESCRIPTION
### Changes
* Arrange doc landing cards in a column layout whenever the row runs out of space

### Preview
Live Preview: https://col-fix-docs.firebaseapp.com/docs/ts/latest/

#### Before
![Before](https://cloud.githubusercontent.com/assets/1329167/15123661/ce390710-15f2-11e6-9aa1-99b91ca50680.png)

#### After
![After](https://cloud.githubusercontent.com/assets/1329167/15123675/d606bbd6-15f2-11e6-9fe6-5f84f49809c9.png)

@naomiblack 