### PR TITLE
docs(glossary): promises point to dead link, update to mozilla link

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -683,7 +683,8 @@ include _util-fns
 
     The browser DOM and JavaScript have a limited number
     of asynchronous activities, activities such as DOM events (e.g., clicks),
-    [promises](#promise), and
+    [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/
+    Promise), and
     [XHR](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest)
     calls to remote servers.
 


### PR DESCRIPTION
The current promises link in the Zone section points to #promise, which doesn't exist in glossary. I added a link to Mozilla's article on Promises since the XHR link in the same section points to Mozilla as a resource.