### PR TITLE
docs(style-guide): make barrels a consider

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -1169,13 +1169,13 @@ a(href="#toc") Back to top
   <a id="04-10"></a>
   #### Style 04-10
 
-.s-rule.do
+.s-rule.consider
   :marked
-    **Do** create a file that imports, aggregates, and re-exports items. We call this technique a **barrel**.
+    **Consider** creating a file that imports, aggregates, and re-exports items. We call this technique a **barrel**.
 
-.s-rule.do
+.s-rule.consider
   :marked
-    **Do** name this barrel file `index.ts`.
+    **Consider** naming this barrel file `index.ts`.
 
 .s-why
   :marked
@@ -1184,6 +1184,14 @@ a(href="#toc") Back to top
 .s-why
   :marked
     **Why?** A barrel reduces the number of imports a file may need.
+    
+.s-why
+  :marked
+    **Why?** A barrel provides a consistent pattern to import everything exported in the barrel from a folder.
+    
+.s-why
+  :marked
+    **Why?** This is consistent with a pattern from Node, which imports the index.js|ts file from a folder.
 
 .s-why.s-why-last
   :marked


### PR DESCRIPTION
I changed barrels (as accorded) to consider and while at it, also put the file name as consider as well (for those who don't want to add a new entry to systemjs and prefer to name the barrel like the folder).

Added a new why too.