### PR TITLE
feat(filter stable): filter by stability stable

### DIFF
--- a/public/resources/js/directives/api-list.js
+++ b/public/resources/js/directives/api-list.js
@@ -27,6 +27,7 @@ angularIO.directive('apiList', function () {
       var $ctrl = this;
 
       $ctrl.apiTypes = [
+        { cssClass: 'stable', title: 'Stable', matches: ['stable']},
         { cssClass: 'directive', title: 'Directive', matches: ['directive'] },
         { cssClass: 'decorator', title: 'Decorator', matches: ['decorator'] },
         { cssClass: 'class', title: 'Class', matches: ['class'] },
@@ -51,6 +52,16 @@ angularIO.directive('apiList', function () {
         var isVisible = false;
 
         section.items.forEach(function(item) {
+
+          // Filter by stability (ericjim: only 'stable' for now)
+          if ($ctrl.apiType && $ctrl.apiType.matches.length === 1 &&
+              $ctrl.apiType.matches[0] === 'stable' && item.stability === 'stable') {
+            item.show = true;
+            isVisible = true;
+            return isVisible;
+          }  // NOTE: other checks can be performed for stability (experimental, deprecated, etc)
+
+          // Filter by docType
           var matchesDocType = !$ctrl.apiType || $ctrl.apiType.matches.indexOf(item.docType) !== -1;
           var matchesTitle = !apiFilter || item.title.toLowerCase().indexOf(apiFilter) !== -1;
           item.show = matchesDocType && (matchesTitle || matchesModule);


### PR DESCRIPTION
### Changes
* Add a "Stable" filter on the api doc list which will only show api elements that have the `@stable` tag

### Preview
* Live preview: https://filter-by-stable.firebaseapp.com/docs/ts/latest/api/#!?apiType=Stable

### Notes
angular2 has yet to incorporate the `@stable` tag, as a result, we will not be merging this branch until some work is done on that end.

@naomiblack 