### PR TITLE
feat(dgeni audit): add more keys to the api-list

### DIFF
--- a/tools/api-builder/angular.io-package/processors/addJadeDataDocsProcessor.js
+++ b/tools/api-builder/angular.io-package/processors/addJadeDataDocsProcessor.js
@@ -76,12 +76,34 @@ module.exports = function addJadeDataDocsProcessor() {
               stability = 'deprecated';
             }
 
+            var howToUse = '';
+            if(_.has(exportDoc, 'howToUse')) {
+              var howToUseArray = exportDoc.tags.tags.filter(function(tag) {
+                return tag.tagName === 'howToUse'
+              });
+
+              // Remove line breaks, there should only be one tag
+              howToUse = howToUseArray[0].description.replace(/(\r\n|\n|\r)/gm,"");
+            }
+
+            var whatItDoes = '';
+            if(_.has(exportDoc, 'whatItDoes')) {
+              var whatItDoesArray = exportDoc.tags.tags.filter(function(tag) {
+                return tag.tagName === 'whatItDoes'
+              });
+
+              // Remove line breaks, there should only be one tag
+              whatItDoes = whatItDoesArray[0].description.replace(/(\r\n|\n|\r)/gm,"");
+            }
+
             var dataDoc = {
               name: exportDoc.name + '-' + exportDoc.docType,
               title: exportDoc.name,
               docType: exportDoc.docType,
               exportDoc: exportDoc,
-              stability: stability
+              stability: stability,
+              howToUse: howToUse,
+              whatItDoes: whatItDoes
             };
 
             if (exportDoc.symbolTypeName) dataDoc.varType = titleCase(exportDoc.symbolTypeName);

--- a/tools/api-builder/angular.io-package/templates/api-list-data.template.html
+++ b/tools/api-builder/angular.io-package/templates/api-list-data.template.html
@@ -4,7 +4,12 @@
     {
       "title": "{$ item.title $}",
       "path": "{$ item.exportDoc.path $}",
-      "docType": "{$ item.docType $}"
+      "docType": "{$ item.docType $}",
+      "stability": "{$ item.stability $}",
+      "secure": "{$ item.security $}",
+      "howToUse": "{$ item.howToUse $}",
+      "whatItDoes": {% if item.whatItDoes %}"Exists"{% else %}"Not Done"{% endif %},
+      "barrel" : "{$ module $}"
     }{% if not loop.last %},{% endif %}
   {% endfor %}]{% if not loop.last %},{% endif %}
 {% endfor -%}


### PR DESCRIPTION
#### Changes
* Add more keys to the api-list, this exposes the status of all api elements.
* The output is located in `ts/api-list.json` and `js/api-list.json`, this only happens when a new build is made.

#### Notes
`api-list.json` is the file that's used to create the list located at https://angular.io/docs/ts/latest/api/ (and in javascript). Since I've only made additions (and not changed previous key-value pairs), the api doc should remain unaffected. Specifically `api-list.js` will use the key-value pairs to generate the list for the api doc.

@naomiblack @petebacondarwin 