### PR TITLE
chore: remove typings.d.ts from style guide

### DIFF
--- a/public/docs/_examples/style-guide/ts/04-10/app/typings.d.ts
+++ b/public/docs/_examples/style-guide/ts/04-10/app/typings.d.ts
@@ -1,1 +1,0 @@
-declare var module.id: any;


### PR DESCRIPTION
With the new node typings, this is not needed anymore.