### PR TITLE
docs(server-communication): Modify file name 'rxjs-operators'

### DIFF
--- a/public/docs/ts/latest/guide/server-communication.jade
+++ b/public/docs/ts/latest/guide/server-communication.jade
@@ -235,7 +235,7 @@ block rxjs
     because the full library is so big. We only use a few operators in our app.
     
     Instead, we'll import each `Observable` operator and static class method, one-by-one, until we have a custom *Observable* implementation tuned
-    precisely to our requirements. We'll put the `import` statements in one `app/add-rxjs-operators.ts` file.
+    precisely to our requirements. We'll put the `import` statements in one `app/rxjs-operators.ts` file.
   +makeExample('server-communication/ts/app/rxjs-operators.ts', null, 'app/rxjs-operators.ts')(format=".")
   :marked
     If we forget an operator, the TypeScript compiler will warn that it's missing and we'll update this file.
@@ -632,7 +632,7 @@ block wikipedia-jsonp+
   .l-sub-section
     :marked
       We added the `debounceTime`, `distinctUntilChanged`, and `switchMap` operators to the RxJS `Observable` class
-      in `add-rxjs-operators` as [described above](#rxjs)
+      in `rxjs-operators` as [described above](#rxjs)
 
 a#in-mem-web-api
 .l-main-section


### PR DESCRIPTION
Modify file name 'add-rxjs-operators.ts' to 'rxjs-operators.ts', according to real file name.
Ref: https://angular.io/resources/live-examples/server-communication/ts/plnkr.html