### PR TITLE
chore: move from typings to @types

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,7 @@ var _apiShredOptions =  {
   zipDir: path.join(RESOURCES_PATH, 'zips/api')
 };
 
-var _excludePatterns = ['**/node_modules/**', '**/typings/**', '**/packages/**'];
+var _excludePatterns = ['**/node_modules/**', '**/packages/**'];
 
 var _excludeMatchers = _excludePatterns.map(function(excludePattern){
   return new Minimatch(excludePattern)
@@ -80,7 +80,6 @@ var _exampleBoilerplateFiles = [
   'systemjs.config.js',
   'tsconfig.json',
   'tslint.json',
-  'typings.json',
   'wallaby.js'
  ];
 
@@ -323,13 +322,6 @@ gulp.task('add-example-boilerplate', function() {
     fsUtils.addSymlink(realPath, linkPath);
   });
 
-  realPath = path.join(EXAMPLES_PATH, '/typings');
-  var typingsPaths = getTypingsPaths(EXAMPLES_PATH);
-  typingsPaths.forEach(function(linkPath) {
-    gutil.log("symlinking " + linkPath + ' -> ' + realPath)
-    fsUtils.addSymlink(realPath, linkPath);
-  });
-
   return copyExampleBoilerplate();
 });
 
@@ -364,11 +356,6 @@ function copyExampleBoilerplate() {
 gulp.task('remove-example-boilerplate', function() {
   var nodeModulesPaths = getNodeModulesPaths(EXAMPLES_PATH);
   nodeModulesPaths.forEach(function(linkPath) {
-    fsUtils.removeSymlink(linkPath);
-  });
-
-  var typingsPaths = getTypingsPaths(EXAMPLES_PATH);
-  typingsPaths.forEach(function(linkPath) {
     fsUtils.removeSymlink(linkPath);
   });
 
@@ -747,13 +734,6 @@ function getE2eSpecPaths(basePath) {
 function getNodeModulesPaths(basePath) {
   var paths = getExamplePaths(basePath).map(function(examplePath) {
     return path.join(examplePath, "/node_modules");
-  });
-  return paths;
-}
-
-function getTypingsPaths(basePath) {
-  var paths = getExamplePaths(basePath).map(function(examplePath) {
-    return path.join(examplePath, "/typings");
   });
   return paths;
 }

--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -31,15 +31,16 @@
     "@angular/router": "2.0.0-rc.1",
     "@angular/router-deprecated": "2.0.0-rc.1",
     "@angular/upgrade": "2.0.0-rc.1",
-
-    "systemjs": "0.19.27",
+    "@types/core-js": "^0.9.22-alpha",
+    "@types/jasmine": "^2.2.22-alpha",
+    "@types/node": "^4.0.22-alpha",
+    "angular2-in-memory-web-api": "0.0.10",
+    "bootstrap": "^3.3.6",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.6",
-    "zone.js": "^0.6.12",
-
-    "angular2-in-memory-web-api": "0.0.10",
-    "bootstrap": "^3.3.6"
+    "systemjs": "0.19.27",
+    "zone.js": "^0.6.12"
   },
   "devDependencies": {
     "canonical-path": "0.0.2",

--- a/public/docs/_examples/tsconfig.json
+++ b/public/docs/_examples/tsconfig.json
@@ -9,5 +9,10 @@
     "removeComments": false,
     "noImplicitAny": true,
     "suppressImplicitAnyIndexErrors": true
-  }
+  },
+  "files": [
+    "node_modules/@types/core-js/index.d.ts",
+    "node_modules/@types/jasmine/index.d.ts",
+    "node_modules/@types/node/index.d.ts"
+  ]
 }

--- a/public/docs/_examples/typings.json
+++ b/public/docs/_examples/typings.json
@@ -1,7 +1,0 @@
-{
-  "globalDependencies": {
-    "core-js": "registry:dt/core-js#0.0.0+20160317120654",
-    "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
-    "node": "registry:dt/node#4.0.0+20160509154515"
-  }
-}


### PR DESCRIPTION
**AS WIP AS IT CAN GET**

The difference in here is that we need to list all the new @types directly into tsconfig.json. I want to believe that the need is going to be removed for Typescript 2.0.

There is much more to do yet, stay tuned.