### PR TITLE
docs(template-syntax): review and update Dart to new doc design

### DIFF
--- a/public/_includes/_util-fns.jade
+++ b/public/_includes/_util-fns.jade
@@ -21,6 +21,7 @@
 - var _an = 'an';
 
 //- TS arrays vs. Dart lists
+- var _Array = 'Array';
 - var _array = 'array';
 //- Deprecate now that we have the articles _a and _an
 - var _an_array = 'an array';
@@ -32,6 +33,9 @@
 //- Location of sample code
 - var _liveLink = 'live link';
 
+//- Other
+- var _truthy = 'truthy';
+- var _falsey = 'falsey';
 
 //- Used to prefix identifiers that are private. In Dart this will be '_'.
 - var _priv = '';
@@ -39,8 +43,8 @@
 //- Use to conditionally include the block that follows +ifDocsFor(...).
 //- Generally favor use of Jade named blocks instead. ifDocsFor is convenient
 //- for prose that should appear only in one language version.
-mixin ifDocsFor(lang)
-  if _docsFor.toLowerCase() === lang.toLowerCase()
+mixin ifDocsFor(langPattern)
+  if _docsFor.toLowerCase().match(langPattern.toLowerCase())
     block
 
 //- Use to map inlined (prose) TS paths into, say, Dart paths via the

--- a/public/docs/_examples/template-syntax/dart/lib/app_component.dart
+++ b/public/docs/_examples/template-syntax/dart/lib/app_component.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:html';
 
 import 'package:angular2/core.dart';
+import 'package:angular2/common.dart';
 
 import 'hero.dart';
 import 'hero_detail_component.dart';
