### PR TITLE
docs(plunker): revise systemjs.config for plunker to load fewer files

### DIFF
--- a/public/docs/_examples/architecture/ts/index.html
+++ b/public/docs/_examples/architecture/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/attribute-directives/ts/index.html
+++ b/public/docs/_examples/attribute-directives/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
   <body>

--- a/public/docs/_examples/cb-a1-a2-quick-reference/ts/index.html
+++ b/public/docs/_examples/cb-a1-a2-quick-reference/ts/index.html
@@ -18,7 +18,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/cb-component-communication/ts/index.html
+++ b/public/docs/_examples/cb-component-communication/ts/index.html
@@ -18,7 +18,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/cb-dependency-injection/ts/index.html
+++ b/public/docs/_examples/cb-dependency-injection/ts/index.html
@@ -19,7 +19,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/cb-dynamic-form/ts/index.html
+++ b/public/docs/_examples/cb-dynamic-form/ts/index.html
@@ -19,7 +19,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
   <body>

--- a/public/docs/_examples/cb-ts-to-js/ts/index.html
+++ b/public/docs/_examples/cb-ts-to-js/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/component-styles/ts/index.html
+++ b/public/docs/_examples/component-styles/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/dependency-injection/ts/index.html
+++ b/public/docs/_examples/dependency-injection/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
  </head>

--- a/public/docs/_examples/displaying-data/ts/index.html
+++ b/public/docs/_examples/displaying-data/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/forms/ts/index.html
+++ b/public/docs/_examples/forms/ts/index.html
@@ -23,7 +23,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/hierarchical-dependency-injection/ts/index.html
+++ b/public/docs/_examples/hierarchical-dependency-injection/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/homepage-hello-world/ts/index.html
+++ b/public/docs/_examples/homepage-hello-world/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/homepage-tabs/ts/index.html
+++ b/public/docs/_examples/homepage-tabs/ts/index.html
@@ -17,7 +17,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/homepage-todo/ts/index.html
+++ b/public/docs/_examples/homepage-todo/ts/index.html
@@ -17,7 +17,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/lifecycle-hooks/ts/index.html
+++ b/public/docs/_examples/lifecycle-hooks/ts/index.html
@@ -17,7 +17,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/pipes/ts/index.html
+++ b/public/docs/_examples/pipes/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/quickstart/ts/index.html
+++ b/public/docs/_examples/quickstart/ts/index.html
@@ -23,7 +23,7 @@
     <!-- #docregion systemjs -->
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
     <!-- #enddocregion systemjs -->
   </head>

--- a/public/docs/_examples/router-deprecated/ts/index.html
+++ b/public/docs/_examples/router-deprecated/ts/index.html
@@ -18,7 +18,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/router/ts/index.html
+++ b/public/docs/_examples/router/ts/index.html
@@ -19,7 +19,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/server-communication/ts/index.html
+++ b/public/docs/_examples/server-communication/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/structural-directives/ts/index.html
+++ b/public/docs/_examples/structural-directives/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/style-guide/ts/index.html
+++ b/public/docs/_examples/style-guide/ts/index.html
@@ -18,7 +18,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/styleguide/ts/index.html
+++ b/public/docs/_examples/styleguide/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
   <body>

--- a/public/docs/_examples/systemjs.config.plunker.js
+++ b/public/docs/_examples/systemjs.config.plunker.js
@@ -2,7 +2,6 @@
  * PLUNKER VERSION (based on systemjs.config.js in angular.io)
  * System configuration for Angular 2 samples
  * Adjust as necessary for your application needs.
