### PR TITLE
chore: disable ngAnimate for ng1 protractor tests

### DIFF
--- a/public/docs/_examples/protractor.config.js
+++ b/public/docs/_examples/protractor.config.js
@@ -71,6 +71,14 @@ exports.config = {
     global.setProtractorToNg1Mode = function() {
       browser.useAllAngular2AppRoots = false;
       browser.rootEl = 'body';
+      
+      var disableNgAnimate = function() {
+        angular.module('disableNgAnimate', []).run(['$animate', function($animate) {
+          $animate.enabled(false);
+        }]);
+      };
+
+      browser.addMockModule('disableNgAnimate', disableNgAnimate);
     };
   },
 


### PR DESCRIPTION
The new upgrade tutorial was taking ages so jasmine was throwing a timeout and killing our CI.

Like angular does on their repo, better to disable ngAnimate from the tests. Now it runs fast and doesn't fail anymore.