### PR TITLE
docs: add recommended node and npm versions

### DIFF
--- a/public/docs/ts/latest/guide/npm-packages.jade
+++ b/public/docs/ts/latest/guide/npm-packages.jade
@@ -5,9 +5,17 @@ include ../_util-fns
   These packages are maintained and installed with the Node Package Manager (<a href="https://docs.npmjs.com/" target="_blank">npm</a>).
 .l-sub-section
   :marked
-    Don't have npm?
-    <a href="https://docs.npmjs.com/getting-started/installing-node" target="_blank" title="Installing Node.js and updating npm">Get it now</a>
-    because we're going to use it now and repeatedly throughout this documentation.
+    Node.js and npm are essential to Angular 2 development. 
+    
+    <a href="https://docs.npmjs.com/getting-started/installing-node" target="_blank" title="Installing Node.js and updating npm">
+    Get it now</a> if it's not already installed on your machine
+ 
+    **Verify that you are running node `v5.x.x` and npm `3.x.x`**
+    by running `node -v` and `npm -v` in a terminal/console window.
+    Older and newer versions produce errors.
+
+    We recommend [nvm](https://github.com/creationix/nvm) for managing multiple versions of node and npm.
+
 :marked
   We recommend a comprehensive starter-set of packages as specified in the `dependencies` and `devDependencies`
   sections of the QuickStart

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -49,6 +49,11 @@ block setup-tooling
   :marked
     Install **[Node.js® and npm](https://nodejs.org/en/download/)**
     if they are not already on your machine.
+  .l-sub-section
+    :marked
+      **Verify that you are running node `v5.x.x` and npm `3.x.x`**
+      by running `node -v` and `npm -v` in a terminal/console window.
+      Older and newer versions produce errors.
 
 block download-source
   .l-main-section


### PR DESCRIPTION
Other versions (4.x and 6.x) are problematic as today so we will recommend those versions for the time being.