### PR TITLE
docs(style-guide): push main.ts to src folder

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -965,7 +965,7 @@ a(href="#toc") Back to top
       .children
         .file ...
       .file app.component.ts|html|css|spec.ts
-      .file main.ts
+    .file main.ts
     .file index.html
     .file ...
 :marked
@@ -1030,7 +1030,7 @@ a(href="#toc") Back to top
         .children
           .file ...
       .file app.component.ts|html|css|spec.ts
-      .file main.ts
+    .file main.ts
     .file index.html
     .file ...
 :marked
@@ -1105,7 +1105,7 @@ a(href="#toc") Back to top
           .file ...
         .file ...
       .file app.component.ts|html|css|spec.ts
-      .file main.ts
+    .file main.ts
     .file index.html
     .file ...
 :marked
@@ -1156,7 +1156,7 @@ a(href="#toc") Back to top
         .file index.ts
         .file ...
       .file app.component.ts|html|css|spec.ts
-      .file main.ts
+    .file main.ts
     .file index.html
     .file ...
 :marked
@@ -1232,7 +1232,7 @@ a(href="#toc") Back to top
         .file ...
         .file index.ts
       .file app.component.ts|html|css|spec.ts
-      .file main.ts
+    .file main.ts
     .file index.html
     .file ...
 :marked


### PR DESCRIPTION
/cc @johnpapa  @wardbell  @Brocco @mgechev

We agreed on pushing `main.ts` to the src folder so here it is. We also talked about adding a barrel in `/src/app/` with a single export, but that is a no-no for @wardbell.

So with this PR and Ward's opinion, we can close the next issue:

Closes #1361