### PR TITLE
fix(gulp): rename angular2 to @angular

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@ var _devguideShredJadeOptions =  {
 };
 
 var _apiShredOptions =  {
-  examplesDir: path.join(ANGULAR_PROJECT_PATH, 'modules/angular2/examples'),
+  examplesDir: path.join(ANGULAR_PROJECT_PATH, 'modules/@angular/examples'),
   fragmentsDir: path.join(DOCS_PATH, '_fragments/_api'),
   zipDir: path.join(RESOURCES_PATH, 'zips/api')
 };
@@ -845,7 +845,7 @@ function filterOutExcludedPatterns(fileNames, excludeMatchers) {
 }
 
 function apiSourceWatch(postBuildAction) {
-  var srcPattern = [path.join(ANGULAR_PROJECT_PATH, 'modules/angular2/src/**/*.*')];
+  var srcPattern = [path.join(ANGULAR_PROJECT_PATH, 'modules/@angular/src/**/*.*')];
   gulp.watch(srcPattern, {readDelay: 500}, function (event, done) {
     gutil.log('API source changed');
     gutil.log('Event type: ' + event.event); // added, changed, or deleted
@@ -856,7 +856,7 @@ function apiSourceWatch(postBuildAction) {
 }
 
 function apiExamplesWatch(postShredAction) {
-  var examplesPath = path.join(ANGULAR_PROJECT_PATH, 'modules/angular2/examples/**');
+  var examplesPath = path.join(ANGULAR_PROJECT_PATH, 'modules/@angular/examples/**');
   var includePattern = path.join(examplesPath, '**/*.*');
   var excludePattern = '!' + path.join(examplesPath, '**/node_modules/**/*.*');
   var cleanPath = [path.join(_apiShredOptions.fragmentsDir, '**/*.*'), '!**/*.ovr.*'];


### PR DESCRIPTION
#### Changes
* rename `angular2` to `@angular` in the gulp file
* fixes missing examples in API Doc, refer to AsyncPipe

#### Preview
* https://fix-missing-api-docs.firebaseapp.com/docs/ts/latest/api/

@naomiblack 