### PR TITLE
docs(ts-tutorial-pt6): correct DetailHeroComponent to HeroDetailComponent

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt6.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt6.jade
@@ -218,7 +218,7 @@ code-example(format="." language="bash").
   In the following section we will update our components to use our new methods to add, edit and delete heroes.
   
   ### Add/Edit in the *HeroDetailComponent*
-  We already have `HeroDetailComponent` for viewing details about a specific hero. Add and Edit are natural extensions of the detail view, so we are able to reuse `DetailHeroComponent` with a few tweaks. The original component was created to render existing data, but to add new data we have to initialize the `hero` property to an empty `Hero` object.
+  We already have `HeroDetailComponent` for viewing details about a specific hero. Add and Edit are natural extensions of the detail view, so we are able to reuse `HeroDetailComponent` with a few tweaks. The original component was created to render existing data, but to add new data we have to initialize the `hero` property to an empty `Hero` object.
   
 +makeExample('toh-6/ts/app/hero-detail.component.ts', 'ngOnInit', 'app/hero-detail.component.ts (ngOnInit)')(format=".")
 


### PR DESCRIPTION
Fixes a minor component name typo in the Http tutorial.