### PR TITLE
fix(homepage gap): remove margin top from features

### DIFF
--- a/public/resources/css/module/_home-promos.scss
+++ b/public/resources/css/module/_home-promos.scss
@@ -1,6 +1,6 @@
-// TODO: (ericjim) is the best place to put this?
 .home-rows {
-  margin-top: 112px;
+  // NOTE (ericjim): if a banner is placed on the homescreen, add this margin.
+  //margin-top: 112px;
 }
 
 .home-row {


### PR DESCRIPTION
#### Changes
* Remove excessive top margin from features on homepage. This was causing an unnecessary gap.

#### Preview
https://fix-gap-hero.firebaseapp.com/

##### Before
<img width="1356" alt="screen shot 2016-05-10 at 10 31 48 am" src="https://cloud.githubusercontent.com/assets/1329167/15150267/7681b1ea-169a-11e6-8216-2d8553275c60.png">

##### After
<img width="1357" alt="screen shot 2016-05-10 at 10 30 17 am" src="https://cloud.githubusercontent.com/assets/1329167/15150194/3866e81c-169a-11e6-9b3c-97b05abbdad3.png">

CLOSES:
https://github.com/angular/angular.io/issues/1346

@naomiblack @petebacondarwin 