### PR TITLE
docs(style-guide): rename toast selector

### DIFF
--- a/public/docs/_examples/style-guide/e2e-spec.js
+++ b/public/docs/_examples/style-guide/e2e-spec.js
@@ -127,7 +127,7 @@ describe('Style Guide', function () {
   it('05-14', function () {
     browser.get('#/05-14');
 
-    var toast = element(by.tagName('sg-app > my-toast'));
+    var toast = element(by.tagName('sg-app > toh-toast'));
     expect(toast.getText()).toBe('...');
   });
 

--- a/public/docs/_examples/style-guide/ts/05-14/app/app.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-14/app/app.component.ts
@@ -4,7 +4,7 @@ import { ToastComponent } from './shared/toast/toast.component';
 
 @Component({
   selector: 'sg-app',
-  template: `<my-toast></my-toast>`,
+  template: `<toh-toast></toh-toast>`,
   directives: [ToastComponent]
 })
 export class AppComponent { }

--- a/public/docs/_examples/style-guide/ts/05-14/app/shared/toast/toast.component.ts
+++ b/public/docs/_examples/style-guide/ts/05-14/app/shared/toast/toast.component.ts
@@ -2,7 +2,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'my-toast',
+  selector: 'toh-toast',
   template: `...`
 })
 // #docregion example


### PR DESCRIPTION
The same file was using a different selector to grab the toast so for consistency, I changed it.