### PR TITLE
chore: translate inline system config for plunker

### DIFF
--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -18,6 +18,14 @@ var _rxRules = {
   link: {
     from: '/<link rel="stylesheet" href=".*%tag%".*>/',
     to: '<link rel="stylesheet" href="%tag%">'
+  },
+  system_extra_main: {
+    from: /main:\s*[\'|\"]index.js[\'|\"]/,
+    to: 'main: "index.ts"'
+  },
+  system_extra_defaultExtension: {
+    from: /defaultExtension:\s*[\'|\"]js[\'|\"]/,
+    to: 'defaultExtension: "ts"'
   }
 };
 
@@ -62,6 +70,12 @@ var _rxData = [
   },
   {
     pattern: 'angular_pkg',
+  },
+  {
+    pattern: 'system_extra_main'
+  },
+  {
+    pattern: 'system_extra_defaultExtension'
   }
 ];
 


### PR DESCRIPTION
Put it in two separate options so you can translate one, both or none in no specific order.

Fixes #1424 