### PR TITLE
docs(pipes): add safari compatibility

### DIFF
--- a/public/docs/_examples/pipes/ts/index.html
+++ b/public/docs/_examples/pipes/ts/index.html
@@ -12,6 +12,7 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en"></script>
 
     <script src="systemjs.config.js"></script>
     <script>


### PR DESCRIPTION
The plunker in safari was broken because it needs that concrete polyfill.

You can read more at https://github.com/angular/angular/issues/3333#issuecomment-219561520