- * Override at the last minute with global.filterSystemConfig (as plunkers do)
  */
 (function(global) {
 
@@ -10,10 +9,14 @@
 
   //map tells the System loader where to look for things
   var  map = {
-    'app':                        'app', // 'dist',
+    'app':                        'app',
+
+    '@angular':                   'https://npmcdn.com/@angular', // sufficient if we didn't pin the version
+    'angular2-in-memory-web-api': 'https://npmcdn.com/angular2-in-memory-web-api', // get latest
     'rxjs':                       'https://npmcdn.com/rxjs@5.0.0-beta.6',
-    'angular2-in-memory-web-api': 'https://npmcdn.com/angular2-in-memory-web-api' // get latest
-  };
+    'ts':                         'https://npmcdn.com/plugin-typescript@4.0.10/lib/plugin.js',
+    'typescript':                 'https://npmcdn.com/typescript@1.8.10/lib/typescript.js',
+ };
 
   //packages tells the System loader how to load when no filename and/or no extension
   var packages = {
@@ -22,39 +25,44 @@
     'angular2-in-memory-web-api': { defaultExtension: 'js' },
   };
 
-  var packageNames = [
-      '@angular/common',
-      '@angular/compiler',
-      '@angular/core',
-      '@angular/http',
-      '@angular/platform-browser',
-      '@angular/platform-browser-dynamic',
-      '@angular/router',
-      '@angular/router-deprecated',
-      '@angular/upgrade',
+  var ngPackageNames = [
+    'common',
+    'compiler',
+    'core',
+    'http',
+    'platform-browser',
+    'platform-browser-dynamic',
+    'router',
+    'router-deprecated',
+    'upgrade',
   ];
 
-  // add map entries for angular packages in the form '@angular/common': 'https://npmcdn.com/@angular/common@0.0.0-3?main=browser'
-  packageNames.forEach(function(pkgName) {
-    map[pkgName] = 'https://npmcdn.com/' + pkgName + ngVer;
+  // Add map entries for each angular package
+  // only because we're pinning the version with `ngVer`.
+  ngPackageNames.forEach(function(pkgName) {
+    map['@angular/'+pkgName] = 'https://npmcdn.com/@angular/' + pkgName + ngVer;
   });
 
-  // add package entries for angular packages in the form '@angular/common': { main: 'index.js', defaultExtension: 'js' }
-  packageNames.forEach(function(pkgName) {
-    packages[pkgName] = { main: 'index.js', defaultExtension: 'js' };
+  // Add package entries for angular packages
+  ngPackageNames.forEach(function(pkgName) {
+
+    // Bundled (~40 requests):
+    packages['@angular/'+pkgName] = { main: pkgName + '.umd.js', defaultExtension: 'js' };
+
+    // Individual files (~300 requests):
+    //packages['@angular/'+pkgName] = { main: 'index.js', defaultExtension: 'js' };
   });
 
   var config = {
+    // DEMO ONLY! REAL CODE SHOULD NOT TRANSPILE IN THE BROWSER
     transpiler: 'typescript',
     typescriptOptions: {
       emitDecoratorMetadata: true
     },
+
     map: map,
     packages: packages
   }
-
-  // filterSystemConfig - index.html's chance to modify config before we register it.
-  if (global.filterSystemConfig) { global.filterSystemConfig(config); }
 
   System.config(config);
 

--- a/public/docs/_examples/template-syntax/ts/index.html
+++ b/public/docs/_examples/template-syntax/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/testing/ts/index.html
+++ b/public/docs/_examples/testing/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/toh-1/ts/index.html
+++ b/public/docs/_examples/toh-1/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
 
   <body>

--- a/public/docs/_examples/toh-2/ts/index.html
+++ b/public/docs/_examples/toh-2/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/toh-3/ts/index.html
+++ b/public/docs/_examples/toh-3/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/toh-4/ts/index.html
+++ b/public/docs/_examples/toh-4/ts/index.html
@@ -15,7 +15,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/toh-5/ts/index.html
+++ b/public/docs/_examples/toh-5/ts/index.html
@@ -23,7 +23,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
   <!-- #enddocregion head -->

--- a/public/docs/_examples/tutorial/ts/index.html
+++ b/public/docs/_examples/tutorial/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/public/docs/_examples/user-input/ts/index.html
+++ b/public/docs/_examples/user-input/ts/index.html
@@ -16,7 +16,7 @@
 
     <script src="systemjs.config.js"></script>
     <script>
-      System.import('app').catch(function(err){ console.error(err);  });
+      System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
 

--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -18,17 +18,7 @@ var _rxRules = {
   link: {
     from: '/<link rel="stylesheet" href=".*%tag%".*>/',
     to: '<link rel="stylesheet" href="%tag%">'
-  },
-  config: {
-    from: /\s*System.config\(\{[\s\S]*\}\);/m,
-    to: "\n" +
-        "      System.config({\n" +
-        "        transpiler: 'typescript', \n" +
-        "        typescriptOptions: { emitDecoratorMetadata: true }, \n" +
-        "        packages: {'app': {defaultExtension: 'ts'}} \n" +
-        "      });"
-  },
-
+  }
 };
 
 var _rxData = [
@@ -38,7 +28,7 @@ var _rxData = [
   {
     pattern: 'script',
     from: 'node_modules/es6-shim/es6-shim.min.js',
-    to:   'https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.35.0/es6-shim.min.js'
+    to:   'https://npmcdn.com/es6-shim@0.35.0/es6-shim.min.js'
   },
   {
     pattern: 'script',
@@ -58,7 +48,7 @@ var _rxData = [
   {
     pattern: 'script',
     from: 'node_modules/systemjs/dist/system.src.js',
-    to:   ['https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.19.27/system.js', 'https://npmcdn.com/typescript@1.8.10/lib/typescript.js']
+    to:   'https://npmcdn.com/systemjs@0.19.27/dist/system.src.js'
   },
   {
     pattern: 'script',
@@ -72,9 +62,6 @@ var _rxData = [
   },
   {
     pattern: 'angular_pkg',
-  },
-  {
-    pattern: 'config',
   }
 ];
 


### PR DESCRIPTION
Supersedes PR #1338. Also includes the warning against transpiling in the browser.
Closes that PR

Coincidentally removes an annoying extra space after `...(err);  ` in all `index.html` files in the line `System.import('app').catch(function(err){ console.error(err);  })`