### PR TITLE
docs(toh): put a bit of clarification

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt3.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt3.jade
@@ -171,7 +171,7 @@ code-example(format=".")
 :marked
   The `AppComponent`’s template should now look like this
 
-+makeExample('toh-3/ts/app/app.component.ts', 'hero-detail-template', 'app.component.ts (Template)')
++makeExample('toh-3/ts/app/app.component.ts', 'hero-detail-template', 'app.component.ts (Template)')(format='.')
 :marked
   Thanks to the binding, the `HeroDetailComponent` should receive the hero from the `AppComponent` and display that hero's detail beneath the list.
   The detail should update every time the user picks a new hero.
@@ -189,8 +189,7 @@ code-example(format=".")
   
   We tell Angular about it by listing it in the metadata `directives` array. Let's add that array property to the bottom of the
   `@Component` configuration object, immediately after the `template` and `styles` properties.
-+makeExample('toh-3/ts/app/app.component.ts', 'directives')
-
++makeExample('toh-3/ts/app/app.component.ts', 'directives', 'app/app.component.ts (Directives)')
 
 :marked
   ### It works!
@@ -215,7 +214,7 @@ code-example(format=".")
       .file hero-detail.component.ts
       .file main.ts
     .file node_modules ...
-    .file typings ...      
+    .file typings ...
     .file index.html
     .file package.json
     .file tsconfig.json

--- a/public/docs/ts/latest/tutorial/toh-pt4.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt4.jade
@@ -167,7 +167,7 @@ code-example(format="." language="bash").
 
   ### Inject the *HeroService*
   
-  Two lines replace the one line of *new*:
+  Two lines replace the one line that created with *new*:
   1. we add a constructor.
   1. we add to the component's `providers` metadata
   
@@ -178,11 +178,6 @@ code-example(format="." language="bash").
   defines a private `heroService` property and identifies it as a `HeroService` injection site.
 :marked
   Now Angular will know to supply an instance of the `HeroService` when it creates a new `AppComponent`. 
-  
-  Angular has to get that instance from somewhere. That's the role of the Angular *Dependency Injector*.
-  The **Injector** has a **container** of previously created services. 
-  Either it finds and returns a pre-existing `HeroService` from its container or it creates a new instance, adds
-  it to the container, and returns it to Angular.
 
 .l-sub-section
   :marked
@@ -201,22 +196,7 @@ code-example(format="." language="html").
 :marked
   The `providers` array  tells Angular to create a fresh instance of the `HeroService` when it creates a new `AppComponent`.
   The `AppComponent` can use that service to get heroes and so can every child component of its component tree.
-<a id="child-component"></a>  
-.l-sub-section
-  :marked
-    ### Services and the component tree
-    
-    Recall that the `AppComponent` creates an instance of `HeroDetail` by virtue of the
-    `<my-hero-detail>` tag at the bottom of its template. That `HeroDetail` is a child of the `AppComponent`.
-    
-    If the `HeroDetailComponent` needed its parent component's `HeroService`,
-    it would ask Angular to inject the service into its constructor which would look just like the one for `AppComponent`:
-  +makeExample('toh-4/ts/app/app.component.1.ts', 'ctor', 'hero-detail.component.ts (constructor)')
-  :marked
-    The `HeroDetailComponent` must *not* repeat its parent's `providers` array! Guess [why](#shadow-provider).
-    
-    The `AppComponent` is the top level component of our application. 
-    There should be only one instance of that component and only one instance of the `HeroService` in our entire app.
+a#child-component
 :marked
   ### *getHeroes* in the *AppComponent*
   We've got the service in a `heroService` private variable. Let's use it.
@@ -384,18 +364,3 @@ code-example(format="." language="html").
   
   Back in the `AppComponent`, replace `heroService.getHeroes` with `heroService.getHeroesSlowly`
   and see how the app behaves.
-  
-.l-main-section
-<a id="shadow-provider"></a>
-:marked
-  ### Appendix: Shadowing the parent's service
-  
-  We stated [earlier](#child-component) that if we injected the parent `AppComponent` `HeroService`
-  into the `HeroDetailComponent`, *we must not add a providers array* to the `HeroDetailComponent` metadata.
-
-  Why?  Because that tells Angular to create a new instance of the `HeroService` at the `HeroDetailComponent` level.
-  The `HeroDetailComponent` doesn't want its *own*  service instance; it wants its *parent's* service instance.
-  Adding the `providers` array creates a new service instance that shadows the parent instance.
-  
-  Think carefully about where and when to register a provider. 
-  Understand the scope of that registration. Be careful not to create a new service instance at the wrong level.


### PR DESCRIPTION
So @johnpapa got some feedback on the ToH and asked me to try to improve it.

Let me go step by step:

_Multiple components_

>Let's add that array property to the bottom of the @Component configuration object, immediately after the template and styles properties.
>>**Which file?**
>>**Also, does it matter where in @Component configuration this is put?**

I put a label in the example to specify which file and also reworded the sentence a bit to tell that where to put the array is a matter of choice than a fixed place.

>Let’s verify that we have the following structure

>>**You might want to say “.js and .map files not shown**

This part refers to the filetrees. I personally don't think that we need to explicitly say that the .js and .map files are not shown.

---

_Services_

>The Injector has a container of previously created services. Either it finds and returns a pre-existing HeroService from its container or it creates a new instance, adds it to the container, and returns it to Angular.

>>**Say a bit more about the container. Is this an actual object I could interact with?**

After this bit, we have a link about "Learn more about dependency injection". Personally I don't think we can or even if we should talk more about containers in the tutorial. Truth being said, we never ever say the word "container" anymore in either "Dependency Injection" or "Hierarchical injectors" guides. Perhaps we could do some work on "Dependency Injection" to name those containers so the reader won't get confused.

>Recall that the AppComponent creates an instance of HeroDetail by virtue of the <my-hero-detail> tag at the bottom of its template. That HeroDetail is a child of the AppComponent.
If the HeroDetailComponent needed its parent component's HeroService, it would ask Angular to inject the service into its constructor which would look just like the one for AppComponent:

>>**This may require a bit of rewriting into smaller conceptual bites.**

>constructor(private heroService: HeroService) { }

>>**I don't think you told me to add the import statement first.**

This is a blue box on the guide that explains that if we want to inject `HeroService` in the child component, we shouldn't use the providers array. What I did here is to update the code example label to say that that is an example. It is easy for the reader to get confused and think that the snippet is something that they should code. So yes, no import statement because that is just an example.

That being said, I think that we could get rid of the box. That is just like an excerpt of the `Dependency Injection` guide and we cannot rewrite it into smaller conceptual bites, because that is what the `Dependency injection` guide does. I suggest removing the blue box or making it more explicit that this is an excerpt of the `Dependency Injection` guide and that they can learn more there.

>Appendix: Shadowing the parent's service

>>**It isn’t clear what creates the parent-child relationship**

This appendix is a continuation from the blue box and again, something that is already explained elsewhere and confuses the reader. I would drop it too.

---

So I updated the parts I see value in and if someone has a good feedback on the other points, I will update this PR.
