### PR TITLE
feat(no index): remove index from api list

### DIFF
--- a/tools/api-builder/angular.io-package/templates/api-list-data.template.html
+++ b/tools/api-builder/angular.io-package/templates/api-list-data.template.html
@@ -1,6 +1,6 @@
 {
 {%- for module, items in doc.data %}
-  "{$ module $}" : [{% for item in items %}
+  "{$ module | replace("/index", "") $}" : [{% for item in items %}
     {
       "title": "{$ item.title $}",
       "path": "{$ item.exportDoc.path $}",
@@ -9,7 +9,7 @@
       "secure": "{$ item.security $}",
       "howToUse": "{$ item.howToUse $}",
       "whatItDoes": {% if item.whatItDoes %}"Exists"{% else %}"Not Done"{% endif %},
-      "barrel" : "{$ module $}"
+      "barrel" : "{$ module | replace("/index", "") $}"
     }{% if not loop.last %},{% endif %}
   {% endfor %}]{% if not loop.last %},{% endif %}
 {% endfor -%}


### PR DESCRIPTION
#### Changes
* Remove the extraneous `/index` from the api list

#### Preview
* Live: https://remove-index.firebaseapp.com/docs/ts/latest/api/
* Live: https://remove-index.firebaseapp.com/docs/js/latest/api/

##### Before
<img width="1188" alt="screen shot 2016-05-12 at 10 49 33 am" src="https://cloud.githubusercontent.com/assets/1329167/15218755/442076e6-182f-11e6-9fb8-032193a5a3b9.png">

##### After
<img width="1193" alt="screen shot 2016-05-12 at 10 49 18 am" src="https://cloud.githubusercontent.com/assets/1329167/15218765/50e43c14-182f-11e6-8ee6-d3b484858e5d.png">

CLOSES:
* https://github.com/angular/angular.io/issues/1359

@petebacondarwin @naomiblack 
