### PR TITLE
docs(glossary): update the example paths for the glossary

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -84,7 +84,7 @@ include _util-fns
 // #enddocregion b-c
 :marked
   That's why we can write this:
-+makeExample('../docs/_fragments/quickstart/ts/app/app.component.ts', 'import')(format=".")
++makeExample('quickstart/ts/app/app.component.ts', 'import')(format=".")
 // #docregion b-c
 
 :marked
@@ -583,7 +583,7 @@ include _util-fns
     The only difference, from a consumer perspective, 
     is that the package name begins with the Angular *scope name*, `@angular`.
 // #enddocregion n-s
-+makeExample('../docs/_fragments/architecture/ts/app/app.component.ts', 'import')(format=".")
++makeExample('architecture/ts/app/app.component.ts', 'import')(format=".")
 // #docregion n-s
 
 :marked


### PR DESCRIPTION
The previous paths caused this error on the glossary page:
```
BAD FILENAME: ../../_fragments/../docs/_fragments/quickstart/ts/app/app.component-import.ts.md   Current path: docs,ts,latest,glossary PathToDocs: ../../
```