### PR TITLE
docs(forms): Now word is interpreted as keyword

### DIFF
--- a/public/docs/ts/latest/guide/forms.jade
+++ b/public/docs/ts/latest/guide/forms.jade
@@ -486,7 +486,7 @@ figure.image-display
     and we only ever apply *one* of these directives to an element tag.
     Consistency rules!
 
-  Now we can control visibility of the "name" error message by binding properties of the `name` control to the message `<div>` element's `hidden` property.
+    Now we can control visibility of the "name" error message by binding properties of the `name` control to the message `<div>` element's `hidden` property.
 +makeExample('forms/ts/app/hero-form.component.html', 
   'hidden-error-msg', 
   'app/hero-form.component.html (excerpt)')


### PR DESCRIPTION
The word `Now` is interpreted as keyword and does not render correctly with its style.