### PR TITLE
chore: put webpack guide in a ordered position

### DIFF
--- a/public/docs/ts/latest/guide/_data.json
+++ b/public/docs/ts/latest/guide/_data.json
@@ -84,6 +84,11 @@
     "intro": "Talk to a remote server with an HTTP Client."
   },
 
+  "webpack": {
+    "title": "Introduction to Webpack",
+    "intro": "Create your Angular 2 applications with a Webpack based tooling"
+  },
+
   "lifecycle-hooks": {
     "title": "Lifecycle Hooks",
     "intro": "Angular calls lifecycle hook methods on directives and components as it creates, changes, and destroys them."
@@ -129,11 +134,6 @@
   "upgrade": {
     "title": "Upgrading from 1.x",
     "intro": "Angular 1 applications can be incrementally upgraded to Angular 2."
-  },
-
-  "webpack": {
-    "title": "Introduction to Webpack",
-    "intro": "Create your Angular 2 applications with a Webpack based tooling"
   },
 
   "glossary": {


### PR DESCRIPTION
I never realized we had the guides in a ordered position. This fixes it.