### PR TITLE
docs: Update architecture.jade link on 'Testing' page

### DIFF
--- a/public/docs/ts/latest/guide/architecture.jade
+++ b/public/docs/ts/latest/guide/architecture.jade
@@ -538,5 +538,5 @@ code-example(language="javascript" linenumbers=".").
 :marked
   >displays a price of "42.33" as `$42.33`.
   
-  >**[Testing](../testing/index.html)** - Angular provides a testing library for "unit testing" our application parts as they
+  >**[Testing](testing.html)** - Angular provides a testing library for "unit testing" our application parts as they
   interact with the Angular framework.


### PR DESCRIPTION
Old one was pointed to [https://angular.io/docs/ts/latest/testing/index.html](url), this page doesn't have info about each step, only lists them.
New page [https://angular.io/docs/ts/latest/guide/testing.html](url) has the same information + description for almost each step. So I think link should point to latter.