@@ -40,7 +41,9 @@ class AppComponent implements OnInit, AfterViewInit {
   bool isSpecial = true;
   bool isUnchanged = true;
   bool isSelected = false;
+  final Color colorRed = Color.red;
   Color color = Color.red;
+  var colorEnum = Color;
 
   List<Hero> heroes;
   Hero currentHero;
@@ -56,7 +59,7 @@ class AppComponent implements OnInit, AfterViewInit {
   final Hero nullHero = null;
   Map product = {'name': 'frimfram', 'price': 42};
   FormElement form;
-  String clickity = '';
+  String clicked = '';
   String clickMessage = '';
   String clickMessage2 = '';
   final String iconUrl = 'assets/images/ng-logo.png';
@@ -87,14 +90,14 @@ class AppComponent implements OnInit, AfterViewInit {
 
   int getVal() => val;
 
-  void onCancel(MouseEvent event) {
-    DivElement el = event.target;
+  void onCancel(UIEvent event) {
+    HtmlElement el = event?.target;
     var evtMsg = event != null ? 'Event target is ${el.innerHtml}.' : '';
     alerter('Canceled. $evtMsg');
   }
 
-  void onClickMe(MouseEvent event) {
-    DivElement el = event.target;
+  void onClickMe(UIEvent event) {
+    HtmlElement el = event?.target;
     var evtMsg = event != null ? 'Event target class is ${el.className}.' : '';
     alerter('Click me. $evtMsg');
   }
@@ -103,9 +106,10 @@ class AppComponent implements OnInit, AfterViewInit {
     alerter('Deleted hero: ${hero?.firstName}');
   }
 
-  bool onSave([MouseEvent event = null]) {
+  bool onSave([UIEvent event = null]) {
+    HtmlElement el = event?.target;
     var evtMsg =
-        event != null ? ' Event target is ${event.target.innerHtml}.' : '';
+        event != null ? ' Event target is ${el.innerHtml}.' : '';
     alerter('Saved. $evtMsg');
     return false;
   }

--- a/public/docs/_examples/template-syntax/dart/lib/app_component.html
+++ b/public/docs/_examples/template-syntax/dart/lib/app_component.html
@@ -31,11 +31,11 @@
 </div>
 <br>
 <a href="#star-prefix">* prefix and &lt;template&gt;</a><br>
-<a href="#local-vars">Template local variables</a><br>
+<a href="#ref-vars">Template reference variables</a><br>
 <a href="#inputs-and-outputs">Inputs and outputs</a><br>
 <a href="#pipes">Pipes</a><br>
 <a href="#safe-navigation-operator">Safe navigation operator <i>?.</i></a><br>
-<!--<a href="#enums">Enums</a><br>-->
+<a href="#enums">Enums</a><br>
 
 <!-- Interpolation and expressions -->
 <hr><h2 id="interpolation">Interpolation</h2>
@@ -105,9 +105,9 @@
 <!-- #docregion event-binding-syntax-1 -->
 <button (click) = "onSave()">Save</button>
 <hero-detail (deleteRequest)="deleteHero()"></hero-detail>
-<div (myClick)="clickity=$event">click me</div>
+<div (myClick)="clicked=$event">click me</div>
 <!-- #enddocregion event-binding-syntax-1 -->
-{{clickity}}
+{{clicked}}
 <br><br>
 
 <div>
@@ -184,15 +184,14 @@ button</button>
 <!-- #enddocregion property-binding-5 -->
 
 <!-- #docregion property-binding-6 -->
-  <!-- BAD! HeroDetailComponent.hero expects a Hero object,
-  not the string "currentHero".
-
-  <hero-detail hero="currentHero"></hero-detail> -->
+<!-- ERROR: HeroDetailComponent.hero expects a
+     Hero object, not the string "currentHero" -->
 <!-- #enddocregion property-binding-6 -->
-
-<!--  In checked mode, uncommenting the hero-detail above causes this:
-    EXCEPTION: type 'String' is not a subtype of type 'Hero' of 'value'. -->
-
+<div *ngIf="false">
+<!-- #docregion property-binding-6 -->
+  <hero-detail hero="currentHero"></hero-detail>
+<!-- #enddocregion property-binding-6 -->
+</div>
 <!-- #docregion property-binding-7 -->
 <hero-detail prefix="You are my" [hero]="currentHero"></hero-detail>
 <!-- #enddocregion property-binding-7 -->
@@ -202,7 +201,7 @@ Interpolated: <img src="{{heroImageUrl}}"><br>
 Property bound: <img [src]="heroImageUrl">
 
 <div>The interpolated title is {{title}}</div>
-<div [textContent]="'The [textContent] title is '+title"></div>
+<div [innerHTML]="'The [innerHTML] title is '+title"></div>
 <!-- #enddocregion property-binding-vs-interpolation -->
 
 <a class="to-toc" href="#toc">top</a>
@@ -258,9 +257,7 @@ Property bound: <img [src]="heroImageUrl">
 <!-- #docregion class-binding-2 -->
 <!-- reset/override all class names with a binding  -->
 <div class="bad curly special"
-     [class]="badCurly">Bad curly</div>
-<p><b>Note:</b> "Bad curly" should be smaller but isn't, due to
-  <a href="http://github.com/angular/angular/issues/6901">issue #6901</a>.</p>
+     [className]="badCurly">Bad curly</div>
 <!-- #enddocregion class-binding-2 -->
 
 <!-- #docregion class-binding-3 -->
@@ -374,15 +371,15 @@ bindon-ngModel
 <br>
 <!-- #docregion NgModel-3 -->
 <input
-    [ngModel]="currentHero.firstName"
-    (ngModelChange)="currentHero.firstName=$event">
+  [ngModel]="currentHero.firstName"
+  (ngModelChange)="currentHero.firstName=$event">
 <!-- #enddocregion NgModel-3 -->
 (ngModelChange) = "...firstName=$event"
 <br>
 <!-- #docregion NgModel-4 -->
 <input
-    [ngModel]="currentHero.firstName"
-    (ngModelChange)="setUpperCaseFirstName($event)">
+  [ngModel]="currentHero.firstName"
+  (ngModelChange)="setUpperCaseFirstName($event)">
 <!-- #enddocregion NgModel-4 -->
 (ngModelChange) = "setUpperCaseFirstName($event)"
 <br>
@@ -443,7 +440,7 @@ bindon-ngModel
 <!-- #enddocregion NgIf-1 -->
 
 <!-- #docregion NgIf-2 -->
-<!-- not displayed because nullHero is false.
+<!-- because of the ngIf guard
     `nullHero.firstName` never has a chance to fail -->
 <div *ngIf="nullHero != null">Hello, {{nullHero.firstName}}</div>
 
@@ -487,33 +484,33 @@ bindon-ngModel
 </fieldset>
 
 <div class="toe">
-    <div *ngIf="toeChoice == null">Pick a toe</div>
-    <div *ngIf="toeChoice != null">
-      You picked ...
-      <!-- #docregion NgSwitch, NgSwitch-expanded -->
-      <span [ngSwitch]="toeChoice">
+  <div *ngIf="toeChoice == null">Pick a toe</div>
+  <div *ngIf="toeChoice != null">
+    You picked ...
+    <!-- #docregion NgSwitch, NgSwitch-expanded -->
+    <span [ngSwitch]="toeChoice">
       <!-- #enddocregion NgSwitch -->
 
-        <!-- with *NgSwitch -->
-        <!-- #docregion NgSwitch -->
-        <span *ngSwitchWhen="'Eenie'">Eenie</span>
-        <span *ngSwitchWhen="'Meanie'">Meanie</span>
-        <span *ngSwitchWhen="'Miney'">Miney</span>
-        <span *ngSwitchWhen="'Moe'">Moe</span>
-        <span *ngSwitchDefault>other</span>
-        <!-- #enddocregion NgSwitch -->
+      <!-- with *NgSwitch -->
+      <!-- #docregion NgSwitch -->
+      <span *ngSwitchWhen="'Eenie'">Eenie</span>
+      <span *ngSwitchWhen="'Meanie'">Meanie</span>
+      <span *ngSwitchWhen="'Miney'">Miney</span>
+      <span *ngSwitchWhen="'Moe'">Moe</span>
+      <span *ngSwitchDefault>other</span>
+      <!-- #enddocregion NgSwitch -->
 
-        <!-- with <template> -->
-        <template ngSwitchWhen="Eenie"><span>Eenie</span></template>
-        <template ngSwitchWhen="Meanie"><span>Meanie</span></template>
-        <template ngSwitchWhen="Miney"><span>Miney</span></template>
-        <template ngSwitchWhen="Moe"><span>Moe</span></template>
-        <template ngSwitchDefault><span>other</span></template>
+      <!-- with <template> -->
+      <template [ngSwitchWhen]="'Eenie'"><span>Eenie</span></template>
+      <template [ngSwitchWhen]="'Meanie'"><span>Meanie</span></template>
+      <template [ngSwitchWhen]="'Miney'"><span>Miney</span></template>
+      <template [ngSwitchWhen]="'Moe'"><span>Moe</span></template>
+      <template ngSwitchDefault><span>other</span></template>
 
       <!-- #docregion NgSwitch -->
-      </span>
-      <!-- #enddocregion NgSwitch, NgSwitch-expanded -->
-    </div>
+    </span>
+    <!-- #enddocregion NgSwitch, NgSwitch-expanded -->
+  </div>
 </div>
 
 <a class="to-toc" href="#toc">top</a>
@@ -620,7 +617,7 @@ bindon-ngModel
 <p><i>expand to &lt;template&gt;</i></p>
 <!-- #docregion Template-2 -->
 <template [ngIf]="currentHero != null">
-    <hero-detail [hero]="currentHero"></hero-detail>
+  <hero-detail [hero]="currentHero"></hero-detail>
 </template>
 <!-- #enddocregion Template-2 -->
 
@@ -644,15 +641,15 @@ bindon-ngModel
   <!-- ngFor w/ hero-detail Component inside a template element -->
   <!-- #docregion Template-4 -->
   <template ngFor let-hero [ngForOf]="heroes" [ngForTrackBy]="trackByHeroes">
-      <hero-detail [hero]="hero"></hero-detail>
+    <hero-detail [hero]="hero"></hero-detail>
   </template>
   <!-- #enddocregion Template-4 -->
 </div>
 
 <a class="to-toc" href="#toc">top</a>
 
-<!-- template local variable -->
-<hr><h2 id="local-vars">Template local variables</h2>
+<!-- template reference variable -->
+<hr><h2 id="ref-vars">Template reference variables</h2>
 
 <!-- #docregion ref-phone -->
 <!-- phone refers to the input element; pass its `value` to an event handler -->
@@ -672,7 +669,7 @@ bindon-ngModel
   <div class="form-group">
     <label for="name">Name</label>
     <input class="form-control" required ngControl="firstName"
-        [(ngModel)]="currentHero.firstName">
+      [(ngModel)]="currentHero.firstName">
   </div>
 <!-- #docregion ref-form-a -->
   <button type="submit" [disabled]="!theForm.form.valid">Submit</button>
@@ -682,7 +679,7 @@ bindon-ngModel
 <br><br>
 
 <!-- btn refers to the button element; show its disabled state -->
-<button #btn disabled [textContent]="'disabled by attribute: ' + btn.disabled.toString()"></button>
+<button #btn disabled [innerHTML]="'disabled by attribute: ' + btn.disabled.toString()"></button>
 
 <a class="to-toc" href="#toc">top</a>
 
@@ -708,13 +705,15 @@ bindon-ngModel
 <hr><h2 id="pipes">Pipes</h2>
 
 <!-- #docregion pipes-1 -->
-<!-- Force title to uppercase -->
-<div>{{ title | uppercase }}</div>
+<div>Title through uppercase pipe: {{title | uppercase}}</div>
 <!-- #enddocregion pipes-1 -->
 
 <!-- #docregion pipes-2 -->
-<!-- Pipe chaining: force title to uppercase, then to lowercase -->
-<div>{{ title | uppercase | lowercase }}</div>
+<!-- Pipe chaining: convert title to uppercase, then to lowercase -->
+<div>
+  Title through a pipe chain:
+  {{title | uppercase | lowercase}}
+</div>
 <!-- #enddocregion pipes-2 -->
 
 <!-- #docregion pipes-3 -->
@@ -723,16 +722,14 @@ bindon-ngModel
 <!-- #enddocregion pipes-3 -->
 
 <!-- #docregion pipes-json -->
-<!-- We don't suggest using json for debugging; you'd probably use toString() instead.
-     Is there a good use for the json pipe in Dart? -->
-<!--<div>{{currentHero | json}}</div>-->
+<div>{{currentHero}}</div>
 <!-- #enddocregion pipes-json -->
 
 <div>Birthdate: {{(currentHero?.birthdate | date:'longDate') | uppercase}}</div>
 
 <div>
   <!-- pipe price to USD and display the $ symbol -->
-  <label>Price: </label>{{product['price'] | currency:'$'}}
+  <label>Price: </label>{{product['price'] | currency:'USD':false}}
 </div>
 
 <a class="to-toc" href="#toc">top</a>
@@ -742,7 +739,7 @@ bindon-ngModel
 
 <div>
   <!-- #docregion safe-1 -->
-  The title is {{ title }}
+  The title is {{title}}
   <!-- #enddocregion safe-1 -->
 </div>
 
@@ -759,11 +756,10 @@ bindon-ngModel
 </div>
 
 
-
 <!--
 The null hero's name is {{nullHero.firstName}}
 
-  See console log:
+See console log:
   EXCEPTION: The null object does not have a getter 'firstName'.
 -->
 
@@ -784,19 +780,16 @@ The null hero's name is {{nullHero.firstName}}
 
 <a class="to-toc" href="#toc">top</a>
 
-<!-- Todo: discuss this in the Style binding section -->
+<!-- TODO: discuss this in the Style binding section -->
 <!-- enums in bindings -->
-
 <hr><h2 id="enums">Enums in binding</h2>
 
-<!--<p>The name of the Color.red enum is {{color}}</p>-->
-<p>The current color number is {{color}}</p>
-<p><button [style.color]="color.toString()" (click)="colorToggle()">Enum Toggle</button>
-
-<a class="to-toc" href="#toc">top</a>
-
-<!-- #docregion my-first-app -->
-<h3>My First Angular Application</h3>
-<!-- #enddocregion my-first-app -->
+<p>
+  <!-- #docregion enums -->
+  The name of the Color.red enum is {{colorRed}}.<br>
+  The current color is {{color}} and its index is {{color.index}}.<br>
+  <button [style.color]="color.toString()" (click)="colorToggle()">Enum Toggle</button>
+  <!-- #enddocregion enums -->
+</p>
 
 <a class="to-toc" href="#toc">top</a>

--- a/public/docs/_examples/template-syntax/ts/app/app.component.html
+++ b/public/docs/_examples/template-syntax/ts/app/app.component.html
@@ -52,13 +52,13 @@
 <!-- #enddocregion title+image -->
 
 <!-- #docregion sum-1 -->
-  <!-- "The sum of 1 + 1 is 2" -->
-  <p>The sum of 1 + 1 is {{1 + 1}}</p>
+<!-- "The sum of 1 + 1 is 2" -->
+<p>The sum of 1 + 1 is {{1 + 1}}</p>
 <!-- #enddocregion sum-1 -->
 
 <!-- #docregion sum-2 -->
-  <!-- "The sum of 1 + 1 is not 4" -->
-  <p>The sum of 1 + 1 is not {{1 + 1 + getVal()}}</p>
+<!-- "The sum of 1 + 1 is not 4" -->
+<p>The sum of 1 + 1 is not {{1 + 1 + getVal()}}</p>
 <!-- #enddocregion sum-2 -->
 
 <a class="to-toc" href="#toc">top</a>
@@ -66,8 +66,8 @@
 <!-- New Mental Model -->
 <hr><h2 id="mental-model">New Mental Model</h2>
 
- <!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
- <!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
+<!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
+<!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
 <!-- #docregion img+button -->
 <div class="special">Mental Model</div>
 <img src="images/hero.png">
@@ -184,13 +184,14 @@ button</button>
 <!-- #enddocregion property-binding-5 -->
 
 <!-- #docregion property-binding-6 -->
-<!--
-  BAD!
-  HeroDetailComponent.hero expects a Hero object,
-  not the string "currentHero"
- -->
-<hero-detail hero="currentHero"></hero-detail>
+<!-- ERROR: HeroDetailComponent.hero expects a
+     Hero object, not the string "currentHero" -->
 <!-- #enddocregion property-binding-6 -->
+<div *ngIf="false">
+<!-- #docregion property-binding-6 -->
+  <hero-detail hero="currentHero"></hero-detail>
+<!-- #enddocregion property-binding-6 -->
+</div>
 <!-- #docregion property-binding-7 -->
 <hero-detail prefix="You are my" [hero]="currentHero"></hero-detail>
 <!-- #enddocregion property-binding-7 -->
@@ -199,8 +200,8 @@ button</button>
 Interpolated: <img src="{{heroImageUrl}}"><br>
 Property bound: <img [src]="heroImageUrl">
 
-  <div>The interpolated title is {{title}}</div>
-  <div [innerHTML]="'The [innerHTML] title is '+title"></div>
+<div>The interpolated title is {{title}}</div>
+<div [innerHTML]="'The [innerHTML] title is '+title"></div>
 <!-- #enddocregion property-binding-vs-interpolation -->
 
 <a class="to-toc" href="#toc">top</a>
@@ -278,13 +279,13 @@ Property bound: <img [src]="heroImageUrl">
 <hr><h2 id="style-binding">Style Binding</h2>
 
 <!-- #docregion style-binding-1 -->
-<button [style.color] = "isSpecial ? 'red' : 'green'">Red</button>
-<button [style.backgroundColor]="canSave ?'cyan' : 'grey'" >Save</button>
+<button [style.color] = "isSpecial ? 'red': 'green'">Red</button>
+<button [style.background-color]="canSave ? 'cyan': 'grey'" >Save</button>
 <!-- #enddocregion style-binding-1 -->
 
 <!-- #docregion style-binding-2 -->
-<button [style.fontSize.em]="isSpecial ? 3 : 1" >Big</button>
-<button [style.fontSize.%]="!isSpecial ? 150 : 50" >Small</button>
+<button [style.font-size.em]="isSpecial ? 3 : 1" >Big</button>
+<button [style.font-size.%]="!isSpecial ? 150 : 50" >Small</button>
 <!-- #enddocregion style-binding-2 -->
 
 <a class="to-toc" href="#toc">top</a>
@@ -393,7 +394,7 @@ bindon-ngModel
 <div [ngClass]="setClasses()">This div is saveable and special</div>
 <!-- #enddocregion NgClass-1 -->
 <div [ngClass]="setClasses()" #classDiv>
-After setClasses(), the classes are "{{classDiv.className}}"
+  After setClasses(), the classes are "{{classDiv.className}}"
 </div>
 
 <!-- not used in chapter -->
@@ -409,8 +410,8 @@ After setClasses(), the classes are "{{classDiv.className}}"
 <hr><h2 id="ngStyle">NgStyle Binding</h2>
 
 <!-- #docregion NgStyle-1 -->
-<div [style.fontSize]="isSpecial ? 'x-large' : 'smaller'" >
-  This div is x-large
+<div [style.font-size]="isSpecial ? 'x-large' : 'smaller'" >
+  This div is x-large.
 </div>
 <!-- #enddocregion NgStyle-1 -->
 
@@ -418,12 +419,12 @@ After setClasses(), the classes are "{{classDiv.className}}"
 <p>setStyles returns {{setStyles() | json}}</p>
 <!-- #docregion NgStyle-2 -->
 <div [ngStyle]="setStyles()">
-  This div is italic, normal weight, and extra large (24px)
+  This div is italic, normal weight, and extra large (24px).
 </div>
 <!-- #enddocregion NgStyle-2 -->
 <p>After setStyles(), the DOM confirms that the styles are
   <span [ngStyle]="setStyles()" #styleDiv>
-    "{{getStyles(styleDiv)}}"
+    {{getStyles(styleDiv)}}
   </span>.
 </p>
 
@@ -439,7 +440,7 @@ After setClasses(), the classes are "{{classDiv.className}}"
 <!-- #enddocregion NgIf-1 -->
 
 <!-- #docregion NgIf-2 -->
-<!-- not displayed because nullHero is falsey.
+<!-- because of the ngIf guard
     `nullHero.firstName` never has a chance to fail -->
 <div *ngIf="nullHero">Hello, {{nullHero.firstName}}</div>
 
@@ -603,22 +604,22 @@ After setClasses(), the classes are "{{classDiv.className}}"
 <hr><h2 id="star-prefix">* prefix and &lt;template&gt;</h2>
 
 <h3>*ngIf expansion</h3>
-  <p><i>*ngIf</i></p>
-  <!-- #docregion Template-1 -->
-  <hero-detail *ngIf="currentHero" [hero]="currentHero"></hero-detail>
-  <!-- #enddocregion Template-1 -->
+<p><i>*ngIf</i></p>
+<!-- #docregion Template-1 -->
+<hero-detail *ngIf="currentHero" [hero]="currentHero"></hero-detail>
+<!-- #enddocregion Template-1 -->
 
-  <p><i>expand to template = "..."</i></p>
-  <!-- #docregion Template-2a -->
-  <hero-detail template="ngIf:currentHero" [hero]="currentHero"></hero-detail>
-  <!-- #enddocregion Template-2a -->
+<p><i>expand to template = "..."</i></p>
+<!-- #docregion Template-2a -->
+<hero-detail template="ngIf:currentHero" [hero]="currentHero"></hero-detail>
+<!-- #enddocregion Template-2a -->
 
-  <p><i>expand to &lt;template&gt;</i></p>
-  <!-- #docregion Template-2 -->
-  <template [ngIf]="currentHero">
-    <hero-detail [hero]="currentHero"></hero-detail>
-  </template>
-  <!-- #enddocregion Template-2 -->
+<p><i>expand to &lt;template&gt;</i></p>
+<!-- #docregion Template-2 -->
+<template [ngIf]="currentHero">
+  <hero-detail [hero]="currentHero"></hero-detail>
+</template>
+<!-- #enddocregion Template-2 -->
 
 <h3>*ngFor expansion</h3>
 <p><i>*ngFor</i></p>
@@ -658,7 +659,7 @@ After setClasses(), the classes are "{{classDiv.className}}"
 <!-- fax refers to the input element; pass its `value` to an event handler -->
 <input ref-fax placeholder="fax number">
 <button (click)="callFax(fax.value)">Fax</button>
-  <!-- #enddocregion ref-phone -->
+<!-- #enddocregion ref-phone -->
 
 <h4>Example Form</h4>
 <!-- #docregion ref-form -->
@@ -704,13 +705,15 @@ After setClasses(), the classes are "{{classDiv.className}}"
 <hr><h2 id="pipes">Pipes</h2>
 
 <!-- #docregion pipes-1 -->
-<!-- Force title to uppercase -->
-<div>{{ title | uppercase }}</div>
+<div>Title through uppercase pipe: {{title | uppercase}}</div>
 <!-- #enddocregion pipes-1 -->
 
 <!-- #docregion pipes-2 -->
-<!-- Pipe chaining: force title to uppercase, then to lowercase -->
-<div>{{ title | uppercase | lowercase }}</div>
+<!-- Pipe chaining: convert title to uppercase, then to lowercase -->
+<div>
+  Title through a pipe chain:
+  {{title | uppercase | lowercase}}
+</div>
 <!-- #enddocregion pipes-2 -->
 
 <!-- #docregion pipes-3 -->
@@ -720,15 +723,7 @@ After setClasses(), the classes are "{{classDiv.className}}"
 
 <!-- #docregion pipes-json -->
 <div>{{currentHero | json}}</div>
-
-<!-- Output:
-  { "firstName": "Hercules", "lastName": "Son of Zeus",
-    "birthdate": "1970-02-25T08:00:00.000Z",
-    "url": "http://www.imdb.com/title/tt0065832/",
-    "rate": 325, "id": 1 }
--->
 <!-- #enddocregion pipes-json -->
-
 
 <div>Birthdate: {{(currentHero?.birthdate | date:'longDate') | uppercase}}</div>
 
@@ -743,29 +738,29 @@ After setClasses(), the classes are "{{classDiv.className}}"
 <hr><h2 id="safe-navigation-operator">Safe navigation operator <i>?.</i></h2>
 
 <div>
-<!-- #docregion safe-1 -->
-The title is {{ title }}
-<!-- #enddocregion safe-1 -->
+  <!-- #docregion safe-1 -->
+  The title is {{title}}
+  <!-- #enddocregion safe-1 -->
 </div>
 
 <div>
-<!-- #docregion safe-2 -->
-The current hero's name is {{currentHero?.firstName}}
-<!-- #enddocregion safe-2 -->
+  <!-- #docregion safe-2 -->
+  The current hero's name is {{currentHero?.firstName}}
+  <!-- #enddocregion safe-2 -->
 </div>
 
 <div>
-<!-- #docregion safe-3 -->
-The current hero's name is {{currentHero.firstName}}
-<!-- #enddocregion safe-3 -->
+  <!-- #docregion safe-3 -->
+  The current hero's name is {{currentHero.firstName}}
+  <!-- #enddocregion safe-3 -->
 </div>
 
 
 <!--
 The null hero's name is {{nullHero.firstName}}
 
-See console log
-          TypeError: Cannot read property 'firstName' of null in [null]
+See console log:
+  TypeError: Cannot read property 'firstName' of null in [null]
 -->
 
 <!-- #docregion safe-4 -->
@@ -780,27 +775,25 @@ The null hero's name is {{nullHero && nullHero.firstName}}
 </div>
 
 <div>
-<!-- #docregion safe-6 -->
-<!-- No hero, no problem! -->
-The null hero's name is {{nullHero?.firstName}}
-<!-- #enddocregion safe-6 -->
+  <!-- #docregion safe-6 -->
+  <!-- No hero, no problem! -->
+  The null hero's name is {{nullHero?.firstName}}
+  <!-- #enddocregion safe-6 -->
 </div>
 
 
 <a class="to-toc" href="#toc">top</a>
 
-<!-- Todo: discuss this in the Style binding section -->
+<!-- TODO: discuss this in the Style binding section -->
 <!-- enums in bindings -->
 <hr><h2 id="enums">Enums in binding</h2>
 
-<p>The name of the Color.Red enum is {{Color[Color.Red]}}</p>
-<p>The current color number is {{color}}</p>
-<p><button [style.color]="Color[color]" (click)="colorToggle()">Enum Toggle</button>
-
-<a class="to-toc" href="#toc">top</a>
-
-<!-- #docregion my-first-app -->
-<h3>My First Angular Application</h3>
-<!-- #enddocregion my-first-app -->
+<p>
+  <!-- #docregion enums -->
+  The name of the Color.Red enum is {{Color[Color.Red]}}.<br>
+  The current color is {{Color[color]}} and its number is {{color}}.<br>
+  <button [style.color]="Color[color]" (click)="colorToggle()">Enum Toggle</button>
+  <!-- #enddocregion enums -->
+</p>
 
 <a class="to-toc" href="#toc">top</a>

--- a/public/docs/_examples/template-syntax/ts/app/app.component.ts
+++ b/public/docs/_examples/template-syntax/ts/app/app.component.ts
@@ -77,6 +77,9 @@ export class AppComponent implements AfterViewInit, OnInit {
   heroImageUrl = 'images/hero.png';
 
   //iconUrl = 'https://angular.io/resources/images/logos/standard/shield-large.png';
+  clicked = '';
+  clickMessage = '';
+  clickMessage2 = '';
   iconUrl = 'images/ng-logo.png';
   isActive = false;
   isSpecial = true;

--- a/public/docs/dart/latest/_util-fns.jade
+++ b/public/docs/dart/latest/_util-fns.jade
@@ -3,6 +3,7 @@ include ../../../_includes/_util-fns
 //- See the _util-fns file included above for a description of the use of these variables.
 - var _docsFor = 'dart';
 - var _decorator = 'annotation';
+- var _Array = 'List';
 - var _array = 'list';
 - var _an_array = 'a list'; //- Deprecate now that we have the articles
 - var _a = 'an';
@@ -12,6 +13,8 @@ include ../../../_includes/_util-fns
 - var _Promise = 'Future';
 - var _Observable = 'Stream';
 - var _liveLink = 'sample repo';
+- var _truthy = 'true';
+- var _falsey = 'false';
 
 mixin liveExampleLink(linkText, exampleUrlPartName)
   - var text = linkText || 'live example';

--- a/public/docs/dart/latest/guide/template-syntax.jade
+++ b/public/docs/dart/latest/guide/template-syntax.jade
@@ -1,407 +1,125 @@
-include ../_util-fns
+extends ../../../ts/latest/guide/template-syntax.jade
 
-+includeShared('{ts}', 'intro')
+block includes
+  include ../_util-fns
+  - var _JavaScript = 'Dart';
+  - var __chaining_op = '<code>;</code>';
+  - var __new_op = '<code>new</code> or <code>const</code>';
+  - var mapApiRef = 'https://api.dartlang.org/stable/1.16.0/dart-core/Map-class.html';
+  - var __objectAsMap = '<b><a href="' + mapApiRef + '">Map</a></b>'
 
-:marked
-  The complete source code for the example app in this chapter is
-  [in GitHub](https://github.com/angular/angular.io/tree/master/public/docs/_examples/template-syntax/dart).
-
-+includeShared('{ts}', 'html-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'my-first-app')(format=".")
-+includeShared('{ts}', 'html-2')
-
-+includeShared('{ts}', 'interpolation-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'first-interpolation')(format=".")
-+includeShared('{ts}', 'interpolation-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'title+image')(format=".")
-+includeShared('{ts}', 'interpolation-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'sum-1')(format=".")
-+includeShared('{ts}', 'interpolation-4')
-+makeExample('template-syntax/dart/lib/app_component.html', 'sum-2')(format=".")
-+includeShared('{ts}', 'interpolation-5')
-
-+includeShared('{ts}', 'template-expressions-1')
-:marked
-  We write template expressions in a language that looks like Dart.
-  Many Dart expressions are legal template expressions, but not all.
-  Dart expressions that have or promote side effects are prohibited,
-  including:
-
-  * assignments (`=`, `+=`, `-=`, ...)
-  * creating instances using `new` or `const`
-  * increment and decrement (`++` and `--`)
-
-  Other notable differences from Dart syntax include:
-
-  * no support for Dart string interpolation; for example,
-    instead of `"'The title is $title'"`, you must use
-    `"'The title is ' + title"`
-  * no support for the bitwise operators `|` and `&`
-  * new [template expression operators](#expression-operators), such as `|`
-+includeShared('{ts}', 'template-expressions-context')
-+includeShared('{ts}', 'template-expressions-guidelines')
-:marked
-  Dependent values should not change during a single turn of the event loop.
-  If an idempotent expression returns a string or a number, it returns the same string or number
-  when called twice in a row. If the expression returns an object (including a `DateTime`, `Map`, or `List`),
-  it returns the same object *reference* when called twice in a row.
-
-.callout.is-helpful
-  header Dart difference: Arrays are lists
+block notable-differences
   :marked
-    Arrays in JavaScript correspond to lists in Dart
-    (instances of the `List` class).
-    This chapter uses _array_ and _list_ interchangeably.
-    For more information, see
-    [Lists](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#lists)
-    in the [Dart language tour](https://www.dartlang.org/docs/dart-up-and-running/ch02.html).
+    * no support for Dart string interpolation; for example,
+      instead of `"'The title is $title'"`, you must use
+      `"'The title is ' + title"`
+    * no support for the bitwise operators `|` and `&`
+    * new [template expression operators](#expression-operators), such as `|`
 
-+includeShared('{ts}', 'template-statements-1')
-:marked
-  Like template expressions, template *statements* use a language that looks like Dart.
-  The template statement parser is different than the template expression parser and
-  specifically supports both basic assignment (`=`) and chaining expressions with semicolons (`;`).
-
-  However, certain Dart syntax is not allowed:
-  * the `new` and `const` keywords
-  * increment and decrement operators, `++` and `--`
-  * operator assignment, such as `+=` and `-=`
-  * the operators `|` and `&` (neither for bitwise operations
-    nor for the Angular [pipe operator](#the-pipe-operator-))
-
-+includeShared('{ts}', 'template-statements-3')
-
-+includeShared('{ts}', 'binding-syntax-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'img+button')(format=".")
-+includeShared('{ts}', 'binding-syntax-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'hero-detail-1')(format=".")
-+includeShared('{ts}', 'binding-syntax-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'disabled-button-1')(format=".")
-+includeShared('{ts}', 'binding-syntax-4')
-+includeShared('{ts}', 'binding-syntax-attribute-vs-property')
-+includeShared('{ts}', 'binding-syntax-5')
-+includeShared('{ts}', 'binding-syntax-world-without-attributes')
-+includeShared('{ts}', 'binding-syntax-targets')
-
-<div width="90%">
-table
-  tr
-    th Binding type
-    th Target
-    th Examples
-  tr
-    td Property
-    td.
-      Element&nbsp;property<br>
-      Component&nbsp;property<br>
-      Directive&nbsp;property
-    td
-      +makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-syntax-1')(format=".")
-  tr
-    td Event
-    td.
-      Element&nbsp;event<br>
-      Component&nbsp;event<br>
-      Directive&nbsp;event
-    td
-      +makeExample('template-syntax/dart/lib/app_component.html', 'event-binding-syntax-1')(format=".")
-  tr
-    td Two-way
-    td.
-      Event and property
-    td
-      +makeExample('template-syntax/dart/lib/app_component.html', '2-way-binding-syntax-1')(format=".")
-  tr
-    td Attribute
-    td.
-      Attribute
-      (the&nbsp;exception)
-    td
-      +makeExample('template-syntax/dart/lib/app_component.html', 'attribute-binding-syntax-1')(format=".")
-  tr
-    td Class
-    td.
-      <code>class</code> property
-    td
-      +makeExample('template-syntax/dart/lib/app_component.html', 'class-binding-syntax-1')(format=".")
-  tr
-    td Style
-    td.
-      <code>style</code> property
-    td
-      +makeExample('template-syntax/dart/lib/app_component.html', 'style-binding-syntax-1')(format=".")
-</div>
-
-+includeShared('{ts}', 'binding-syntax-end')
-
-+includeShared('{ts}', 'property-binding-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-1')(format=".")
-+includeShared('{ts}', 'property-binding-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-2')(format=".")
-+includeShared('{ts}', 'property-binding-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-3')(format=".")
-+includeShared('{ts}', 'property-binding-4')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-4')(format=".")
-+includeShared('{ts}', 'property-binding-5')
-+includeShared('{ts}', 'property-binding-6')
-+includeShared('{ts}', 'property-binding-7')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-1')(format=".")
-+includeShared('{ts}', 'property-binding-8')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-5')(format=".")
-+includeShared('{ts}', 'property-binding-9')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-3')(format=".")
-+includeShared('{ts}', 'property-binding-10')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-4')(format=".")
-+includeShared('{ts}', 'property-binding-11')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-6')(format=".")
-.callout.is-helpful
-  header Dart difference: Type exceptions
+block template-expressions-cannot
   :marked
-    In checked mode, uncommenting the `<hero-detail>` element above causes a type exception,
-    because `String` isn't a subtype of `Hero`.
-    For information on checked mode, see [Important concepts](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#important-concepts)
-    in the Dart language tour.
-+includeShared('{ts}', 'property-binding-12')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-7')(format=".")
-+includeShared('{ts}', 'property-binding-13')
-+makeExample('template-syntax/dart/lib/app_component.html', 'property-binding-vs-interpolation')(format=".")
-+includeShared('{ts}', 'property-binding-14')
+    Perhaps more surprising, template expressions can’t refer to static
+    properties, nor to top-level variables or functions, such as `window` or
+    `document` from `dart:html`. They can’t directly call `print` or functions
+    imported from `dart:math`. They are restricted to referencing members of
+    the expression context.
 
-+includeShared('{ts}', 'other-bindings-1')
-+includeShared('{ts}', 'other-bindings-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'attrib-binding-colspan')(format=".")
-+includeShared('{ts}', 'other-bindings-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'attrib-binding-aria')(format=".")
-+includeShared('{ts}', 'other-bindings-class-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'class-binding-1')(format=".")
-+includeShared('{ts}', 'other-bindings-class-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'class-binding-2')(format=".")
-//
-  +includeShared('{ts}', 'other-bindings-class-3')
-:marked
-  Finally, we can bind to a specific class name.
-  Angular adds the class when the template expression evaluates to `true`.
-  It removes the class when the expression evaluates to `false`.
-+makeExample('template-syntax/dart/lib/app_component.html', 'class-binding-3')(format=".")
-+includeShared('{ts}', 'other-bindings-class-4')
-+includeShared('{ts}', 'other-bindings-style-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'style-binding-1')(format=".")
-+includeShared('{ts}', 'other-bindings-style-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'style-binding-2')(format=".")
-+includeShared('{ts}', 'other-bindings-style-3')
+block array-is-list-in-Dart
+  .callout.is-helpful
+    header Dart difference: Arrays are lists
+    :marked
+      Arrays in JavaScript correspond to lists in Dart
+      (instances of the `List` class).
+      This chapter uses _array_ and _list_ interchangeably.
+      For more information, see
+      [Lists](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#lists)
+      in the [Dart language tour](https://www.dartlang.org/docs/dart-up-and-running/ch02.html).
 
-+includeShared('{ts}', 'event-binding-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'event-binding-1')(format=".")
-+includeShared('{ts}', 'event-binding-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'event-binding-1')(format=".")
-+includeShared('{ts}', 'event-binding-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'event-binding-2')(format=".")
-+includeShared('{ts}', 'event-binding-4')
-+makeExample('template-syntax/dart/lib/app_component.html', 'event-binding-3')(format=".")
-+includeShared('{ts}', 'event-binding-5')
-+makeExample('template-syntax/dart/lib/app_component.html', 'without-NgModel')(format=".")
-+includeShared('{ts}', 'event-binding-6')
-+makeExample('template-syntax/dart/lib/hero_detail_component.dart',
-'template-1', 'HeroDetailComponent.ts (template)')(format=".")
-+makeExample('template-syntax/dart/lib/hero_detail_component.dart',
-'deleteRequest', 'HeroDetailComponent.ts (delete logic)')(format=".")
-+includeShared('{ts}', 'event-binding-7')
-+makeExample('template-syntax/dart/lib/app_component.html', 'event-binding-to-component')(format=".")
-+includeShared('{ts}', 'event-binding-8')
-
-+includeShared('{ts}', 'ngModel-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgModel-1')(format=".")
-+includeShared('{ts}', 'ngModel-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgModel-2')(format=".")
-+includeShared('{ts}', 'ngModel-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'without-NgModel')(format=".")
-+includeShared('{ts}', 'ngModel-4')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgModel-3')(format=".")
-+includeShared('{ts}', 'ngModel-5')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgModel-1')(format=".")
-+includeShared('{ts}', 'ngModel-6')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgModel-4')(format=".")
-+includeShared('{ts}', 'ngModel-7')
-
-+includeShared('{ts}', 'directives-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'event-binding-1')(format=".")
-+includeShared('{ts}', 'directives-2')
-+includeShared('{ts}', 'directives-ngClass-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'class-binding-3a')(format=".")
-+includeShared('{ts}', 'directives-ngClass-2')
-+makeExample('template-syntax/dart/lib/app_component.dart', 'setClasses')(format=".")
-// PENDING: Add "Dart difference" for returning maps in Dart? for omitting unnecessary `this.`s?
-+includeShared('{ts}', 'directives-ngClass-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgClass-1')(format=".")
-+includeShared('{ts}', 'directives-ngStyle-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgStyle-1')(format=".")
-+includeShared('{ts}', 'directives-ngStyle-2')
-+makeExample('template-syntax/dart/lib/app_component.dart', 'setStyles')(format=".")
-+includeShared('{ts}', 'directives-ngStyle-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgStyle-2')(format=".")
-//
-  +includeShared('{ts}', 'directives-ngIf-1')
-<a id="ngIf"></a>
-.l-main-section
-:marked
-  ### NgIf
-  We can add an element subtree (an element and its children) to the DOM  by binding an `NgIf` directive to a `true` expression.
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgIf-1')(format=".")
-+includeShared('{ts}', 'directives-ngIf-2')
-//
-  +includeShared('{ts}', 'directives-ngIf-3')
-:marked
-  Binding to a false expression removes the element subtree from the DOM.
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgIf-2')(format=".")
-.callout.is-helpful
-  header Dart difference: No truthy values
+block statement-context
   :marked
-    In checked mode, Dart expects Boolean values
-    (those with type `bool`) to be either `true` or `false`.
-    Even in production mode, the only value Dart treats as `true` is
-    the value `true`; all other values are `false`.
-    TypeScript and JavaScript, on the other hand, treat
-    many values (including non-null objects) as true.
-    A TypeScript Angular 2 program, for example, often has code like
-    `*ngIf="currentHero"` where a Dart program has code like
-    `*ngIf="currentHero != null"`.
+    Template statements can’t refer to static properties on the class, nor to
+    top-level variables or functions, such as `window` or `document` from
+    `dart:html`. They can’t directly call `print` or functions imported from
+    `dart:math`.
 
-    When converting TypeScript code to Dart code, watch out for
-    true/false problems. For example, forgetting the `!= null`
-    can lead to exceptions in checked mode, such as
-    "EXCEPTION: type 'Hero' is not a subtype of type 'bool' of 'boolean expression'".
-    For more information, see
-    [Booleans](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#booleans)
-    in the [Dart language tour](https://www.dartlang.org/docs/dart-up-and-running/ch02.html).
-+includeShared('{ts}', 'directives-ngIf-4')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgIf-3')(format=".")
-+includeShared('{ts}', 'directives-ngIf-5')
-+includeShared('{ts}', 'directives-ngSwitch-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgSwitch')(format=".")
-+includeShared('{ts}', 'directives-ngSwitch-2')
-+includeShared('{ts}', 'directives-ngFor-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgFor-1')(format=".")
-+includeShared('{ts}', 'directives-ngFor-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgFor-2')(format=".")
-+includeShared('{ts}', 'directives-ngFor-3')
-+includeShared('{ts}', 'directives-ngFor-4')
-+includeShared('{ts}', 'directives-ngFor-5')
-+includeShared('{ts}', 'directives-ngFor-6')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgFor-3')(format=".")
-+includeShared('{ts}', 'directives-ngFor-7')
-+includeShared('{ts}', 'directives-ngForTrackBy-1')
-+makeExample('template-syntax/dart/lib/app_component.dart', 'trackByHeroes')(format=".")
-+includeShared('{ts}', 'directives-ngForTrackBy-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgForTrackBy-2')(format=".")
-+includeShared('{ts}', 'directives-ngForTrackBy-3')
+block dart-type-exceptions
+  .callout.is-helpful
+    header Dart difference: Type exceptions
+    :marked
+      In checked mode, if the template expression result type and the target
+      property type are not assignment compatible, then a type exception will
+      be thrown.
+      For information on checked mode, see [Important concepts](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#important-concepts)
+      in the Dart language tour.
 
-+includeShared('{ts}', 'star-template')
-+includeShared('{ts}', 'star-template-ngIf-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'Template-1')(format=".")
-+includeShared('{ts}', 'star-template-ngIf-2a')
-+makeExample('template-syntax/dart/lib/app_component.html', 'Template-2a')(format=".")
-+includeShared('{ts}', 'star-template-ngIf-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'Template-2')(format=".")
-+includeShared('{ts}', 'star-template-ngIf-3')
-// Changed from RED to ORANGE, since this isn't so dire a situation in Dart.
-.callout.is-important
-  header Remember the brackets!
+block dart-type-exception-example
+  .callout.is-helpful
+    header Dart difference: Type exception example
+    :marked
+      In checked mode, the code above will result in a type exception: 
+      `String` isn't a subtype of `Hero`.
+
+block dart-class-binding-bug
+  .callout.is-helpful
+    header Angular Issue #6901
+    :marked
+      Issue [#6901][6901] prevents us from using `[class]`. As is illustrated
+      above, in the meantime we can achieve the same effect by binding to
+      `className`.
+      
+      [6901]: http://github.com/angular/angular/issues/6901
+
+block dart-no-truthy-falsey
+  .callout.is-helpful
+    header Dart difference: No truthy/falsey values
+    :marked
+      In checked mode, Dart expects Boolean values
+      (those with type `bool`) to be either `true` or `false`.
+      Even in production mode, the only value Dart treats as `true` is
+      the value `true`; all other values are `false`.
+      TypeScript and JavaScript, on the other hand, treat
+      many values (including non-null objects) as true.
+      A TypeScript Angular 2 program, for example, often has code like
+      `*ngIf="currentHero"` where a Dart program has code like
+      `*ngIf="currentHero != null"`.
+
+      When converting TypeScript code to Dart code, watch out for
+      true/false problems. For example, forgetting the `!= null`
+      can lead to exceptions in checked mode, such as
+      "EXCEPTION: type 'Hero' is not a subtype of type 'bool' of 'boolean expression'".
+      For more information, see
+      [Booleans](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#booleans)
+      in the [Dart language tour](https://www.dartlang.org/docs/dart-up-and-running/ch02.html).
+
+block remember-the-brackets
+  //- Changed from RED to ORANGE, since this isn't so dire a situation in Dart.
+  .callout.is-important
+    header Remember the brackets!
+    :marked
+      Don’t make the mistake of writing `ngIf="currentHero"`!
+      That syntax assigns the *string* value `"currentHero"` to `ngIf`,
+      which won't work because `ngIf` expects a `bool`.
+
+block dart-safe-nav-op
+  .callout.is-helpful
+    header Dart difference: ?. is a Dart operator
+    :marked
+      The safe navigation operator (`?.`) is part of the Dart language.
+      It's considered a template expression operator because
+      Angular 2 supports `?.` even in TypeScript and JavaScript apps.
+
+block json-pipe
+  //- TODO: explain alternative in Dart
+  //- {{ e | json }} --> {{ e }}
+  //- which causes the object's toString() method to be invoked.
+  //- Of course the `json` pipe can be used if the instance supports
+  //- JSON encoding.
+
+block null-deref-example
   :marked
-    Don’t make the mistake of writing `ngIf="currentHero"`!
-    That syntax assigns the *string* value "currentHero" to `ngIf`,
-    which won't work because `ngIf` expects a bool.
-+includeShared('{ts}', 'star-template-ngSwitch-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'NgSwitch-expanded')(format=".")
-+includeShared('{ts}', 'star-template-ngSwitch-2')
-+includeShared('{ts}', 'star-template-ngFor-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'Template-3a')(format=".")
-+includeShared('{ts}', 'star-template-ngFor-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'Template-3')(format=".")
-+includeShared('{ts}', 'star-template-ngFor-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'Template-4')(format=".")
-+includeShared('{ts}', 'star-template-ngFor-4')
+    Dart throws an exception, and so does Angular:
+  code-example(format="nocode").
+    EXCEPTION: The null object does not have a getter 'firstName'.
 
-+includeShared('{ts}', 'ref-vars')
-+makeExample('template-syntax/dart/lib/app_component.html', 'ref-phone')(format=".")
-+includeShared('{ts}', 'ref-vars-value')
-+includeShared('{ts}', 'ref-vars-form-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'ref-form')(format=".")
-+includeShared('{ts}', 'ref-vars-form-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'ref-form-a')(format=".")
-+includeShared('{ts}', 'ref-vars-form-3')
-
-+includeShared('{ts}', 'inputs-outputs-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'io-1')(format=".")
-+includeShared('{ts}', 'inputs-outputs-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'io-2')(format=".")
-+includeShared('{ts}', 'inputs-outputs-3')
-+makeExample('template-syntax/dart/lib/hero_detail_component.dart', 'input-output-1')(format=".")
-:marked
-.l-sub-section
-  :marked
-    Alternatively, we can identify members in the `inputs` and `outputs` arrays
-    of the directive metadata, as in this example:
-  +makeExample('template-syntax/dart/lib/hero_detail_component.dart', 'input-output-2')(format=".")
-  <br>
-  :marked
-    We can specify an input/output property either with a decorator or in a metadata array.
-    Don't do both!
-+includeShared('{ts}', 'inputs-outputs-4')
-+includeShared('{ts}', 'inputs-outputs-5')
-+makeExample('template-syntax/dart/lib/app_component.html', 'my-click')(format=".")
-+includeShared('{ts}', 'inputs-outputs-6')
-+makeExample('template-syntax/dart/lib/my_click_directive.dart', 'my-click-output-1')(format=".")
-.l-sub-section
-  :marked
-    We can also alias property names in the `inputs` and `outputs` arrays.
-    We write a colon-delimited (`:`) string with
-    the directive property name on the *left* and the public alias on the *right*:
-  +makeExample('template-syntax/dart/lib/my_click_directive.dart', 'my-click-output-2')(format=".")
-
-<a id="expression-operators"></a>
-.l-main-section
-:marked
-  ## Template expression operators
-  The template expression language employs a subset of Dart syntax supplemented with a few special operators
-  for specific scenarios. We'll cover two of these operators: _pipe_ and _safe navigation operator_.
-.callout.is-helpful
-  header Dart difference: ?. is a Dart operator
-  :marked
-    The safe navigation operator (`?.`) is part of the Dart language.
-    It's considered a template expression operator because
-    Angular 2 supports `?.` even in TypeScript and JavaScript apps.
-+includeShared('{ts}', 'expression-operators-pipe-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'pipes-1')(format=".")
-+includeShared('{ts}', 'expression-operators-pipe-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'pipes-2')(format=".")
-+includeShared('{ts}', 'expression-operators-pipe-3')
-+makeExample('template-syntax/dart/lib/app_component.html', 'pipes-3')(format=".")
-//
-  NOTE: Intentionally omit discussion of the json pipe.
-  +includeShared('{ts}', 'expression-operators-pipe-4')
-  +makeExample('template-syntax/dart/lib/app_component.html', 'pipes-json')(format=".")
-+includeShared('{ts}', 'expression-operators-safe-1')
-+makeExample('template-syntax/dart/lib/app_component.html', 'safe-2')(format=".")
-+includeShared('{ts}', 'expression-operators-safe-2')
-+makeExample('template-syntax/dart/lib/app_component.html', 'safe-1')(format=".")
-+includeShared('{ts}', 'expression-operators-safe-3')
-// +includeShared('{ts}', 'expression-operators-safe-4')
-:marked
-  Dart throws an exception, and so does Angular:
-code-example(format="" language="html").
-  EXCEPTION: The null object does not have a getter 'firstName'.
-+includeShared('{ts}', 'expression-operators-safe-5')
-+makeExample('template-syntax/dart/lib/app_component.html', 'safe-4')(format=".")
-
-//
-  NOTE: Intentionally skip ugly null checking you wouldn't do in Dart.
-  That means skipping the shared sections 'expression-operators-safe-6' & 7,
-  plus the example 'safe-5'.
-:marked
-  This approach has merit but can be cumbersome, especially if the property path is long.
-  Imagine guarding against a null somewhere in a long property path such as `a.b.c.d`.
-+includeShared('{ts}', 'expression-operators-safe-8')
-+makeExample('template-syntax/dart/lib/app_component.html', 'safe-6')(format=".")
-+includeShared('{ts}', 'expression-operators-safe-9')
-
-+includeShared('{ts}', 'summary')
+block safe-op-alt
+  //- N/A

--- a/public/docs/dart/latest/guide/template-syntax.jade
+++ b/public/docs/dart/latest/guide/template-syntax.jade
@@ -24,17 +24,6 @@ block template-expressions-cannot
     imported from `dart:math`. They are restricted to referencing members of
     the expression context.
 
-block array-is-list-in-Dart
-  .callout.is-helpful
-    header Dart difference: Arrays are lists
-    :marked
-      Arrays in JavaScript correspond to lists in Dart
-      (instances of the `List` class).
-      This chapter uses _array_ and _list_ interchangeably.
-      For more information, see
-      [Lists](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#lists)
-      in the [Dart language tour](https://www.dartlang.org/docs/dart-up-and-running/ch02.html).
-
 block statement-context
   :marked
     Template statements can’t refer to static properties on the class, nor to

--- a/public/docs/dart/latest/guide/template-syntax.jade
+++ b/public/docs/dart/latest/guide/template-syntax.jade
@@ -58,6 +58,20 @@ block dart-class-binding-bug
       
       [6901]: http://github.com/angular/angular/issues/6901
 
+block style-property-name-dart-diff
+  .callout.is-helpful
+    header Dart difference: Style property names
+    :marked
+      While [camelCase](glossary.html#camelcase) and
+      [dash-case](glossary.html#dash-case) style property naming schemes are
+      equivalent in Angular Dart, only dash-case names are recognized by the
+      `dart:html` [CssStyleDeclaration][CssSD] methods `getPropertyValue()`
+      and `setProperty()`. Hence, we recommend only using dash-case for style
+      property names.
+      
+      [CssSD]: https://api.dartlang.org/stable/1.16.1/dart-html/CssStyleDeclaration-class.html
+
+
 block dart-no-truthy-falsey
   .callout.is-helpful
     header Dart difference: No truthy/falsey values

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -7,7 +7,7 @@ block includes
   - var __objectAsMap = 'object';
 
 :marked
-  Our Angular application manages what the user sees and it achieves this through the interaction of a Component class instance (the *component*) and its user-facing template.
+  Our Angular application manages what the user sees and can do, achieving this through the interaction of a Component class instance (the *component*) and its user-facing template.
 
   Many of us are familiar with the component/template duality from our experience with model-view-controller (MVC) or model-view-viewmodel (MVVM). In Angular,  the component plays the part of the controller/viewmodel, and the template represents the view.
 
@@ -33,11 +33,11 @@ block includes
   * [Input and output properties](#inputs-outputs)
   * [Template expression operators](#expression-operators)
     * [pipe](#pipe)
-    * ["safe navigation operator" (?.)](#safe-navigation-operator)
-.l-sub-section
-  p.
-    The #[+liveExampleLink2()]
-    demonstrates all of the syntax and code snippets described in this chapter.
+    * [safe navigation operator (?.)](#safe-navigation-operator)
+
+p.
+  The #[+liveExampleLink2()]
+  demonstrates all of the syntax and code snippets described in this chapter.
 
 .l-main-section
 :marked
@@ -99,9 +99,9 @@ code-example(language="html" escape="html").
   We’ll see template expressions again in the [property binding](#property-binding) section,
   appearing in quotes to the right of the `=` symbol as in `[property]="expression"`.
 
-:marked
   We write template expressions in a language that looks like #{_JavaScript}.
   Many #{_JavaScript} expressions are legal template expressions, but not all.
+
   #{_JavaScript} expressions that have or promote side effects are prohibited,
   including:
 
@@ -187,14 +187,10 @@ block template-expressions-cannot
 :marked
   Dependent values should not change during a single turn of the event loop.
   If an idempotent expression returns a string or a number, it returns the same string or number
-  when called twice in a row. If the expression returns an object (including #{_a} `#{_Array}`),
+  when called twice in a row. If the expression returns an object (including #{_an} `#{_Array}`),
   it returns the same object *reference* when called twice in a row.
 
-block array-is-list-in-Dart
-  //- N/A
-
-<a id="template-statements"></a>
-.l-main-section
+.l-main-section#template-statements
 :marked
   ## Template statements
 
@@ -217,7 +213,7 @@ block array-is-list-in-Dart
   Like template expressions, template *statements* use a language that looks like #{_JavaScript}.
   The template statement parser is different than the template expression parser and
   specifically supports both basic assignment (`=`) and chaining expressions 
-  with !{__chaining_op}.
+  (with !{__chaining_op}).
 
   However, certain #{_JavaScript} syntax is not allowed:
   * !{__new_op}
@@ -691,7 +687,7 @@ block dart-class-binding-bug
 
 .l-sub-section
   :marked
-    Note that the _style property_ name can be written in camcel case, such as `fontSize`.
+    Note that the _style property_ name can be written in camelCase, such as `fontSize`.
 
 .l-main-section
 :marked

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -1,7 +1,13 @@
-include ../_util-fns
+block includes
+  include ../_util-fns
+  - var _JavaScript = 'JavaScript';
+  //- Double underscore means don't escape var, use !{__var}.
+  - var __chaining_op = '<code>;</code> or <code>,</code>';
+  - var __new_op = '<code>new</code>';
+  - var __objectAsMap = 'object';
 
 :marked
-  Our Angular application manages what the user sees and does through the interaction of a Component class instance (the *component*) and its user-facing template.
+  Our Angular application manages what the user sees and it achieves this through the interaction of a Component class instance (the *component*) and its user-facing template.
 
   Many of us are familiar with the component/template duality from our experience with model-view-controller (MVC) or model-view-viewmodel (MVVM). In Angular,  the component plays the part of the controller/viewmodel, and the template represents the view.
 
@@ -29,8 +35,8 @@ include ../_util-fns
     * [pipe](#pipe)
     * ["safe navigation operator" (?.)](#safe-navigation-operator)
 .l-sub-section
-  :marked
-    The [live example](/resources/live-examples/template-syntax/ts/plnkr.html)
+  p.
+    The #[+liveExampleLink2()]
     demonstrates all of the syntax and code snippets described in this chapter.
 
 .l-main-section
@@ -38,7 +44,9 @@ include ../_util-fns
   ## HTML
   HTML is the language of the Angular template. Our [QuickStart](../quickstart.html) application had a template that was pure HTML:
 
-+makeExample('template-syntax/ts/app/app.component.html', 'my-first-app')(format=".")
+code-example(language="html" escape="html").
+  <h1>My First Angular 2 App</h1>
+
 :marked
   Almost all HTML syntax is valid template syntax. The `<script>` element is a notable exception; it is forbidden, eliminating the risk of script injection attacks. (In practice, `<script>` is simply ignored.)
 
@@ -92,33 +100,38 @@ include ../_util-fns
   appearing in quotes to the right of the `=` symbol as in `[property]="expression"`.
 
 :marked
-  We write template expressions in a language that looks like JavaScript.
-  Many JavaScript expressions are legal template expressions, but not all.
-  JavaScript expressions that have or promote side effects are prohibited,
+  We write template expressions in a language that looks like #{_JavaScript}.
+  Many #{_JavaScript} expressions are legal template expressions, but not all.
+  #{_JavaScript} expressions that have or promote side effects are prohibited,
   including:
 
-  * assignments (`=`, `+=`, `-=`)
-  * the `new` operator
-  * chaining expressions with `;` or `,`
+  * assignments (`=`, `+=`, `-=`, ...)
+  * !{__new_op}
+  * chaining expressions with !{__chaining_op}
   * increment and decrement operators (`++` and `--`)
 
-  Other notable differences from JavaScript syntax include:
-
-  * no support for the bitwise operators `|` and `&`
-  * new [template expression operators](#expression-operators), such as `|` and `?.`
-
-- var lang = current.path[1]
-- var details = lang === 'dart' ? 'template expressions can’t refer to static properties, nor to top-level variables or functions, such as <code>window</code> or <code>document</code> from <code>dart:html</code>. They can’t directly call <code>print</code> or functions imported from <code>dart:math</code>. They are restricted to referencing members of the expression context.' : 'template expressions cannot refer to anything in the global namespace. They can’t refer to <code>window</code> or <code>document</code>. They can’t call <code>console.log</code> or <code>Math.max</code>. They are restricted to referencing members of the expression context.'
 :marked
-  <a id="expression-context"></a>
-  ### Expression context
+  Other notable differences from #{_JavaScript} syntax include:
 
-  Perhaps more surprising, !{details}
+block notable-differences
+  :marked
+    * no support for the bitwise operators `|` and `&`
+    * new [template expression operators](#expression-operators), such as `|` and `?.`
 
+h3#expression-context Expression context
+
+block template-expressions-cannot
+  :marked
+    Perhaps more surprising, template expressions cannot refer to anything in
+    the global namespace. They can’t refer to `window` or `document`. They
+    can’t call `console.log` or `Math.max`. They are restricted to referencing
+    members of the expression context.
+
+:marked
   The *expression context* is typically the **component instance**, which is
   the source of binding values.
 
-  When we see *title* wrapped in double-curly braces, <code>{{title}}</code>,
+  When we see *title* wrapped in double-curly braces, `{{title}}`,
   we know that `title` is a property of the data-bound component.
   When we see *isUnchanged* in `[disabled]="isUnchanged"`,
   we know we are referring to that component's `isUnchanged` property.
@@ -174,8 +187,11 @@ include ../_util-fns
 :marked
   Dependent values should not change during a single turn of the event loop.
   If an idempotent expression returns a string or a number, it returns the same string or number
-  when called twice in a row. If the expression returns an object (including a `Date` or `Array`),
+  when called twice in a row. If the expression returns an object (including #{_a} `#{_Array}`),
   it returns the same object *reference* when called twice in a row.
+
+block array-is-list-in-Dart
+  //- N/A
 
 <a id="template-statements"></a>
 .l-main-section
@@ -196,27 +212,33 @@ include ../_util-fns
   :marked
     Responding to events is the other side of Angular's "unidirectional data flow".
     We're free to change anything, anywhere, during this turn of the event loop.
-:marked
-  Like template expressions, template *statements* use a language that looks like JavaScript.
-  The template statement parser is different than the template expression parser and
-  specifically supports both basic assignment (`=`) and chaining expressions with semicolons (`;`) and commas (`,`).
 
-  However, certain JavaScript syntax is not allowed:
-  * the `new` operator
+:marked
+  Like template expressions, template *statements* use a language that looks like #{_JavaScript}.
+  The template statement parser is different than the template expression parser and
+  specifically supports both basic assignment (`=`) and chaining expressions 
+  with !{__chaining_op}.
+
+  However, certain #{_JavaScript} syntax is not allowed:
+  * !{__new_op}
   * increment and decrement operators, `++` and `--`
   * operator assignment, such as `+=` and `-=`
   * the bitwise operators `|` and `&`
   * the [template expression operators](#expression-operators)
 
-- var lang = current.path[1]
-- var details = lang === 'dart' ? 'Template statements can’t refer to static properties on the class, nor to top-level variables or functions, such as <code>window</code> or <code>document</code> from <code>dart:html</code>. They can’t directly call <code>print</code> or functions imported from <code>dart:math</code>.' : 'Template statements cannot refer to anything in the global namespace. They can’t refer to <code>window</code> or <code>document</code>. They can’t call <code>console.log</code> or <code>Math.max</code>.'
 :marked
   ### Statement context
 
   As with expressions, statements can refer only to what's in the statement context — typically the
   **component instance** to which we're binding the event.
-  !{details}
 
+block statement-context
+  :marked
+    Template statements cannot refer to anything in the global namespace. They
+    can’t refer to `window` or `document`. They can’t call `console.log` or
+    `Math.max`.
+
+:marked
   The *onSave* in `(click)="onSave()"` is sure to be a method of the data-bound component instance.
 
   The statement context may include an object other than the component.
@@ -254,7 +276,7 @@ table
   tr
     td One-way<br>from data source<br>to view target
     td
-      code-example(format="" ).
+      code-example().
         {{expression}}
         [target] = "expression"
         bind-target = "expression"
@@ -267,14 +289,14 @@ table
     tr
       td One-way<br>from view target<br>to data source
       td
-        code-example(format="" ).
+        code-example().
           (target) = "statement"
           on-target = "statement"
       td Event
     tr
       td Two-way
       td
-        code-example(format="" ).
+        code-example().
           [(target)] = "expression"
           bindon-target = "expression"
       td Two-way
@@ -517,6 +539,10 @@ table
 
   The `hero` property of the `HeroDetail` component expects a `Hero` object, which is exactly what we’re sending in the property binding:
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-4')(format=".")
+
+block dart-type-exceptions
+  //- N/A
+
 :marked
   ### Remember the brackets
   The brackets tell Angular to evaluate the template expression.
@@ -525,6 +551,10 @@ table
 
   Don't make the following mistake:
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-6')(format=".")
+
+block dart-type-exception-example
+  //- N/A
+
 a(id="one-time-initialization")
 :marked
   ### One-time string initialization
@@ -536,7 +566,7 @@ a(id="one-time-initialization")
   We routinely initialize attributes this way in standard HTML, and it works
   just as well for directive and component property initialization.
   The following example initializes the `prefix` property of the `HeroDetailComponent` to a fixed string,
-  not a template expression. Angular sets it and forgets it.
+  not a template expression. Angular sets it and forgets about it.
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-7')(format=".")
 :marked
   The `[hero]` binding, on the other hand, remains a live binding to the component's `currentHero` property.
@@ -551,7 +581,7 @@ a(id="one-time-initialization")
 
   There is no technical reason to prefer one form to the other.
   We lean toward readability, which tends to favor interpolation.
-  We suggest establishing coding style rules for the organization and choosing the form that
+  We suggest establishing coding style rules and choosing the form that
   both conforms to the rules and feels most natural for the task at hand.
 
 .l-main-section
@@ -582,7 +612,7 @@ code-example(language="html").
   &lt;tr>&lt;td colspan="{{1 + 1}}">Three-Four&lt;/td>&lt;/tr>
 :marked
   We get this error:
-code-example(format="", language="html").
+code-example(format="nocode").
   Template parse errors:
   Can't bind to 'colspan' since it isn't a known native property
 :marked
@@ -625,10 +655,14 @@ code-example(format="", language="html").
 :marked
   We can replace that with a binding to a string of the desired class names; this is an all-or-nothing, replacement binding.
 +makeExample('template-syntax/ts/app/app.component.html', 'class-binding-2')(format=".")
+
+block dart-class-binding-bug
+  //- N/A
+
 :marked
   Finally, we can bind to a specific class name.
-  Angular adds the class when the template expression evaluates to something truthy.
-  It removes the class when the expression is falsey.
+  Angular adds the class when the template expression evaluates to #{_truthy}.
+  It removes the class when the expression is #{_falsey}.
 +makeExample('template-syntax/ts/app/app.component.html', 'class-binding-3')(format=".")
 
 .l-sub-section
@@ -654,6 +688,10 @@ code-example(format="", language="html").
   :marked
     While this is a fine way to set a single style,
     we generally prefer the [NgStyle directive](#ngStyle) when setting several inline styles at the same time.
+
+.l-sub-section
+  :marked
+    Note that the _style property_ name can be written in camcel case, such as `fontSize`.
 
 .l-main-section
 :marked
@@ -685,11 +723,17 @@ code-example(format="", language="html").
   Element events may be the more common targets, but Angular looks first to see if the name matches an event property
   of a known directive, as it does in the following example:
 +makeExample('template-syntax/ts/app/app.component.html', 'event-binding-3')(format=".")
+
+.l-sub-section
+  :marked
+    The `myClick` directive is further described below in the section
+    on [Aliasing input/output properties](#aliasing-io).
+
 :marked
   If the name fails to match an element event or an output property of a known directive,
   Angular reports an “unknown directive” error.
 
-  ### $event and event handling statements
+  ### *$event* and event handling statements
   In an event binding, Angular sets up an event handler for the target event.
 
   When the event is raised, the handler executes the template statement.
@@ -749,7 +793,7 @@ code-example(format="", language="html").
   passing the *hero-to-delete* (emitted by `HeroDetail`) in the `$event` variable.
 
   ### Template statements have side effects
-  The `deleteHero` method has a side effect: It deletes a hero.
+  The `deleteHero` method has a side effect: it deletes a hero.
   Template statement side effects are not just OK, they are expected.
 
   Deleting the hero updates the model, perhaps triggering other changes
@@ -790,12 +834,10 @@ code-example(format="", language="html").
   ## Two-way binding with NgModel
   When developing data entry forms, we often want to both display a data property and update that property when the user makes changes.
 
-  The `[(NgModel)]` two-way data binding syntax makes that easy. Here's an example:
+  The `[(ngModel)]` two-way data binding syntax makes that easy. Here's an example:
 +makeExample('template-syntax/ts/app/app.component.html', 'NgModel-1')(format=".")
 .callout.is-important
-  header
-    :marked
-       <span style="font-family:consolas; monospace">[()]</span> = banana in a box
+  header [()] = banana in a box
   :marked
     To remember that the parentheses go inside the brackets, visualize a *banana in a box*.
 :marked
@@ -822,7 +864,7 @@ code-example(format="", language="html").
     The details are specific to each kind of element and therefore the `NgModel` directive only works for elements,
     such as the input text box, that are supported by a [ControlValueAccessor](../api/common/ControlValueAccessor-interface.html).
     We can't apply `[(ngModel)]` to our custom components until we write a suitable *value accessor*,
-    a technique that is out of scope for this chapter.
+    a technique that is beyond the scope of this chapter.
 
 :marked
   Separate `ngModel` bindings is an improvement. We can do better.
@@ -837,10 +879,9 @@ code-example(format="", language="html").
     into an `x` input property for property binding and an `xChange` output property for event binding.
     Angular constructs the event property binding's template statement by appending `=$event`
     to the literal string of the template expression.
-  code-example(format="." ).
-    [(x)]="hero.name" &lt;==> [x]="hero.name" (xChange)="hero.name=$event"
 
-  :marked
+    > <span style="font-family:courier">[(_x_)]="_e_" &lt;==> [_x_]="_e_" (<i>x</i>Change)="_e_=$event"</span>
+
     We can write a two-way binding directive of our own to exploit this behavior.
 
 :marked
@@ -891,8 +932,9 @@ figure.image-display
   The `NgClass` directive may be the better choice
   when we want to add or remove *many* CSS classes at the same time.
 
-  A good way to apply `NgClass` is by binding it to a key:value control object. Each key of the object is a CSS class name; its value is `true` if the class should be added, `false` if it should be removed.
+  A good way to apply `NgClass` is by binding it to a key:value control !{__objectAsMap}. Each key of the object is a CSS class name; its value is `true` if the class should be added, `false` if it should be removed.
 
+:marked
   Consider a component method such as `setClasses` that manages the state of three CSS classes:
 +makeExample('template-syntax/ts/app/app.component.ts', 'setClasses')(format=".")
 :marked
@@ -913,7 +955,7 @@ figure.image-display
   The `NgStyle` directive may be the better choice
   when we want to set *many* inline styles at the same time.
 
-  We apply `NgStyle` by binding it to a key:value control object.
+  We apply `NgStyle` by binding it to a key:value control !{__objectAsMap}.
   Each key of the object is a style name; its value is whatever is appropriate for that style.
 
   Consider a component method such as `setStyles` that returns an object defining three styles:
@@ -927,7 +969,7 @@ figure.image-display
 .l-main-section
 :marked
   ### NgIf
-  We can add an element subtree (an element and its children) to the DOM  by binding an `NgIf` directive to a truthy expression.
+  We can add an element subtree (an element and its children) to the DOM  by binding an `NgIf` directive to a #{_truthy} expression.
 +makeExample('template-syntax/ts/app/app.component.html', 'NgIf-1')(format=".")
 
 .alert.is-critical
@@ -935,8 +977,11 @@ figure.image-display
     Don't forget the asterisk (`*`) in front of `ngIf`.
     For more information, see [\* and &lt;template>](#star-template).
 :marked
-  Binding to a falsey expression removes the element subtree from the DOM.
+  Binding to a #{_falsey} expression removes the element subtree from the DOM.
 +makeExample('template-syntax/ts/app/app.component.html', 'NgIf-2')(format=".")
+
+block dart-no-truthy-falsey
+  //- N/A
 
 :marked
   #### Visibility and NgIf are not the same
@@ -1025,18 +1070,17 @@ figure.image-display
 :marked
   #### NgFor microsyntax
   The string assigned to `*ngFor` is not a [template expression](#template-expressions).
-  It’s a *microsyntax* &mdash; a little language of its own that Angular interprets. In this example, the string "let hero of heroes" means:
+  It’s a *microsyntax* &mdash; a little language of its own that Angular interprets. In this example, the string `"let hero of heroes"` means:
 
-  >*Take each hero in the `heroes` array, store it in the local `hero` variable, and make it available to the templated HTML
-  for each iteration.*
+  > *Take each hero in the `heroes` #{_array}, store it in the local `hero` variable, and make it available to the templated HTML for each iteration.*
 
   Angular translates this instruction into a new set of elements and bindings.
-:marked
-  In the two previous examples, the `ngFor` directive iterates over the `heroes` array returned by the parent component’s `heroes` property,
+
+  In the two previous examples, the `ngFor` directive iterates over the `heroes` #{_array} returned by the parent component’s `heroes` property,
   stamping out instances of the element to which it is applied.
   Angular creates a fresh instance of the template for each hero in the array.
 
-  The `let` keyword before "hero" creates a template input variable called `hero`.
+  The `let` keyword before `hero` creates a template input variable called `hero`.
 
 .alert.is-critical
   :marked
@@ -1123,14 +1167,15 @@ figure.image-display
   Notice that the `[hero]="currentHero"` binding remains on the child `<hero-detail>`
   element inside the template.
 
-.callout.is-critical
-  header Remember the brackets!
-  :marked
-    Don’t make the mistake of writing `ngIf="currentHero"`!
-    That syntax assigns the *string* value "currentHero" to `ngIf`.
-    In JavaScript a non-empty string is a truthy value, so `ngIf` would always be
-    `true` and Angular would always display the `hero-detail`
-    … even when there is no `currentHero`!
+block remember-the-brackets
+  .callout.is-critical
+    header Remember the brackets!
+    :marked
+      Don’t make the mistake of writing `ngIf="currentHero"`!
+      That syntax assigns the *string* value `"currentHero"` to `ngIf`.
+      In JavaScript a non-empty string is a truthy value, so `ngIf` would always be
+      `true` and Angular would always display the `hero-detail`
+      … even when there is no `currentHero`!
 
 :marked
   ### Expanding `*ngSwitch`
@@ -1172,7 +1217,7 @@ figure.image-display
 
   A **template reference variable** is a reference to an DOM element or directive within a template.
 
-  It can be used with native DOM elements but also with Angular 2 components - in fact, it will work with any custom web component.
+  It can be used with native DOM elements but also with Angular 2 components &mdash; in fact, it will work with any custom web component.
 
 :marked
   ### Referencing a template reference variable
@@ -1245,7 +1290,7 @@ figure.image-display
     The *source* is on the *right* of the `=`.
 
     The *target* of a binding is the property or event inside the binding punctuation: `[]`, `()` or `[()]`.
-    The *source* is either inside quotes (`" "`) or within an interpolation (`{}`).
+    The *source* is either inside quotes (`" "`) or within an interpolation (`{{}}`).
 
     Every member of a **source** directive is automatically available for binding.
     We don't have to do anything special to access a directive member in a template expression or statement.
@@ -1276,12 +1321,12 @@ figure.image-display
 :marked
 .l-sub-section
   :marked
-    Alternatively, we can identify members in the `inputs` and `outputs` arrays
+    Alternatively, we can identify members in the `inputs` and `outputs` #{_array}s
     of the directive metadata, as in this example:
   +makeExample('template-syntax/ts/app/hero-detail.component.ts', 'input-output-2')(format=".")
   <br>
   :marked
-    We can specify an input/output property either with a decorator or in a metadata array.
+    We can specify an input/output property either with a decorator or in a metadata #{_array}.
     Don't do both!
 :marked
   ### Input or output?
@@ -1299,9 +1344,8 @@ figure.image-display
   `HeroDetailComponent.deleteRequest` is an **output** property from the perspective of `HeroDetailComponent`
   because events stream *out* of that property and toward the handler in a template binding statement.
 
+h3#aliasing-io Aliasing input/output properties
 :marked
-  ### Aliasing input/output properties
-
   Sometimes we want the public name of an input/output property to be different from the internal name.
 
   This is frequently the case with [attribute directives](attribute-directives.html).
@@ -1325,7 +1369,7 @@ figure.image-display
 
 .l-sub-section
   :marked
-    We can also alias property names in the `inputs` and `outputs` arrays.
+    We can also alias property names in the `inputs` and `outputs` #{_array}s.
     We write a colon-delimited (`:`) string with
     the directive property name on the *left* and the public alias on the *right*:
   +makeExample('template-syntax/ts/app/my-click.directive.ts', 'my-click-output-2')(format=".")
@@ -1334,7 +1378,7 @@ figure.image-display
 .l-main-section
 :marked
   ## Template expression operators
-  The template expression language employs a subset of JavaScript syntax supplemented with a few special operators
+  The template expression language employs a subset of #{_JavaScript} syntax supplemented with a few special operators
   for specific scenarios. We'll cover two of these operators: _pipe_ and _safe navigation operator_.
 
 :marked
@@ -1352,11 +1396,20 @@ figure.image-display
   We can chain expressions through multiple pipes:
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-2')(format=".")
 :marked
-  And we can configure them too:
+  And we can also [apply parameters](./pipes.html#parameterizing-a-pipe) to a pipe:
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-3')(format=".")
-:marked
-  The `json` pipe is particularly helpful for debugging our bindings:
-+makeExample('template-syntax/ts/app/app.component.html', 'pipes-json')(format=".")
+
+block json-pipe
+  :marked
+    The `json` pipe is particularly helpful for debugging our bindings:
+  +makeExample('template-syntax/ts/app/app.component.html', 'pipes-json')(format=".")
+  :marked
+    The generated output would look something like this
+  code-example(language="json").
+    { "firstName": "Hercules", "lastName": "Son of Zeus",
+      "birthdate": "1970-02-25T08:00:00.000Z",
+      "url": "http://www.imdb.com/title/tt0065832/",
+      "rate": 325, "id": 1 }
 
 :marked
   <a id="safe-navigation-operator"></a>
@@ -1365,6 +1418,10 @@ figure.image-display
   The Angular **safe navigation operator (`?.`)** is a fluent and convenient way to guard against null and undefined values in property paths.
   Here it is, protecting against a view render failure if the `currentHero` is null.
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-2')(format=".")
+
+block dart-safe-nav-op
+  //- N/A
+  
 :marked
   Let’s elaborate on the problem and this particular solution.
 
@@ -1377,12 +1434,15 @@ figure.image-display
   Suppose the template expression involves a property path, as in this next example
   where we’re displaying the `firstName` of a null hero.
 
-code-example(format="" language="html").
+code-example(language="html").
   The null hero's name is {{nullHero.firstName}}
-:marked
-  JavaScript throws a null reference error, and so does Angular:
-code-example(format="" language="html").
-  TypeError: Cannot read property 'firstName' of null in [null]
+
+block null-deref-example
+  :marked
+    JavaScript throws a null reference error, and so does Angular:
+  code-example(format="nocode").
+    TypeError: Cannot read property 'firstName' of null in [null].
+
 :marked
   Worse, the *entire view disappears*.
 
@@ -1401,14 +1461,17 @@ code-example(format="" language="html").
 
   We could code around that problem with [NgIf](#ngIf).
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-4')(format=".")
-:marked
-  Or we could try to chain parts of the property path with `&&`, knowing that the expression bails out
-  when it encounters the first null.
-+makeExample('template-syntax/ts/app/app.component.html', 'safe-5')(format=".")
+
+block safe-op-alt
+  :marked
+    Or we could try to chain parts of the property path with `&&`, knowing that the expression bails out
+    when it encounters the first null.
+  +makeExample('template-syntax/ts/app/app.component.html', 'safe-5')(format=".")
+
 :marked
   These approaches have merit but can be cumbersome, especially if the property path is long.
   Imagine guarding against a null somewhere in a long property path such as `a.b.c.d`.
-:marked
+
   The Angular safe navigation operator (`?.`) is a more fluent and convenient way to guard against nulls in property paths.
   The expression bails out when it hits the first null value.
   The display is blank, but the app keeps rolling without errors.

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -1,6 +1,5 @@
 include ../_util-fns
 
-// #docregion intro
 :marked
   Our Angular application manages what the user sees and does through the interaction of a Component class instance (the *component*) and its user-facing template.
 
@@ -29,21 +28,17 @@ include ../_util-fns
   * [Template expression operators](#expression-operators)
     * [pipe](#pipe)
     * ["safe navigation operator" (?.)](#safe-navigation-operator)
-// #enddocregion intro
 .l-sub-section
   :marked
     The [live example](/resources/live-examples/template-syntax/ts/plnkr.html)
     demonstrates all of the syntax and code snippets described in this chapter.
 
-// #docregion html-1
 .l-main-section
 :marked
   ## HTML
   HTML is the language of the Angular template. Our [QuickStart](../quickstart.html) application had a template that was pure HTML:
-// #enddocregion html-1
 
 +makeExample('template-syntax/ts/app/app.component.html', 'my-first-app')(format=".")
-// #docregion html-2
 :marked
   Almost all HTML syntax is valid template syntax. The `<script>` element is a notable exception; it is forbidden, eliminating the risk of script injection attacks. (In practice, `<script>` is simply ignored.)
 
@@ -52,22 +47,16 @@ include ../_util-fns
   We can extend the HTML vocabulary of our templates with components and directives that appear as new elements and attributes. And we are about to learn how to get and set DOM values dynamically through data binding.
 
   Let’s turn to the first form of data binding &mdash; interpolation &mdash; to see how much richer template HTML can be.
-// #enddocregion html-2
 
-// #docregion interpolation-1
 .l-main-section
 :marked
   ## Interpolation
   We met the double-curly braces of interpolation, `{{` and `}}`, early in our Angular education.
-// #enddocregion interpolation-1
 +makeExample('template-syntax/ts/app/app.component.html', 'first-interpolation')(format=".")
-// #docregion interpolation-2
 :marked
   We use interpolation to weave calculated strings into the text between HTML element tags and within attribute assignments.
-// #enddocregion interpolation-2
 
 +makeExample('template-syntax/ts/app/app.component.html', 'title+image')(format=".")
-// #docregion interpolation-3
 :marked
   The material between the braces is often the name of a component property. Angular replaces that name with the
   string value of the corresponding component property. In this example, Angular evaluates the `title` and `heroImageUrl` properties
@@ -75,14 +64,10 @@ include ../_util-fns
 
   More generally, the material between the braces is a **template expression** that Angular first **evaluates**
   and then **converts to a string**. The following interpolation illustrates the point by adding the two numbers within braces:
-// #enddocregion interpolation-3
 +makeExample('template-syntax/ts/app/app.component.html', 'sum-1')(format=".")
-// #docregion interpolation-4
 :marked
   The expression can invoke methods of the host component, as we do here with `getVal()`:
-// #enddocregion interpolation-4
 +makeExample('template-syntax/ts/app/app.component.html', 'sum-2')(format=".")
-// #docregion interpolation-5
 :marked
   Angular evaluates all expressions in double curly braces, converts the expression results to strings, and concatenates them with neighboring literal strings. Finally,
   it assigns this composite interpolated result to an **element or directive property**.
@@ -93,9 +78,7 @@ include ../_util-fns
   [property binding](#property-binding), as we'll explain below.
 
   But first, let's take a closer look at template expressions and statements.
-// #enddocregion interpolation-5
 
-// #docregion template-expressions-1
 <a id="template-expressions"></a>
 .l-main-section
 :marked
@@ -107,9 +90,7 @@ include ../_util-fns
   We put a template expression within the interpolation braces when we wrote `{{1 + 1}}`.
   We’ll see template expressions again in the [property binding](#property-binding) section,
   appearing in quotes to the right of the `=` symbol as in `[property]="expression"`.
-// #enddocregion template-expressions-1
 
-// #docregion template-expressions-2
 :marked
   We write template expressions in a language that looks like JavaScript.
   Many JavaScript expressions are legal template expressions, but not all.
@@ -125,9 +106,7 @@ include ../_util-fns
 
   * no support for the bitwise operators `|` and `&`
   * new [template expression operators](#expression-operators), such as `|` and `?.`
-// #enddocregion template-expressions-2
 
-// #docregion template-expressions-context
 - var lang = current.path[1]
 - var details = lang === 'dart' ? 'template expressions can’t refer to static properties, nor to top-level variables or functions, such as <code>window</code> or <code>document</code> from <code>dart:html</code>. They can’t directly call <code>print</code> or functions imported from <code>dart:math</code>. They are restricted to referencing members of the expression context.' : 'template expressions cannot refer to anything in the global namespace. They can’t refer to <code>window</code> or <code>document</code>. They can’t call <code>console.log</code> or <code>Math.max</code>. They are restricted to referencing members of the expression context.'
 :marked
@@ -149,9 +128,7 @@ include ../_util-fns
 
   The expression context can include objects other than the component.
   A [template reference variable](#ref-vars) is one such alternative context object.
-// #enddocregion template-expressions-context
 
-// #docregion template-expressions-guidelines
 :marked
   <a id="no-side-effects"></a>
   ### Expression guidelines
@@ -194,16 +171,12 @@ include ../_util-fns
 
   In Angular terms, an idempotent expression always returns *exactly the same thing* until
   one of its dependent values changes.
-// #enddocregion template-expressions-guidelines
-// #docregion template-expressions-guidelines-2
 :marked
   Dependent values should not change during a single turn of the event loop.
   If an idempotent expression returns a string or a number, it returns the same string or number
   when called twice in a row. If the expression returns an object (including a `Date` or `Array`),
   it returns the same object *reference* when called twice in a row.
-// #enddocregion template-expressions-guidelines-2
 
-// #docregion template-statements-1
 <a id="template-statements"></a>
 .l-main-section
 :marked
@@ -223,8 +196,6 @@ include ../_util-fns
   :marked
     Responding to events is the other side of Angular's "unidirectional data flow".
     We're free to change anything, anywhere, during this turn of the event loop.
-// #enddocregion template-statements-1
-// #docregion template-statements-2
 :marked
   Like template expressions, template *statements* use a language that looks like JavaScript.
   The template statement parser is different than the template expression parser and
@@ -236,9 +207,7 @@ include ../_util-fns
   * operator assignment, such as `+=` and `-=`
   * the bitwise operators `|` and `&`
   * the [template expression operators](#expression-operators)
-// #enddocregion template-statements-2
 
-// #docregion template-statements-3
 - var lang = current.path[1]
 - var details = lang === 'dart' ? 'Template statements can’t refer to static properties on the class, nor to top-level variables or functions, such as <code>window</code> or <code>document</code> from <code>dart:html</code>. They can’t directly call <code>print</code> or functions imported from <code>dart:math</code>.' : 'Template statements cannot refer to anything in the global namespace. They can’t refer to <code>window</code> or <code>document</code>. They can’t call <code>console.log</code> or <code>Math.max</code>.'
 :marked
@@ -262,9 +231,7 @@ include ../_util-fns
 
   Now that we have a feel for template expressions and statements,
   we’re ready to learn about the varieties of data binding syntax beyond interpolation.
-// #enddocregion template-statements-3
 
-// #docregion binding-syntax-1
 .l-main-section
 :marked
   <a id="binding-syntax"></a>
@@ -329,26 +296,20 @@ table
 
   In the normal course of HTML development, we create a visual structure with HTML elements, and
   we modify those elements by setting element attributes with string constants.
-// #enddocregion binding-syntax-1
 
 +makeExample('template-syntax/ts/app/app.component.html', 'img+button')(format=".")
-// #docregion binding-syntax-2
 :marked
   We still create a structure and initialize attribute values this way in Angular templates.
 
   Then we learn to create new elements with components that encapsulate HTML
   and drop them into our templates as if they were native HTML elements.
-// #enddocregion binding-syntax-2
 +makeExample('template-syntax/ts/app/app.component.html', 'hero-detail-1')(format=".")
-// #docregion binding-syntax-3
 :marked
   That’s HTML Plus.
 
   Now we start to learn about data binding. The first binding we meet might look like this:
-// #enddocregion binding-syntax-3
 
 +makeExample('template-syntax/ts/app/app.component.html', 'disabled-button-1')(format=".")
-// #docregion binding-syntax-4
 :marked
   We’ll get to that peculiar bracket notation in a moment. Looking beyond it,
   our intuition tells us that we’re binding to the button's `disabled` attribute and setting
@@ -357,9 +318,7 @@ table
   Our intuition is wrong! Our everyday HTML mental model is misleading us.
   In fact, once we start data binding, we are no longer working with HTML *attributes*. We aren't setting attributes.
   We are setting the *properties* of DOM elements, components, and directives.
-// #enddocregion binding-syntax-4
 
-// #docregion binding-syntax-attribute-vs-property
 .l-sub-section
   :marked
     ### HTML attribute vs. DOM property
@@ -402,24 +361,18 @@ table
     The value of the *property* matters.
 
     **The HTML attribute and the DOM property are not the same thing, even when they have the same name.**
-// #enddocregion binding-syntax-attribute-vs-property
 
-// #docregion binding-syntax-5
 :marked
   This is so important, we’ll say it again.
 
   **Template binding works with *properties* and *events*, not *attributes*.**
-// #enddocregion binding-syntax-5
 
-// #docregion binding-syntax-world-without-attributes
 .callout.is-helpful
   header A world without attributes
   :marked
     In the world of Angular 2, the only role of attributes is to initialize element and directive state.
     When we data bind, we're dealing exclusively with element and directive properties and events.
     Attributes effectively disappear.
-// #enddocregion binding-syntax-world-without-attributes
-// #docregion binding-syntax-targets
 :marked
   With this model firmly in mind, let's learn about binding targets.
 
@@ -429,7 +382,6 @@ table
   (element | component | directive) property, an
   (element | component | directive) event, or (rarely) an attribute name.
   The following table summarizes:
-// #enddocregion binding-syntax-targets
 
 // If you update this table, UPDATE it in Dart & JS, too.
 <div width="90%">
@@ -481,12 +433,9 @@ table
       +makeExample('template-syntax/ts/app/app.component.html', 'style-binding-syntax-1')(format=".")
 </div>
 
-// #docregion binding-syntax-end
 :marked
   Let’s descend from the architectural clouds and look at each of these binding types in concrete detail.
-// #enddocregion binding-syntax-end
 
-// #docregion property-binding-1
 .l-main-section
 :marked
   ## Property binding
@@ -495,25 +444,17 @@ table
 
   The most common property binding sets an element property to a component property value. An example is
   binding the `src` property of an image element to a component’s `heroImageUrl` property:
-// #enddocregion property-binding-1
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-1')(format=".")
-// #docregion property-binding-2
 :marked
   Another example is disabling a button when the component says that it `isUnchanged`:
-// #enddocregion property-binding-2
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-2')(format=".")
-// #docregion property-binding-3
 :marked
   Another is setting a property of a directive:
-// #enddocregion property-binding-3
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-3')(format=".")
-// #docregion property-binding-4
 :marked
   Yet another is setting the model property of a custom component (a great way
   for parent and child components to communicate):
-// #enddocregion property-binding-4
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-4')(format=".")
-// #docregion property-binding-5
 :marked
   ### One-way *in*
   People often describe property binding as *one-way data binding* because it flows a value in one direction,
@@ -521,9 +462,7 @@ table
 
   We cannot use property binding to pull values *out* of the target element.
   We can't bind to a property of the target element to read it. We can only set it.
-// #enddocregion property-binding-5
 
-// #docregion property-binding-6
 .l-sub-section
   :marked
     Nor can we use property binding to *call* a method on the target element.
@@ -535,33 +474,25 @@ table
     See the API reference for
     [viewChild](../api/core/ViewChild-var.html) and
     [contentChild](../api/core/ContentChild-var.html).
-// #enddocregion property-binding-6
 
 // TODO (global): once we have api docs everywhere, change /docs/ts/latest/ to ../
 
-// #docregion property-binding-7
 :marked
   ### Binding target
   An element property between enclosing square brackets identifies the target property. The target property in the following code is the image element’s `src` property.
 
-// #enddocregion property-binding-7
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-1')(format=".")
-// #docregion property-binding-8
 :marked
   Some people prefer the `bind-` prefix alternative, known as the *canonical form*:
-// #enddocregion property-binding-8
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-5')(format=".")
-// #docregion property-binding-9
 :marked
   The target name is always the name of a property, even when it appears to be the name of something else. We see `src` and may think it’s the name of an attribute. No. It’s the name of an image element property.
 
   Element properties may be the more common targets,
   but Angular looks first to see if the name is a property of a known directive,
   as it is in the following example:
-// #enddocregion property-binding-9
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-3')(format=".")
 
-// #docregion property-binding-10
 .l-sub-section
   :marked
     Technically, Angular is matching the name to a directive [input](#inputs-outputs),
@@ -585,9 +516,7 @@ table
   Return an object if the target property expects an object.
 
   The `hero` property of the `HeroDetail` component expects a `Hero` object, which is exactly what we’re sending in the property binding:
-// #enddocregion property-binding-10
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-4')(format=".")
-// #docregion property-binding-11
 :marked
   ### Remember the brackets
   The brackets tell Angular to evaluate the template expression.
@@ -595,9 +524,7 @@ table
   It does *not* evaluate the string!
 
   Don't make the following mistake:
-// #enddocregion property-binding-11
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-6')(format=".")
-// #docregion property-binding-12
 a(id="one-time-initialization")
 :marked
   ### One-time string initialization
@@ -610,17 +537,13 @@ a(id="one-time-initialization")
   just as well for directive and component property initialization.
   The following example initializes the `prefix` property of the `HeroDetailComponent` to a fixed string,
   not a template expression. Angular sets it and forgets it.
-// #enddocregion property-binding-12
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-7')(format=".")
-// #docregion property-binding-13
 :marked
   The `[hero]` binding, on the other hand, remains a live binding to the component's `currentHero` property.
 
   ### Property binding or interpolation?
   We often have a choice between interpolation and property binding. The following binding pairs do the same thing:
-// #enddocregion property-binding-13
 +makeExample('template-syntax/ts/app/app.component.html', 'property-binding-vs-interpolation')(format=".")
-// #docregion property-binding-14
 :marked
   Interpolation is a convenient alternative for property binding in many cases.
   In fact, Angular  translates those interpolations into the corresponding property bindings
@@ -630,9 +553,7 @@ a(id="one-time-initialization")
   We lean toward readability, which tends to favor interpolation.
   We suggest establishing coding style rules for the organization and choosing the form that
   both conforms to the rules and feels most natural for the task at hand.
-// #enddocregion property-binding-14
 
-// #docregion other-bindings-1
 .l-main-section
 :marked
   <a id="other-bindings"></a>
@@ -641,8 +562,6 @@ a(id="one-time-initialization")
 
   ### Attribute binding
   We can set the value of an attribute directly with an **attribute binding**.
-// #enddocregion other-bindings-1
-// #docregion other-bindings-2
 .l-sub-section
   :marked
     This is the only exception to the rule that a binding sets a target property. This is the only binding that creates and sets an attribute.
@@ -679,9 +598,7 @@ code-example(format="", language="html").
   value, using an expression that resolves to a string.
 
   Here we bind `[attr.colspan]` to a calculated value:
-// #enddocregion other-bindings-2
 +makeExample('template-syntax/ts/app/app.component.html', 'attrib-binding-colspan')(format=".")
-// #docregion other-bindings-3
 :marked
   Here's how the table renders:
   <table border="1px">
@@ -691,9 +608,7 @@ code-example(format="", language="html").
 
   One of the primary use cases for attribute binding
   is to set ARIA attributes, as in this example:
-// #enddocregion other-bindings-3
 +makeExample('template-syntax/ts/app/app.component.html', 'attrib-binding-aria')(format=".")
-// #docregion other-bindings-class-1
 :marked
   ### Class binding
 
@@ -706,29 +621,21 @@ code-example(format="", language="html").
 
   The following examples show how to add and remove the application's "special" class
   with class bindings.  Here's how we set the attribute without binding:
-// #enddocregion other-bindings-class-1
 +makeExample('template-syntax/ts/app/app.component.html', 'class-binding-1')(format=".")
-// #docregion other-bindings-class-2
 :marked
   We can replace that with a binding to a string of the desired class names; this is an all-or-nothing, replacement binding.
-// #enddocregion other-bindings-class-2
 +makeExample('template-syntax/ts/app/app.component.html', 'class-binding-2')(format=".")
-// #docregion other-bindings-class-3
 :marked
   Finally, we can bind to a specific class name.
   Angular adds the class when the template expression evaluates to something truthy.
   It removes the class when the expression is falsey.
-// #enddocregion other-bindings-class-3
 +makeExample('template-syntax/ts/app/app.component.html', 'class-binding-3')(format=".")
 
-// #docregion other-bindings-class-4
 .l-sub-section
   :marked
     While this is a fine way to toggle a single class name,
     we generally prefer the [NgClass directive](#ngClass) for managing multiple class names at the same time.
-// #enddocregion other-bindings-class-4
 
-// #docregion other-bindings-style-1
 :marked
   ### Style binding
 
@@ -738,22 +645,16 @@ code-example(format="", language="html").
   Instead of an element property between brackets, we start with the prefix `style`,
   followed by a dot (`.`) and the name of a CSS style property: `[style.style-property]`.
 
-// #enddocregion other-bindings-style-1
 +makeExample('template-syntax/ts/app/app.component.html', 'style-binding-1')(format=".")
-// #docregion other-bindings-style-2
 :marked
   Some style binding styles have unit extension. Here we conditionally set the font size in  “em” and “%” units .
-// #enddocregion other-bindings-style-2
 +makeExample('template-syntax/ts/app/app.component.html', 'style-binding-2')(format=".")
 
-// #docregion other-bindings-style-3
 .l-sub-section
   :marked
     While this is a fine way to set a single style,
     we generally prefer the [NgStyle directive](#ngStyle) when setting several inline styles at the same time.
-// #enddocregion other-bindings-style-3
 
-// #docregion event-binding-1
 .l-main-section
 :marked
   ## Event binding
@@ -771,27 +672,19 @@ code-example(format="", language="html").
   [template statement](#template-statements) on the right.
   The following event binding listens for the button’s click event, calling
   the component's `onSave()` method whenever a click occurs:
-// #enddocregion event-binding-1
 +makeExample('template-syntax/ts/app/app.component.html', 'event-binding-1')(format=".")
-// #docregion event-binding-2
 :marked
   ### Target event
   A **name between enclosing parentheses** &mdash; for example, `(click)` &mdash;
   identifies the target event. In the following example, the target is the button’s click event.
-// #enddocregion event-binding-2
 +makeExample('template-syntax/ts/app/app.component.html', 'event-binding-1')(format=".")
-// #docregion event-binding-3
 :marked
   Some people prefer the `on-` prefix alternative, known as the *canonical form*:
-// #enddocregion event-binding-3
 +makeExample('template-syntax/ts/app/app.component.html', 'event-binding-2')(format=".")
-// #docregion event-binding-4
 :marked
   Element events may be the more common targets, but Angular looks first to see if the name matches an event property
   of a known directive, as it does in the following example:
-// #enddocregion event-binding-4
 +makeExample('template-syntax/ts/app/app.component.html', 'event-binding-3')(format=".")
-// #docregion event-binding-5
 :marked
   If the name fails to match an element event or an output property of a known directive,
   Angular reports an “unknown directive” error.
@@ -813,9 +706,7 @@ code-example(format="", language="html").
   with properties such as `target` and `target.value`.
 
   Consider this example:
-// #enddocregion event-binding-5
 +makeExample('template-syntax/ts/app/app.component.html', 'without-NgModel')(format=".")
-// #docregion event-binding-6
 :marked
   We’re binding the input box `value` to a `firstName` property, and we’re listening for changes by binding to the input box’s `input` event.
   When the user makes changes, the `input` event is raised, and the binding executes the statement within a context that includes the DOM event object, `$event`.
@@ -839,24 +730,20 @@ code-example(format="", language="html").
   The best it can do is raise an event reporting the user's delete request.
 
   Here are the pertinent excerpts from that `HeroDetailComponent`:
-// #enddocregion event-binding-6
 +makeExample('template-syntax/ts/app/hero-detail.component.ts',
 'template-1', 'HeroDetailComponent.ts (template)')(format=".")
 +makeExample('template-syntax/ts/app/hero-detail.component.ts',
 'deleteRequest', 'HeroDetailComponent.ts (delete logic)')(format=".")
 
-// #docregion event-binding-7
 :marked
   The component defines a `deleteRequest` property that returns an `EventEmitter`.
   When the user clicks *delete*, the component invokes the `delete()` method
   which tells the `EventEmitter` to emit a `Hero` object.
 
   Now imagine a hosting parent component that binds to the `HeroDetailComponent`'s `deleteRequest` event.
-// #enddocregion event-binding-7
 
 +makeExample('template-syntax/ts/app/app.component.html',
 'event-binding-to-component')(format=".")
-// #docregion event-binding-8
 :marked
   When the `deleteRequest` event fires, Angular calls the parent component's `deleteHero` method,
   passing the *hero-to-delete* (emitted by `HeroDetail`) in the `$event` variable.
@@ -869,7 +756,6 @@ code-example(format="", language="html").
   including queries and saves to a remote server.
   These changes percolate through the system and are ultimately displayed in this and other views.
   It's all good.
-// #enddocregion event-binding-8
 
 //
   :marked
@@ -898,7 +784,6 @@ code-example(format="", language="html").
   +makeExample('template-syntax/ts/app/app.component.html', 'event-binding-propagation')(format=".")
 
 
-// #docregion ngModel-1
 .l-main-section
 :marked
   <a id="ngModel"></a>
@@ -906,9 +791,7 @@ code-example(format="", language="html").
   When developing data entry forms, we often want to both display a data property and update that property when the user makes changes.
 
   The `[(NgModel)]` two-way data binding syntax makes that easy. Here's an example:
-// #enddocregion ngModel-1
 +makeExample('template-syntax/ts/app/app.component.html', 'NgModel-1')(format=".")
-// #docregion ngModel-2
 .callout.is-important
   header
     :marked
@@ -917,27 +800,21 @@ code-example(format="", language="html").
     To remember that the parentheses go inside the brackets, visualize a *banana in a box*.
 :marked
   Alternatively, we can use the canonical prefix form:
-// #enddocregion ngModel-2
 +makeExample('template-syntax/ts/app/app.component.html', 'NgModel-2')(format=".")
-// #docregion ngModel-3
 :marked
   There’s a story behind this construction, a story that builds on the property and event binding techniques we learned previously.
 
   ### Inside [(ngModel)]
   We could have achieved the same result with separate bindings to
   the `<input>` element's  `value` property and `input` event.
-// #enddocregion ngModel-3
 +makeExample('template-syntax/ts/app/app.component.html', 'without-NgModel')(format=".")
-// #docregion ngModel-4
 :marked
   That’s cumbersome. Who can remember which element property to set and what event reports user changes?
   How do we extract the currently displayed text from the input box so we can update the data property?
   Who wants to look that up each time?
 
   That `ngModel` directive hides these onerous details behind its own  `ngModel` input and `ngModelChange` output properties.
-// #enddocregion ngModel-4
 +makeExample('template-syntax/ts/app/app.component.html', 'NgModel-3')(format=".")
-// #docregion ngModel-5
 .l-sub-section
   :marked
     The `ngModel` input property sets the element's value property and the `ngModelChange` output property
@@ -952,10 +829,8 @@ code-example(format="", language="html").
 
   We shouldn't have to mention the data property twice. Angular should be able to capture the component’s data property and set it
   with a single declaration &mdash; which it can with the `[( )]` syntax:
-// #enddocregion ngModel-5
 +makeExample('template-syntax/ts/app/app.component.html', 'NgModel-1')(format=".")
 
-// #docregion ngModel-6
 .l-sub-section
   :marked
     `[(ngModel)]` is a specific example of a more general pattern in which Angular "de-sugars" the `[(x)]` syntax
@@ -975,16 +850,12 @@ code-example(format="", language="html").
   If we need to do something more or something different, we need to write the expanded form ourselves.
 
   Let's try something silly like forcing the input value to uppercase:
-// #enddocregion ngModel-6
 +makeExample('template-syntax/ts/app/app.component.html', 'NgModel-4')(format=".")
-// #docregion ngModel-7
 :marked
   Here are all variations in action, including the uppercase version:
 figure.image-display
     img(src='/resources/images/devguide/template-syntax/ng-model-anim.gif' alt="NgModel variations")
-// #enddocregion ngModel-7
 
-// #docregion directives-1
 .l-main-section
 :marked
   <a id="directives"></a>
@@ -997,18 +868,14 @@ figure.image-display
   We don’t need many of those directives in Angular 2.
   Quite often we can achieve the same results with the more capable and expressive Angular 2 binding system.
   Why create a directive to handle a click when we can write a simple binding such as this?
-// #enddocregion directives-1
 +makeExample('template-syntax/ts/app/app.component.html', 'event-binding-1')(format=".")
-// #docregion directives-2
 :marked
   We still benefit from directives that simplify complex tasks.
   Angular still ships with built-in directives; just not as many.
   We'll write our own directives, just not as many.
 
   This segment reviews some of the most frequently used built-in directives.
-// #enddocregion directives-2
 
-// #docregion directives-ngClass-1
 <a id="ngClass"></a>
 .l-main-section
 :marked
@@ -1019,9 +886,7 @@ figure.image-display
   We can bind to `NgClass` to add or remove several classes simultaneously.
 
   A [class binding](#class-binding) is a good way to add or remove a *single* class.
-// #enddocregion directives-ngClass-1
 +makeExample('template-syntax/ts/app/app.component.html', 'class-binding-3a')(format=".")
-// #docregion directives-ngClass-2
 :marked
   The `NgClass` directive may be the better choice
   when we want to add or remove *many* CSS classes at the same time.
@@ -1029,16 +894,12 @@ figure.image-display
   A good way to apply `NgClass` is by binding it to a key:value control object. Each key of the object is a CSS class name; its value is `true` if the class should be added, `false` if it should be removed.
 
   Consider a component method such as `setClasses` that manages the state of three CSS classes:
-// #enddocregion directives-ngClass-2
 +makeExample('template-syntax/ts/app/app.component.ts', 'setClasses')(format=".")
-// #docregion directives-ngClass-3
 :marked
   Now we can add an `NgClass` property binding that calls `setClasses`
   and sets the element's classes accordingly:
-// #enddocregion directives-ngClass-3
 +makeExample('template-syntax/ts/app/app.component.html', 'NgClass-1')(format=".")
 
-// #docregion directives-ngStyle-1
 <a id="ngStyle"></a>
 .l-main-section
 :marked
@@ -1047,9 +908,7 @@ figure.image-display
   Binding to `NgStyle` lets us set many inline styles simultaneously.
 
   A [style binding](#style-binding) is an easy way to set a *single* style value.
-// #enddocregion directives-ngStyle-1
 +makeExample('template-syntax/ts/app/app.component.html', 'NgStyle-1')(format=".")
-// #docregion directives-ngStyle-2
 :marked
   The `NgStyle` directive may be the better choice
   when we want to set *many* inline styles at the same time.
@@ -1058,44 +917,32 @@ figure.image-display
   Each key of the object is a style name; its value is whatever is appropriate for that style.
 
   Consider a component method such as `setStyles` that returns an object defining three styles:
-// #enddocregion directives-ngStyle-2
 +makeExample('template-syntax/ts/app/app.component.ts', 'setStyles')(format=".")
-// #docregion directives-ngStyle-3
 :marked
   Now we just add an `NgStyle` property binding that calls `setStyles`
   and sets the element's styles accordingly:
-// #enddocregion directives-ngStyle-3
 +makeExample('template-syntax/ts/app/app.component.html', 'NgStyle-2')(format=".")
 
-// #docregion directives-ngIf-1
 <a id="ngIf"></a>
 .l-main-section
 :marked
   ### NgIf
   We can add an element subtree (an element and its children) to the DOM  by binding an `NgIf` directive to a truthy expression.
-// #enddocregion directives-ngIf-1
 +makeExample('template-syntax/ts/app/app.component.html', 'NgIf-1')(format=".")
 
-// #docregion directives-ngIf-2
 .alert.is-critical
   :marked
     Don't forget the asterisk (`*`) in front of `ngIf`.
     For more information, see [\* and &lt;template>](#star-template).
-// #enddocregion directives-ngIf-2
-// #docregion directives-ngIf-3
 :marked
   Binding to a falsey expression removes the element subtree from the DOM.
-// #enddocregion directives-ngIf-3
 +makeExample('template-syntax/ts/app/app.component.html', 'NgIf-2')(format=".")
 
-// #docregion directives-ngIf-4
 :marked
   #### Visibility and NgIf are not the same
   We can show and hide an element subtree (the element and its children) with a
   [class](#class-binding) or [style](#style-binding) binding:
-// #enddocregion directives-ngIf-4
 +makeExample('template-syntax/ts/app/app.component.html', 'NgIf-3')(format=".")
-// #docregion directives-ngIf-5
 :marked
   Hiding a subtree is quite different from excluding a subtree with `NgIf`.
 
@@ -1110,9 +957,7 @@ figure.image-display
 
   The show/hide technique is probably fine for small element trees.
   We should be wary when hiding large trees; `NgIf` may be the safer choice. Always measure before leaping to conclusions.
-// #enddocregion directives-ngIf-5
 
-// #docregion directives-ngSwitch-1
 <a id="ngSwitch"></a>
 .l-main-section
 :marked
@@ -1122,9 +967,7 @@ figure.image-display
   Angular puts only the *selected* element tree into the DOM.
 
   Here’s an example:
-// #enddocregion directives-ngSwitch-1
 +makeExample('template-syntax/ts/app/app.component.html', 'NgSwitch')(format=".")
-// #docregion directives-ngSwitch-2
 :marked
   We bind the parent `NgSwitch` directive to an expression returning a *switch value*.
   The value is a string in this example, but it can be a value of any type.
@@ -1155,9 +998,7 @@ figure.image-display
 
     **Do** put the asterisk (`*`) in front of `ngSwitchWhen` and `ngSwitchDefault`.
     For more information, see [\* and &lt;template>](#star-template).
-// #enddocregion directives-ngSwitch-2
 
-// #docregion directives-ngFor-1
 <a id="ngFor"></a>
 .l-main-section
 :marked
@@ -1168,24 +1009,18 @@ figure.image-display
   We tell Angular to use that block as a template for rendering each item in the list.
 
   Here is an example of `NgFor` applied to a simple `<div>`:
-// #enddocregion directives-ngFor-1
 +makeExample('template-syntax/ts/app/app.component.html', 'NgFor-1')(format=".")
-// #docregion directives-ngFor-2
 :marked
   We can also apply an `NgFor` to a component element, as in this example:
-// #enddocregion directives-ngFor-2
 +makeExample('template-syntax/ts/app/app.component.html', 'NgFor-2')(format=".")
 
-// #docregion directives-ngFor-3
 .alert.is-critical
   :marked
     Don't forget the asterisk (`*`) in front of `ngFor`.
     For more information, see [\* and &lt;template>](#star-template).
 :marked
   The text assigned to `*ngFor` is the instruction that guides the repeater process.
-// #enddocregion directives-ngFor-3
 
-// #docregion directives-ngFor-4
 <a id="ngForMicrosyntax"></a>
 :marked
   #### NgFor microsyntax
@@ -1196,8 +1031,6 @@ figure.image-display
   for each iteration.*
 
   Angular translates this instruction into a new set of elements and bindings.
-// #enddocregion directives-ngFor-4
-// #docregion directives-ngFor-5
 :marked
   In the two previous examples, the `ngFor` directive iterates over the `heroes` array returned by the parent component’s `heroes` property,
   stamping out instances of the element to which it is applied.
@@ -1214,24 +1047,18 @@ figure.image-display
   as we’re doing in the interpolation.
   We can also pass the variable in a binding to a component element,
   as we're doing with `hero-detail`.
-// #enddocregion directives-ngFor-5
 
-// #docregion directives-ngFor-6
 :marked
   #### NgFor with index
   The `ngFor` directive supports an optional `index` that increases from 0 to the length of the array for each iteration.
   We can capture the index in a template input variable and use it in our template.
 
   The next example captures the index in a variable named `i`, using it to stamp out rows like "1 - Hercules Son of Zeus".
-// #enddocregion directives-ngFor-6
 +makeExample('template-syntax/ts/app/app.component.html', 'NgFor-3')(format=".")
-// #docregion directives-ngFor-7
 .l-sub-section
   :marked
     Learn about other special *index-like* values such as `last`, `even`, and `odd` in the [NgFor API reference](../api/common/NgFor-directive.html).
-// #enddocregion directives-ngFor-7
 
-// #docregion directives-ngForTrackBy-1
 :marked
   #### NgForTrackBy
   The `ngFor` directive has the potential to perform poorly, especially with large lists.
@@ -1246,15 +1073,11 @@ figure.image-display
 
   Angular can avoid this churn if we give it a *tracking* function that tells it what we know:
   that two objects with the same `hero.id` are the same *hero*. Here is such a function:
-// #enddocregion directives-ngForTrackBy-1
 +makeExample('template-syntax/ts/app/app.component.ts', 'trackByHeroes')(format=".")
-// #docregion directives-ngForTrackBy-2
 :marked
   Now set the `NgForTrackBy` directive to that *tracking* function.
   Angular offers a variety of equivalent syntax choices including these two:
-// #enddocregion directives-ngForTrackBy-2
 +makeExample('template-syntax/ts/app/app.component.html', 'NgForTrackBy-2')(format=".")
-// #docregion directives-ngForTrackBy-3
 :marked
   The *tracking* function doesn't eliminate all DOM changes.
   Angular may have to update the DOM element if the same-hero *properties* have changed.
@@ -1264,9 +1087,7 @@ figure.image-display
   Here is an illustration of the `NgForTrackBy` effect.
 figure.image-display
   img(src='/resources/images/devguide/template-syntax/ng-for-track-by-anim.gif' alt="NgForTrackBy")
-// #enddocregion directives-ngForTrackBy-3
 
-// #docregion star-template
 <a id="star-template"></a>
 <a id="structural-directive"></a>
 .l-main-section
@@ -1283,35 +1104,25 @@ figure.image-display
 
   In this section we go under the hood and see how
   Angular strips away the `*` and expands the HTML into the `<template>` tags for us.
-// #enddocregion star-template
 
-// #docregion star-template-ngIf-1
 :marked
   ### Expanding `*ngIf`
   We can do what Angular does ourselves and expand the `*` prefix syntax to template syntax. Here's some code with `*ngIf`:
-// #enddocregion star-template-ngIf-1
 +makeExample('template-syntax/ts/app/app.component.html', 'Template-1')(format=".")
-// #docregion star-template-ngIf-2a
 :marked
   The `currentHero` is referenced twice, first as the true/false condition for `NgIf` and
   again as the actual hero passed into the `HeroDetailComponent`.
 
   The first expansion step transports the `ngIf` (without the `*` prefix) and its contents
   into an expression assigned to a `template` directive.
-// #enddocregion star-template-ngIf-2a
 +makeExample('template-syntax/ts/app/app.component.html', 'Template-2a')(format=".")
-// #docregion star-template-ngIf-2
 :marked
   The next (and final) step unfolds the HTML into a `<template>` tag and `[ngIf]` [property binding](#property-binding):
-// #enddocregion star-template-ngIf-2
 +makeExample('template-syntax/ts/app/app.component.html', 'Template-2')(format=".")
-// #docregion star-template-ngIf-3
 :marked
   Notice that the `[hero]="currentHero"` binding remains on the child `<hero-detail>`
   element inside the template.
-// #enddocregion star-template-ngIf-3
 
-// #docregion star-template-ngIf-4
 .callout.is-critical
   header Remember the brackets!
   :marked
@@ -1320,16 +1131,12 @@ figure.image-display
     In JavaScript a non-empty string is a truthy value, so `ngIf` would always be
     `true` and Angular would always display the `hero-detail`
     … even when there is no `currentHero`!
-// #enddocregion star-template-ngIf-4
 
-// #docregion star-template-ngSwitch-1
 :marked
   ### Expanding `*ngSwitch`
   A similar transformation applies to `*ngSwitch`. We can de-sugar the syntax ourselves.
   Here's an example, first with `*ngSwitchWhen` and `*ngSwitchDefault` and then again with `<template>` tags:
-// #enddocregion star-template-ngSwitch-1
 +makeExample('template-syntax/ts/app/app.component.html', 'NgSwitch-expanded')(format=".")
-// #docregion star-template-ngSwitch-2
 :marked
   The `*ngSwitchWhen` and `*ngSwitchDefault` expand in exactly the same manner as `*ngIf`,
   wrapping their former elements in `<template>` tags.
@@ -1343,31 +1150,21 @@ figure.image-display
   That's exactly what we see in this example:
 figure.image-display
     img(src='/resources/images/devguide/template-syntax/ng-switch-anim.gif' alt="NgSwitch")
-// #enddocregion star-template-ngSwitch-2
-// #docregion star-template-ngFor-1
 :marked
   ### Expanding `*ngFor`
   The `*ngFor` undergoes a similar transformation. We begin with an `*ngFor` example:
-// #enddocregion star-template-ngFor-1
 +makeExample('template-syntax/ts/app/app.component.html', 'Template-3a')(format=".")
-// #docregion star-template-ngFor-2
 :marked
   Here's the same example after transporting the `ngFor` to the `template` directive:
-// #enddocregion star-template-ngFor-2
 +makeExample('template-syntax/ts/app/app.component.html', 'Template-3')(format=".")
-// #docregion star-template-ngFor-3
 :marked
   And here it is expanded further into a `<template>` tag wrapping the original `<hero-detail>` element:
-// #enddocregion star-template-ngFor-3
 +makeExample('template-syntax/ts/app/app.component.html', 'Template-4')(format=".")
-// #docregion star-template-ngFor-4
 :marked
   The `NgFor` code is a bit more complex than `NgIf` because a repeater has more moving parts to configure.
   In this case, we have to remember to create and assign the `NgForOf` directive that identifies the list and the `NgForTrackBy` directive.
   Using the `*ngFor` syntax is much easier than writing out this expanded HTML ourselves.
-// #enddocregion star-template-ngFor-4
 
-// #docregion ref-vars
 <a id="ref-vars"></a>
 .l-main-section
 :marked
@@ -1384,9 +1181,7 @@ figure.image-display
   any child elements.
 
   Here are two other examples of creating and consuming a Template reference variable:
-// #enddocregion ref-vars
 +makeExample('template-syntax/ts/app/app.component.html', 'ref-phone')(format=".")
-// #docregion ref-vars-value
 :marked
   The hash (`#`) prefix to "phone" means that we're defining a `phone` variable.
 .l-sub-section
@@ -1402,24 +1197,18 @@ figure.image-display
   We defined these variables on the `input` elements.
   We’re passing those `input` element objects across to the
   button elements, where they're used in arguments to the `call` methods in the event bindings.
-// #enddocregion ref-vars-value
 
-// #docregion ref-vars-form-1
 :marked
   ### NgForm and template reference variables
   Let's look at one final example: a form, the poster child for template reference variables.
 
   The HTML for a form can be quite involved, as we saw in the [Forms](forms.html) chapter.
   The following is a *simplified* example &mdash; and it's not simple at all.
-// #enddocregion ref-vars-form-1
 +makeExample('template-syntax/ts/app/app.component.html', 'ref-form')(format=".")
-// #docregion ref-vars-form-2
 :marked
   A template reference variable, `theForm`, appears three times in this example, separated
   by a large amount of HTML.
-// #enddocregion ref-vars-form-2
 +makeExample('template-syntax/ts/app/app.component.html', 'ref-form-a')(format=".")
-// #docregion ref-vars-form-3
 :marked
   What is the value of `theForm`?
 
@@ -1431,9 +1220,7 @@ figure.image-display
 
   This explains how we can disable the submit button by checking `theForm.form.valid`
   and pass an object with rich information to the parent component's `onSubmit` method.
-// #enddocregion ref-vars-form-3
 
-// #docregion inputs-outputs-1
 <a id="inputs-outputs"></a>
 .l-main-section
 :marked
@@ -1468,16 +1255,12 @@ figure.image-display
 :marked
   In the following example, `iconUrl` and `onSave` are members of a component
   that are referenced within quoted syntax to the right of the `=`.
-// #enddocregion inputs-outputs-1
 +makeExample('template-syntax/ts/app/app.component.html', 'io-1')(format=".")
-// #docregion inputs-outputs-2
 :marked
   They are *neither inputs nor outputs* of the component. They are data sources for their bindings.
 
   Now look at `HeroDetailComponent` when it is the **target of a binding**.
-// #enddocregion inputs-outputs-2
 +makeExample('template-syntax/ts/app/app.component.html', 'io-2')(format=".")
-// #docregion inputs-outputs-3
 :marked
   Both `HeroDetailComponent.hero` and `HeroDetailComponent.deleteRequest` are on the **left side** of binding declarations.
   `HeroDetailComponent.hero` is inside brackets; it is the target of a property binding.
@@ -1488,7 +1271,6 @@ figure.image-display
 
   When we peek inside `HeroDetailComponent`, we see that these properties are marked
   with decorators as input and output properties.
-// #enddocregion inputs-outputs-3
 +makeExample('template-syntax/ts/app/hero-detail.component.ts', 'input-output-1')(format=".")
 
 :marked
@@ -1501,7 +1283,6 @@ figure.image-display
   :marked
     We can specify an input/output property either with a decorator or in a metadata array.
     Don't do both!
-// #docregion inputs-outputs-4
 :marked
   ### Input or output?
 
@@ -1517,9 +1298,7 @@ figure.image-display
 
   `HeroDetailComponent.deleteRequest` is an **output** property from the perspective of `HeroDetailComponent`
   because events stream *out* of that property and toward the handler in a template binding statement.
-// #enddocregion inputs-outputs-4
 
-// #docregion inputs-outputs-5
 :marked
   ### Aliasing input/output properties
 
@@ -1529,9 +1308,7 @@ figure.image-display
   Directive consumers expect to bind to the name of the directive.
   For example, when we apply a directive with a `myClick` selector to a `<div>` tag,
   we expect to bind to an event property that is also called `myClick`.
-// #enddocregion inputs-outputs-5
 +makeExample('template-syntax/ts/app/app.component.html', 'my-click')(format=".")
-// #docregion inputs-outputs-6
 :marked
   However, the directive name is often a poor choice for the name of a property within the directive class.
   The directive name rarely describes what the property does.
@@ -1543,7 +1320,6 @@ figure.image-display
   the directive's own `clicks` property.
 
   We can specify the alias for the property name by passing it into the input/output decorator like this:
-// #enddocregion inputs-outputs-6
 
 +makeExample('template-syntax/ts/app/my-click.directive.ts', 'my-click-output-1')(format=".")
 
@@ -1554,16 +1330,13 @@ figure.image-display
     the directive property name on the *left* and the public alias on the *right*:
   +makeExample('template-syntax/ts/app/my-click.directive.ts', 'my-click-output-2')(format=".")
 
-// #docregion expression-operators
 <a id="expression-operators"></a>
 .l-main-section
 :marked
   ## Template expression operators
   The template expression language employs a subset of JavaScript syntax supplemented with a few special operators
   for specific scenarios. We'll cover two of these operators: _pipe_ and _safe navigation operator_.
-// #enddocregion expression-operators
 
-// #docregion expression-operators-pipe-1
 :marked
   <a id="pipe"></a>
   ### The pipe operator ( | )
@@ -1572,43 +1345,31 @@ figure.image-display
   Angular [pipes](./pipes.html) are a good choice for small transformations such as these.
   Pipes are simple functions that accept an input value and return a transformed value.
   They're easy to apply within template expressions, using the **pipe operator (`|`)**:
-// #enddocregion expression-operators-pipe-1
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-1')(format=".")
-// #docregion expression-operators-pipe-2
 :marked
   The pipe operator passes the result of an expression on the left to a pipe function on the right.
 
   We can chain expressions through multiple pipes:
-// #enddocregion expression-operators-pipe-2
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-2')(format=".")
-// #docregion expression-operators-pipe-3
 :marked
   And we can configure them too:
-// #enddocregion expression-operators-pipe-3
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-3')(format=".")
-// #docregion expression-operators-pipe-4
 :marked
   The `json` pipe is particularly helpful for debugging our bindings:
-// #enddocregion expression-operators-pipe-4
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-json')(format=".")
 
-// #docregion expression-operators-safe-1
 :marked
   <a id="safe-navigation-operator"></a>
   ### The safe navigation operator ( ?. ) and null property paths
 
   The Angular **safe navigation operator (`?.`)** is a fluent and convenient way to guard against null and undefined values in property paths.
   Here it is, protecting against a view render failure if the `currentHero` is null.
-// #enddocregion expression-operators-safe-1
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-2')(format=".")
-// #docregion expression-operators-safe-2
 :marked
   Let’s elaborate on the problem and this particular solution.
 
   What happens when the following data bound `title` property is null?
-// #enddocregion expression-operators-safe-2
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-1')(format=".")
-// #docregion expression-operators-safe-3
 :marked
   The view still renders but the displayed value is blank; we see only "The title is" with nothing after it.
   That is reasonable behavior. At least the app doesn't crash.
@@ -1618,14 +1379,10 @@ figure.image-display
 
 code-example(format="" language="html").
   The null hero's name is {{nullHero.firstName}}
-// #enddocregion expression-operators-safe-3
-// #docregion expression-operators-safe-4
 :marked
   JavaScript throws a null reference error, and so does Angular:
 code-example(format="" language="html").
   TypeError: Cannot read property 'firstName' of null in [null]
-// #enddocregion expression-operators-safe-4
-// #docregion expression-operators-safe-5
 :marked
   Worse, the *entire view disappears*.
 
@@ -1643,34 +1400,23 @@ code-example(format="" language="html").
   Unfortunately, our app crashes when the `currentHero` is null.
 
   We could code around that problem with [NgIf](#ngIf).
-// #enddocregion expression-operators-safe-5
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-4')(format=".")
-// #docregion expression-operators-safe-6
 :marked
   Or we could try to chain parts of the property path with `&&`, knowing that the expression bails out
   when it encounters the first null.
-// #enddocregion expression-operators-safe-6
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-5')(format=".")
-// #docregion expression-operators-safe-7
 :marked
   These approaches have merit but can be cumbersome, especially if the property path is long.
   Imagine guarding against a null somewhere in a long property path such as `a.b.c.d`.
-// #enddocregion expression-operators-safe-7
-// #docregion expression-operators-safe-8
 :marked
   The Angular safe navigation operator (`?.`) is a more fluent and convenient way to guard against nulls in property paths.
   The expression bails out when it hits the first null value.
   The display is blank, but the app keeps rolling without errors.
-// #enddocregion expression-operators-safe-8
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-6')(format=".")
-// #docregion expression-operators-safe-9
 :marked
   It works perfectly with long property paths such as `a?.b?.c?.d`.
-// #enddocregion expression-operators-safe-9
 
-// #docregion summary
 .l-main-section
 :marked
   ## Summary
   We’ve completed our survey of template syntax. Now it's time to put that knowledge to work as we write our own components and directives.
-// #enddocregion summary

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -687,7 +687,12 @@ block dart-class-binding-bug
 
 .l-sub-section
   :marked
-    Note that the _style property_ name can be written in camelCase, such as `fontSize`.
+    Note that a _style property_ name can be written in either
+    [dash-case](glossary.html#dash-case), as shown above, or
+    [camelCase](glossary.html#camelcase), such as `fontSize`.
+
+block style-property-name-dart-diff
+  //- N/A
 
 .l-main-section
 :marked


### PR DESCRIPTION
Fixes #1460.

- Dart
  - update prose to new doc design.
  - enable e2e tests. Note: **tests pass**.
- TS: copyedits and changes to support Dart doc.
