### PR TITLE
fix(resources): use title key from firebase. 

### DIFF
--- a/public/resources/css/module/_resources.scss
+++ b/public/resources/css/module/_resources.scss
@@ -1,10 +1,10 @@
 .resources {
   display: flex;
   justify-content: space-between;
-  flex-wrap: wrap;
   flex-direction: row-reverse;
 
-  @media(max-width: 400px) {
+  @media(max-width: 768px) {
+    justify-content: center;
     flex-direction: column-reverse;
   }
 

--- a/public/resources/index.ejs
+++ b/public/resources/index.ejs
@@ -5,10 +5,10 @@
         <div>
             <h1 class="capitalize">{{category}}</h1>
             <div ng-repeat="section in categoryContent">
-                <div class="grid-fluid" ng-repeat="(subsectionName, subsectionArray) in section">
+                <div ng-repeat="(subsectionName, subsectionObj) in section">
                     <div>
-                        <h2 class="capitalize">{{ subsectionName }}</h2>
-                        <ul ng-repeat="resource in subsectionArray.resources">
+                        <h2>{{ subsectionObj.title }}</h2>
+                        <ul ng-repeat="resource in subsectionObj.resources">
                             <li ng-if="resource.rev"><a target="_blank" href="{{resource.url}}">{{ resource.title }}</a></li>
                         </ul>
                     </div>


### PR DESCRIPTION
#### Changes: 
* Use `title` key from firebase for each subsection, this fixes the odd titles (`Ui, Ide`)
* No longer using `capitalize` since the data on firebase already comes preformatted on titles.
* Adjust breakpoint for single column layout, use `space-around` to increase the gutter spacing between columns

#### Preview 
* Live Preview: https://resources-db.firebaseapp.com/resources/

#### Notes
We still use `capitalize` and `h1` tags for each individual section: Education, Development, Community. No one has objected my use of them, so I will keep them for now. Also, we need a design for this, this will occur after Google I/O

@naomiblack @juleskremer @PeEllAvaj 