### PR TITLE
docs(style-guide): avoid I prefix for interface naming convention

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -688,9 +688,9 @@ a(href="#toc") Back to top
   :marked
     **Do** name an interface using upper camel case.
 
-.s-rule.do
+.s-rule.avoid
   :marked
-    **Consider** naming an interface without an `I` prefix.
+    **Avoid** prefixing interfaces with an `I`.
 
 .s-why.s-why-last
   :marked


### PR DESCRIPTION
The `style-guide` first points out that you should consider to not use an I prefix for interfaces and 2 lines later says you should avoid it. This should be consistent. (Also 'Consider' has a blue mark on the left side instead of a green one). 

![image](https://cloud.githubusercontent.com/assets/6278665/15253026/b7287326-1930-11e6-8efd-cf364e4e58e3.png)
