### PR TITLE
Fix typo

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -433,7 +433,7 @@ h2#index Step 4: Add #[code index.html]
 
         * We see compiler warnings and errors that are hidden from us in the browser.
 
-        * Precompilation simpifies the module loading process and
+        * Precompilation simplifies the module loading process and
         it's much easier to diagnose problems when this is a separate, external step.
 
         * Precompilation means a faster user experience because the browser doesn't waste time compiling.


### PR DESCRIPTION
`simplifies` is misspelled in quickstart guide.

This PR fixes that.