### PR TITLE
docs: align badges vertically within their container

### DIFF
--- a/public/docs/_layout.jade
+++ b/public/docs/_layout.jade
@@ -25,7 +25,7 @@ html(lang="en" ng-app="angularIOApp" itemscope itemtype="http://schema.org/Frame
       else
         article(class="l-content-small grid-fluid docs-content")
           div(class="c10")
-            .showcase.shadow-1
+            .showcase
               .showcase-content
                 != yield
                   if (current.path[3] == 'guide' || current.path[3] == 'tutorial') && current.path[4]

--- a/public/resources/css/module/_hero.scss
+++ b/public/resources/css/module/_hero.scss
@@ -67,6 +67,11 @@ $hero-padding: ($unit * 10) ($unit * 6) ($unit * 7);
   }
 
   .badges {
+    display: flex;
+    justify-content: flex-start;
+    align-content: space-around;
+    align-items: center;
+
     margin-top: 4px;
 
     .status-badge {


### PR DESCRIPTION
#### Changes
* Align badges vertically

#### Preview
<img width="1191" alt="screen shot 2016-05-25 at 10 48 43 am" src="https://cloud.githubusercontent.com/assets/1329167/15544445/b8ebe94c-2266-11e6-8245-47843376ae25.png">
