### PR TITLE
fix(copy btn): remove overflow from copy button

### DIFF
--- a/public/resources/css/main.scss
+++ b/public/resources/css/main.scss
@@ -54,6 +54,7 @@
 @import 'module/press-kit';
 @import 'module/features';
 @import 'module/docs-landing';
+@import 'module/copy';
 
 /*
 * PRINT STYLES

--- a/public/resources/css/module/_copy.scss
+++ b/public/resources/css/module/_copy.scss
@@ -1,0 +1,10 @@
+.copy-container-template {
+  position: relative;
+
+  & > .copy-button {
+    margin-top: 8px;
+    right: 0;
+    z-index: 1;
+    position: absolute;
+  }
+}

--- a/public/resources/js/directives/copy.js
+++ b/public/resources/js/directives/copy.js
@@ -24,8 +24,8 @@ angularIO.directive('copyContainer', function() {
     restrict: 'E',
     transclude: true,
     template:
-      '<div style="position: relative; overflow: auto;">' +
-        '<copy-button style="position: absolute; top: 18px; right: 0px; z-index: 1" ></copy-button>' +
+      '<div class="copy-container-template">' +
+        '<copy-button class="copy-button"></copy-button>' +
         '<ng-transclude></ng-transclude>' +
       '</div>'
   };


### PR DESCRIPTION
#### Changes
* Refactor inline styles from directive to a SASS file
* Remove overflow from copy button which was causing scroll bars to appear
* Adjust button to the top right of the `.copy-container-template`

#### Preview
* Live: https://copy-btn-no-scroll.firebaseapp.com/docs/ts/latest/quickstart.html

CLOSES:
* https://github.com/angular/angular.io/issues/1331

@naomiblack 