### PR TITLE
doc(dart): add link to AngularDart API docs

### DIFF
--- a/public/docs/dart/latest/index.jade
+++ b/public/docs/dart/latest/index.jade
@@ -33,3 +33,6 @@ class="docs-landing")
         footer
           a(href="/docs/#{current.path[1]}/#{current.path[2]}/api/" class="button md-button") View API
 
+.alert.is-helpful.
+  Not using Angular 2 yet? Perhaps you need the
+  <a href="https://www.dartdocs.org/documentation/angular/latest" target="_blank">API docs for the original AngularDart</a>.


### PR DESCRIPTION
@naomiblack when you get a chance, could you review this change that I made eons ago but misplaced...