### PR TITLE
docs(toh-pt5): change getHero to match toh-pt6 getHero

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-5/ts/app/hero.service.ts
@@ -19,9 +19,8 @@ export class HeroService {
 
   //#docregion get-hero
   getHero(id: number) {
-    return Promise.resolve(HEROES).then(
-      heroes => heroes.filter(hero => hero.id === id)[0]
-    );
+    return this.getHeroes()
+               .then(heroes => heroes.filter(hero => hero.id === id)[0]);
   }
   //#enddocregion get-hero
 }

--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -427,7 +427,7 @@ code-example(format='').
   The problem with this bit of code is that `HeroService` doesn't have a `getHero` method!
   We better fix that quickly before someone notices that we broke the app.
   
-  Open `HeroService` and add the `getHero` method. It's trivial given that we're still faking data access:
+  Open `HeroService` and add the `getHero` method. It's trivial given that we can access the heroes list:
 +makeExample('toh-5/ts/app/hero.service.ts', 'get-hero', 'app/hero.service.ts (getHero)')(format=".")
 :marked
   Return to the `HeroDetailComponent` to clean up loose ends.


### PR DESCRIPTION
Fixes a discrepancy between the `getHero` functions in the Tour of Heroes tutorial part 6 and 7.

Part 6 getHero: https://github.com/angular/angular.io/blob/master/public/docs/_examples/toh-5/ts/app/hero.service.ts#L21
Part 7 getHero: https://github.com/angular/angular.io/blob/master/public/docs/_examples/toh-6/ts/app/hero.service.ts#L34

Reasoning: [part 7 advises the reader to remove the mock `HEROES` data](https://github.com/angular/angular.io/blob/master/public/docs/_examples/toh-6/ts/app/hero.service.ts#L34) but does not tell the reader to update `getHero` accordingly, resulting in an error. Rather than requiring the reader to rewrite `getHero` to use `getHeroes` in part 7, it seems to make more sense to have them write it this way from the start.