### PR TITLE
docs(router-deprecated): fix example links that weren't to deprecated code

### DIFF
--- a/public/docs/_examples/router-deprecated/ts/plnkr.json
+++ b/public/docs/_examples/router-deprecated/ts/plnkr.json
@@ -1,0 +1,12 @@
+{
+  "description": "Router (Deprecated)",
+  "files":[
+    "!**/*.d.ts",
+    "!**/*.js",
+    "!**/*.[1,2,3].*",
+    "!app/crisis-list.component.ts",
+    "!app/hero-list.component.ts",
+    "!app/crisis-center/add-crisis.component.ts"
+  ],
+  "tags": ["router", "deprecated"]
+}

--- a/public/docs/dart/latest/guide/_data.json
+++ b/public/docs/dart/latest/guide/_data.json
@@ -101,7 +101,7 @@
   },
 
   "router-deprecated": {
-    "title": "Beta Router (Deprecated)",
+    "title": "Router (Deprecated Beta)",
     "intro": "The deprecated Beta Router."
   },
 

--- a/public/docs/js/latest/guide/_data.json
+++ b/public/docs/js/latest/guide/_data.json
@@ -100,7 +100,7 @@
   },
 
   "router-deprecated": {
-    "title": "Beta Router (Deprecated)",
+    "title": "Router (Deprecated Beta)",
     "intro": "The deprecated Beta Router."
   },
 

--- a/public/docs/ts/latest/guide/_data.json
+++ b/public/docs/ts/latest/guide/_data.json
@@ -101,7 +101,7 @@
 
 
   "router-deprecated": {
-    "title": "Beta Router (Deprecated)",
+    "title": "Router (Deprecated Beta)",
     "intro": "The deprecated Beta Router."
   },
 

--- a/public/docs/ts/latest/guide/router-deprecated.jade
+++ b/public/docs/ts/latest/guide/router-deprecated.jade
@@ -10,7 +10,7 @@ include ../_util-fns
   as users perform application tasks.
   
   We cover the router's primary features in this chapter, illustrating them through the evolution
-  of a small application that we can [run live](/resources/live-examples/router/ts/plnkr.html).
+  of a small application that we can [run live](/resources/live-examples/router-deprecated/ts/plnkr.html).
 .l-sub-section
   img(src='/resources/images/devguide/plunker-separate-window-button.png' alt="pop out the window" align="right" style="margin-right:-20px")
   :marked
@@ -207,7 +207,7 @@ table
     We discuss code and design decisions pertinent to routing and application design.
     We gloss over everything in between.
     
-    The full source is available in the [live example](/resources/live-examples/router/ts/plnkr.html).
+    The full source is available in the [live example](/resources/live-examples/router-deprecated/ts/plnkr.html).
 :marked
   Our client is the Hero Employment Agency.
   Heroes need work and The Agency finds Crises for them to solve.
@@ -216,7 +216,7 @@ table
   1. A *Crisis Center* where we maintain the list of crises for assignment to heroes.
   1. A *Heroes* area where we maintain the list of heroes employed by The Agency.
 
-  Run the [live example](/resources/live-examples/router/ts/plnkr.html).
+  Run the [live example](/resources/live-examples/router-deprecated/ts/plnkr.html).
   It opens in the *Crisis Center*.  We'll come back to that.
 
   Click the *Heroes* link. We're presented with a list of Heroes.
