### PR TITLE
[WIP] fix(github link): replace relativePath from github link

### DIFF
--- a/tools/api-builder/angular.io-package/templates/lib/githubLinks.html
+++ b/tools/api-builder/angular.io-package/templates/lib/githubLinks.html
@@ -1,7 +1,7 @@
 {% macro githubHref(doc) -%}
-https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/modules/{$ doc.fileInfo.relativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}
+https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/modules/{$ doc.fileInfo.relativePath | replace( r/.*angular\/modules\// , "") $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}
 {%- endmacro %}
 
 {% macro githubViewLink(doc) -%}
-  <a href="{$ githubHref(doc) $}">{$ doc.fileInfo.relativePath $} (line {$ doc.location.start.line+1 $})</a>
+  <a href="{$ githubHref(doc) $}">{$ doc.fileInfo.relativePath | replace( r/.*angular\/modules\// , "") $} (line {$ doc.location.start.line+1 $})</a>
 {%- endmacro -%}


### PR DESCRIPTION
WIP, do not merge; @petebacondarwin has suggested I amend https://github.com/angular/angular.io/pull/1224/files in some ways to fix this issue.

#### Changes
* Construct the github url, from all api docs, appropriately.
* Replace the part of the github link with pertains to the relative path of whomever is deploying the repo.

#### Preview
https://doc-bottom-link.firebaseapp.com/docs/ts/latest/api

#### Notes
* Is there a better solution? I am not sure. @petebacondarwin 

CLOSES:
https://github.com/angular/angular.io/issues/1433

@naomiblack 