### PR TITLE
chore(dart/_util-fns): make adjustExamplePath idempotent

### DIFF
--- a/public/docs/dart/latest/_util-fns.jade
+++ b/public/docs/dart/latest/_util-fns.jade
@@ -37,7 +37,7 @@ mixin liveExampleLink2(linkText, exampleUrlPartName)
 -   // Adjust the folder path, e.g., ts -> dart
 -   folder = folder.replace(/(^|\/)ts($|\/)/, '$1dart$2').replace(/(^|\/)app($|\/)/, inWebFolder ? '$1web$2' : '$1lib$2');
 -   // Special case not handled above: e.g., index.html -> web/index.html
--   if(baseNameNoExt.match(/^(index|styles)(\.\d)?$/)) folder = (folder ? folder + '/' : '') + 'web';
+-   if(baseNameNoExt.match(/^(index|styles)(\.\d)?$/) && !folder.match(/web$/)) folder = (folder ? folder + '/' : '') + 'web';
 -   // In file name, replace special characters with underscore
 -   baseNameNoExt = baseNameNoExt.replace(/[\-\.]/g, '_');
 -   // Adjust the file extension


### PR DESCRIPTION
Fixes #1513.

Note that `adjustExamplePath()` is being renamed to `adjustTsExamplePath4Dart()` in #1510.