@@ -459,11 +459,11 @@ figure.image-display
 :marked
   Here are the files discussed in this milestone
 +makeTabs(
-  `router/ts/app/app.component.1.ts,
-  router/ts/app/main.1.ts,
-  router/ts/app/hero-list.component.ts,
-  router/ts/app/crisis-list.component.ts,
-  router/ts/index.html`,
+  `router-deprecated/ts/app/app.component.1.ts,
+  router-deprecated/ts/app/main.1.ts,
+  router-deprecated/ts/app/hero-list.component.ts,
+  router-deprecated/ts/app/crisis-list.component.ts,
+  router-deprecated/ts/index.html`,
   ',all,,',
   `app.component.ts, 
   main.ts,
@@ -687,10 +687,10 @@ code-example(format="." language="bash").
   ### The Heroes App code
   Here are the relevant files for this version of the sample application.
 +makeTabs(
-  `router/ts/app/app.component.2.ts,
-   router/ts/app/heroes/hero-list.component.1.ts,
-   router/ts/app/heroes/hero-detail.component.1.ts,
-   router/ts/app/heroes/hero.service.ts`,
+  `router-deprecated/ts/app/app.component.2.ts,
+   router-deprecated/ts/app/heroes/hero-list.component.1.ts,
+   router-deprecated/ts/app/heroes/hero-detail.component.1.ts,
+   router-deprecated/ts/app/heroes/hero.service.ts`,
    null,
   `app.component.ts,
   hero-list.component.ts,
@@ -999,10 +999,10 @@ code-example(format="").
   The relevant *Crisis Center* code for this milestone is
   
 +makeTabs(
-   `router/ts/app/crisis-center/crisis-center.component.ts,
-   router/ts/app/crisis-center/crisis-list.component.1.ts,
-   router/ts/app/crisis-center/crisis-detail.component.1.ts,
-   router/ts/app/crisis-center/crisis.service.ts
+   `router-deprecated/ts/app/crisis-center/crisis-center.component.ts,
+   router-deprecated/ts/app/crisis-center/crisis-list.component.1.ts,
+   router-deprecated/ts/app/crisis-center/crisis-detail.component.1.ts,
+   router-deprecated/ts/app/crisis-center/crisis.service.ts
   `,
   null,
    `crisis-center.component.ts,
@@ -1110,7 +1110,7 @@ code-example(format="." language="bash").
 
 .l-sub-section
   :marked
-    The [live example](/resources/live-examples/router/ts/plnkr.html) *does* highlight the selected
+    The [live example](/resources/live-examples/router-deprecated/ts/plnkr.html) *does* highlight the selected
     row because it demonstrates the final state of the application which includes the steps we're *about* to cover.
     At the moment we're describing the state of affairs *prior* to those steps.
 :marked
@@ -1157,10 +1157,10 @@ figure.image-display
   Confirm the similarities in these *Hero* and *CrisisCenter* components,
   arranged side-by-side for easy comparison:
 +makeTabs(
-    `router/ts/app/heroes/hero-list.component.ts,
-    router/ts/app/crisis-center/crisis-list.component.ts,
-    router/ts/app/heroes/hero-detail.component.ts,
-    router/ts/app/crisis-center/crisis-detail.component.ts
+    `router-deprecated/ts/app/heroes/hero-list.component.ts,
+    router-deprecated/ts/app/crisis-center/crisis-list.component.ts,
+    router-deprecated/ts/app/heroes/hero-detail.component.ts,
+    router-deprecated/ts/app/crisis-center/crisis-detail.component.ts
     `,
     null,
     `hero-list.component.ts,
@@ -1202,7 +1202,7 @@ code-example(format="." language="bash").
   As we end our chapter, we take a parting look at
   the entire application.
 
-  We can always try the [live example](/resources/live-examples/router/ts/plnkr.html) and download the source code from there.
+  We can always try the [live example](/resources/live-examples/router-deprecated/ts/plnkr.html) and download the source code from there.
 
   Our final project folder structure looks like this:
 .filetree
@@ -1225,10 +1225,10 @@ code-example(format="." language="bash").
 :marked
   The pertinent top level application files are
 +makeTabs(
-  `router/ts/app/app.component.ts,
-   router/ts/app/main.ts,
-   router/ts/app/dialog.service.ts,
-   router/ts/index.html
+  `router-deprecated/ts/app/app.component.ts,
+   router-deprecated/ts/app/main.ts,
+   router-deprecated/ts/app/dialog.service.ts,
+   router-deprecated/ts/index.html
   `,
   null,
   `app.component.ts,
@@ -1251,10 +1251,10 @@ code-example(format="." language="bash").
       .file crisis.service.ts
 :marked
 +makeTabs(
-   `router/ts/app/crisis-center/crisis-center.component.ts,
-   router/ts/app/crisis-center/crisis-list.component.ts,
-   router/ts/app/crisis-center/crisis-detail.component.ts,
-   router/ts/app/crisis-center/crisis.service.ts
+   `router-deprecated/ts/app/crisis-center/crisis-center.component.ts,
+   router-deprecated/ts/app/crisis-center/crisis-list.component.ts,
+   router-deprecated/ts/app/crisis-center/crisis-detail.component.ts,
+   router-deprecated/ts/app/crisis-center/crisis.service.ts
   `,
   null,
    `crisis-center.component.ts,
@@ -1275,9 +1275,9 @@ code-example(format="." language="bash").
       .file hero.service.ts
 :marked
 +makeTabs(
-   `router/ts/app/heroes/hero-list.component.ts,
-   router/ts/app/heroes/hero-detail.component.ts,
-   router/ts/app/heroes/hero.service.ts
+   `router-deprecated/ts/app/heroes/hero-list.component.ts,
+   router-deprecated/ts/app/heroes/hero-detail.component.ts,
+   router-deprecated/ts/app/heroes/hero.service.ts
   `,
   null,
    `hero-list.component.ts,


### PR DESCRIPTION
Most examples were pointing forward to the RC router as was the plunker