### PR TITLE
chore: kill http-server on failed tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('run-e2e-tests', function() {
     }
   }).catch(function(e) {
     gutil.log(e);
-    process.exit(1);
+    process.exitCode = 1;
   });
 });
 


### PR DESCRIPTION
Instead of making a check to see which OS are you using (needs an extra lib and extra code), I just kill it twice, better be sure it is dead.

No problem on Mac, but let see Windows.