### PR TITLE
docs(index) grammar suggestion for homepage

### DIFF
--- a/public/index.jade
+++ b/public/index.jade
@@ -43,7 +43,7 @@ div(class="home-rows")
       div(class="text-block l-pad-top-2")
         h3(class="text-headline") Loved by Millions
         p(class="text-body").
-          Supports you from your first scrappy launch all the way through global deployment -- Angular brings you the scaling infrastructure and techniques that support Google's largest applications.
+          Supporting you from your first prototype all the way through global deployment, Angular brings you the scaling infrastructure and techniques that support Google's largest applications.
     div(class="promo-img-container promo-4")
       div
         img(src="resources/images/home/loved-by-millions.png")


### PR DESCRIPTION
Suggesting a grammatical change to the last promo box to use a more distinct dependent clause. I feel the terminology 'scrappy launch' is not the ideal choice.