### PR TITLE
docs(dependency-injection): revise Dart and TS code and prose

### DIFF
--- a/public/docs/_examples/dependency-injection/dart/lib/app_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/app_component.dart
@@ -11,6 +11,7 @@ import 'user_service.dart';
 //PENDING: check whether we intend to hide injector_component.dart & providers_component.dart; if so, change docregion name?
 // #enddocregion imports
 import 'injector_component.dart';
+import 'test_component.dart';
 import 'providers_component.dart';
 
 @Component(
@@ -31,21 +32,21 @@ import 'providers_component.dart';
       CarComponent,
       HeroesComponent,
       InjectorComponent,
+      TestComponent,
       ProvidersComponent
     ],
-// #docregion providers
+    // #docregion providers
     providers: const [
-      Logger,
-      UserService,
-      const Provider(AppConfig, useValue: config1)]
-// #enddocregion providers
+      Logger, UserService,
+      const Provider(APP_CONFIG, useFactory: heroDiConfigFactory)]
+    // #enddocregion providers
 )
 class AppComponent {
   final UserService _userService;
   final String title;
 
-  //#docregion ctor
-  AppComponent(AppConfig config, this._userService)
+  // #docregion ctor
+  AppComponent(@Inject(APP_CONFIG) AppConfig config, this._userService)
       : title = config.title;
   // #enddocregion ctor
 
@@ -64,4 +65,3 @@ class AppComponent {
   String get userInfo => 'Current user, ${user.name}, is'
       '${isAuthorized ? "" : " not"} authorized. ';
 }
-// #enddocregion

--- a/public/docs/_examples/dependency-injection/dart/lib/app_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/app_component.dart
@@ -1,6 +1,3 @@
-// #docplaster
-// #docregion
-// #docregion imports
 import 'package:angular2/core.dart';
 
 import 'app_config.dart';
@@ -8,8 +5,6 @@ import 'car/car_component.dart';
 import 'heroes/heroes_component.dart';
 import 'logger_service.dart';
 import 'user_service.dart';
-//PENDING: check whether we intend to hide injector_component.dart & providers_component.dart; if so, change docregion name?
-// #enddocregion imports
 import 'injector_component.dart';
 import 'test_component.dart';
 import 'providers_component.dart';
@@ -62,6 +57,6 @@ class AppComponent {
     return _userService.user;
   }
 
-  String get userInfo => 'Current user, ${user.name}, is'
-      '${isAuthorized ? "" : " not"} authorized. ';
+  String get userInfo => 'Current user, ${user.name}, is' +
+    (isAuthorized ? '' : ' not') + ' authorized. ';
 }

--- a/public/docs/_examples/dependency-injection/dart/lib/app_component_1.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/app_component_1.dart
@@ -16,13 +16,3 @@ import 'heroes/heroes_component_1.dart';
 class AppComponent {
   final String title = 'Dependency Injection';
 }
-// #enddocregion
-
-/*
-//#docregion ctor-di-fail
-// FAIL! Injectable `config` is not a class!
-AppComponent(HeroService heroService, Map config) {
-  title = config['title'];
-}
-//#enddocregion ctor-di-fail
-*/

--- a/public/docs/_examples/dependency-injection/dart/lib/app_component_2.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/app_component_2.dart
@@ -21,13 +21,16 @@ import 'logger_service.dart';
     ],
     providers: const [
       Logger,
-      const Provider(AppConfig, useValue: config1)
-    ])
+      // #docregion providers
+      const Provider(APP_CONFIG, useValue: heroDiConfig)
+      // #enddocregion providers
+    ]
+)
 class AppComponent {
   final String title;
 
   // #docregion ctor
-  AppComponent(AppConfig config)
-      : title = config.title;
-  // #enddocregion
+  AppComponent(@Inject(APP_CONFIG) Map config)
+      : title = config['title'];
+  // #enddocregion ctor
 }

--- a/public/docs/_examples/dependency-injection/dart/lib/app_config.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/app_config.dart
@@ -1,17 +1,27 @@
-// #docregion
 // #docregion token
 import 'package:angular2/core.dart';
 
-//#docregion const-class
-@Injectable()
+const APP_CONFIG = const OpaqueToken('app.config');
+// #enddocregion token
+
+// #docregion config
+const Map heroDiConfig = const <String,String>{
+  'apiEndpoint' : 'api.heroes.com',
+  'title' : 'Dependency Injection'
+};
+// #enddocregion config
+
+// #docregion config-alt
 class AppConfig {
-  final apiEndpoint;
-  final String title;
-
-  const AppConfig(this.apiEndpoint, this.title);
+  String apiEndpoint;
+  String title;
 }
-//#enddocregion const-class
 
-//#docregion const-object
-const config1 = const AppConfig('api.heroes.com', 'Dependency Injection');
-//#enddocregion const-object
+AppConfig heroDiConfigFactory() => new AppConfig()
+  ..apiEndpoint = 'api.heroes.com'
+  ..title = 'Dependency Injection';
+// #enddocregion config-alt
+
+const appConfigProvider = const Provider(APP_CONFIG,
+  useFactory: heroDiConfigFactory,
+  deps: const []);

--- a/public/docs/_examples/dependency-injection/dart/lib/car/car.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/car/car.dart
@@ -1,21 +1,19 @@
-// #docregion
 import 'package:angular2/core.dart';
 
 @Injectable()
-// #docregion engine
 class Engine {
-  final int cylinders = 4;
+  final int cylinders;
+
+  Engine() : cylinders = 4;
+  Engine.withCylinders(this.cylinders);
 }
-// #enddocregion engine
 
 @Injectable()
-// #docregion tires
 class Tires {
   String make = 'Flintstone';
   String model = 'Square';
 }
 
-// #enddocregion tires
 @Injectable()
 class Car {
   //#docregion car-ctor
@@ -24,11 +22,10 @@ class Car {
   String description = 'DI';
 
   Car(this.engine, this.tires);
-
   // #enddocregion car-ctor
 
   // Method using the engine and tires
-  String drive() => '$description car with ${engine.cylinders} cylinders'
-      ' and ${tires.make} tires.';
+  String drive() => '$description car with '
+      '${engine.cylinders} cylinders and '
+      '${tires.make} tires.';
 }
-// #enddocregion car

--- a/public/docs/_examples/dependency-injection/dart/lib/car/car_creations.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/car/car_creations.dart
@@ -3,50 +3,39 @@
 import 'car.dart';
 
 ///////// example 1 ////////////
-Car simpleCar() {
-  //#docregion car-ctor-instantiation
+Car simpleCar() =>
+  // #docregion car-ctor-instantiation
   // Simple car with 4 cylinders and Flintstone tires.
-  var car = new Car(new Engine(), new Tires());
-  //#enddocregion car-ctor-instantiation
-  car.description = 'Simple';
-  return car;
-}
+  new Car(new Engine(), new Tires())
+  // #enddocregion car-ctor-instantiation
+  ..description = 'Simple';
+
 ///////// example 2 ////////////
 
-//#docregion car-ctor-instantiation-with-param
-class Engine2 implements Engine {
-  final int cylinders;
-
-  Engine2(this.cylinders);
+// #docregion car-ctor-instantiation-with-param
+class Engine2 extends Engine {
+  Engine2(cylinders) : super.withCylinders(cylinders);
 }
-//#enddocregion car-ctor-instantiation-with-param
 
-Car superCar() {
-//#docregion car-ctor-instantiation-with-param
-// Super car with 12 cylinders and Flintstone tires.
-var bigCylinders = 12;
-var car = new Car(new Engine2(bigCylinders), new Tires());
-//#enddocregion car-ctor-instantiation-with-param
-  car.description = 'Super';
-  return car;
-}
+Car superCar() =>
+  // Super car with 12 cylinders and Flintstone tires.
+  new Car(new Engine2(12), new Tires())
+  ..description = 'Super';
+// #enddocregion car-ctor-instantiation-with-param
+
 /////////// example 3 //////////
 
-//#docregion car-ctor-instantiation-with-mocks
+// #docregion car-ctor-instantiation-with-mocks
 class MockEngine extends Engine {
-  final int cylinders = 8;
+  MockEngine() : super.withCylinders(8);
 }
 
 class MockTires extends Tires {
-  String make = 'YokoGoodStone';
+  MockTires() { make = 'YokoGoodStone'; }
 }
 
-//#enddocregion car-ctor-instantiation-with-mocks
-Car testCar() {
-//#docregion car-ctor-instantiation-with-mocks
-// Test car with 8 cylinders and YokoGoodStone tires.
-var car = new Car(new MockEngine(), new MockTires());
-//#enddocregion car-ctor-instantiation-with-mocks
-  car.description = 'Test';
-  return car;
-}
+Car testCar() =>
+  // Test car with 8 cylinders and YokoGoodStone tires.
+  new Car(new MockEngine(), new MockTires())
+  ..description = 'Test';
+// #enddocregion car-ctor-instantiation-with-mocks

--- a/public/docs/_examples/dependency-injection/dart/lib/car/car_factory.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/car/car_factory.dart
@@ -3,10 +3,9 @@ import 'car.dart';
 
 // BAD pattern!
 class CarFactory {
-  Car createCar() {
-    return new Car(createEngine(), createTires())
-      ..description = 'Factory';
-  }
+  Car createCar() =>
+      new Car(createEngine(), createTires())
+        ..description = 'Factory';
 
   Engine createEngine() => new Engine();
   Tires createTires() => new Tires();

--- a/public/docs/_examples/dependency-injection/dart/lib/car/car_injector.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/car/car_injector.dart
@@ -1,36 +1,27 @@
-// #docplaster
-//#docregion
 import 'package:angular2/core.dart';
 
 import '../logger_service.dart';
 import 'car.dart';
 
-//#docregion injector
+// #docregion injector
 Car useInjector() {
   ReflectiveInjector injector;
-  //#enddocregion injector
-
+  // #enddocregion injector
   /*
-//#docregion injector-no-new
-  // Cannot 'new' an ReflectiveInjector like this!
-  var injector = new ReflectiveInjector([Car, Engine, Tires, Logger]);
-//#enddocregion injector-no-new
-*/
-
-  //#docregion injector
-
-  //#docregion injector-create-and-call
-  injector = ReflectiveInjector.resolveAndCreate([Car, Engine, Tires, Logger]);
-  //#docregion injector-call
+  // #docregion injector-no-new
+  // Cannot instantiate an ReflectiveInjector like this!
+  var injector = new ReflectiveInjector([Car, Engine, Tires]);
+  // #enddocregion injector-no-new
+  */
+  // #docregion injector, injector-create-and-call
+  injector = ReflectiveInjector.resolveAndCreate([Car, Engine, Tires]);
+  // #docregion injector-call
   var car = injector.get(Car);
-  //#enddocregion injector-call
-  //#enddocregion injector-create-and-call
-
+  // #enddocregion injector-call, injector-create-and-call
   car.description = 'Injector';
+
+  injector = ReflectiveInjector.resolveAndCreate([Logger]);
   var logger = injector.get(Logger);
   logger.log('Injector car.drive() said: ' + car.drive());
   return car;
 }
-//#enddocregion injector
-
-//#enddocregion

--- a/public/docs/_examples/dependency-injection/dart/lib/car/car_no_di.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/car/car_no_di.dart
@@ -17,6 +17,7 @@ class Car {
 
   // Method using the engine and tires
   String drive() => '$description car with '
-      '${engine.cylinders} cylinders and ${tires.make} tires.';
+    '${engine.cylinders} cylinders and '
+    '${tires.make} tires.';
 }
 //#enddocregion car

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/hero.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/hero.dart
@@ -1,6 +1,8 @@
 // #docregion
 class Hero {
-  num id;
-  String name;
-  bool isSecret = false;
+  final int id;
+  final String name;
+  final bool isSecret;
+
+  Hero(this.id, this.name, [this.isSecret = false]);
 }

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_list_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_list_component.dart
@@ -14,7 +14,8 @@ import 'hero_service.dart';
 class HeroListComponent {
   final List<Hero> heroes;
 
-//#docregion ctor-signature
-  HeroListComponent(HeroService heroService) : heroes = heroService.getHeroes();
-//#enddocregion ctor-signature
+  // #docregion ctor-signature
+  HeroListComponent(HeroService heroService)
+  // #enddocregion ctor-signature
+    : heroes = heroService.getHeroes();
 }

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_list_component_2.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_list_component_2.dart
@@ -1,8 +1,16 @@
+// #docplaster
 // #docregion
 import 'package:angular2/core.dart';
 
 import 'hero.dart';
+// #enddocregion
+import 'hero_service_1.dart';
+/*
+// #docregion
 import 'hero_service.dart';
+// #enddocregion
+*/
+// #docregion
 
 @Component(
     selector: 'hero-list',
@@ -13,8 +21,8 @@ import 'hero_service.dart';
 class HeroListComponent {
   final List<Hero> heroes;
 
-//#docregion ctor
+  // #docregion ctor
   HeroListComponent(HeroService heroService)
       : heroes = heroService.getHeroes();
-//#enddocregion ctor
+  // #enddocregion ctor
 }

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_service.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_service.dart
@@ -20,5 +20,5 @@ class HeroService {
         .where((hero) => _isAuthorized || !hero.isSecret)
         .toList();
   }
-// #enddocregion internals
+  // #enddocregion internals
 }

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_service_1.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_service_1.dart
@@ -1,7 +1,10 @@
 // #docregion
+import 'package:angular2/core.dart';
+
 import 'hero.dart';
 import 'mock_heroes.dart';
 
+@Injectable()
 class HeroService {
   List<Hero> getHeroes() => HEROES;
 }

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_service_2.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_service_2.dart
@@ -11,7 +11,6 @@ class HeroService {
 
   //#docregion ctor
   HeroService(this._logger);
-
   //#enddocregion ctor
   List<Hero> getHeroes() {
     _logger.log('Getting heroes ...');

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_service_provider.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/hero_service_provider.dart
@@ -6,8 +6,7 @@ import '../user_service.dart';
 import 'hero_service.dart';
 
 // #docregion factory
-@Injectable()
-heroServiceFactory(Logger logger, UserService userService) =>
+HeroService heroServiceFactory(Logger logger, UserService userService) =>
     new HeroService(logger, userService.user.isAuthorized);
 // #enddocregion factory
 

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/heroes_component_1.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/heroes_component_1.dart
@@ -1,23 +1,27 @@
 // #docplaster
 // #docregion
-// #docregion v1
+// #docregion full, v1
 import 'package:angular2/core.dart';
 
+// #enddocregion full, v1
+import 'hero_list_component_2.dart';
+import 'hero_service_1.dart';
+/*
+// #docregion full
 import 'hero_list_component.dart';
-// #enddocregion v1
-import 'hero_service.dart';
 // #docregion v1
+import 'hero_service.dart';
+// #enddocregion full, v1
+*/
+// #docregion full, v1
 
 @Component(
     selector: 'my-heroes',
     template: '''
       <h2>Heroes</h2>
       <hero-list></hero-list>''',
-// #enddocregion v1
-// #docregion providers
+    // #enddocregion v1
     providers: const [HeroService],
-// #enddocregion providers
-// #docregion v1
+    // #docregion v1
     directives: const [HeroListComponent])
 class HeroesComponent {}
-// #enddocregion v1

--- a/public/docs/_examples/dependency-injection/dart/lib/heroes/mock_heroes.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/heroes/mock_heroes.dart
@@ -1,45 +1,18 @@
 // #docregion
 import 'hero.dart';
 
-List<Hero> HEROES = [
-  new Hero()
-    ..id = 11
-    ..isSecret = false
-    ..name = 'Mr. Nice',
-  new Hero()
-    ..id = 12
-    ..isSecret = false
-    ..name = 'Narco',
-  new Hero()
-    ..id = 13
-    ..isSecret = false
-    ..name = 'Bombasto',
-  new Hero()
-    ..id = 14
-    ..isSecret = false
-    ..name = 'Celeritas',
-  new Hero()
-    ..id = 15
-    ..isSecret = false
-    ..name = 'Magneta',
-  new Hero()
-    ..id = 16
-    ..isSecret = false
-    ..name = 'RubberMan',
-  new Hero()
-    ..id = 17
-    ..isSecret = false
-    ..name = 'Dynama',
-  new Hero()
-    ..id = 18
-    ..isSecret = true
-    ..name = 'Dr IQ',
-  new Hero()
-    ..id = 19
-    ..isSecret = true
-    ..name = 'Magma',
-  new Hero()
-    ..id = 20
-    ..isSecret = true
-    ..name = 'Tornado'
-];
+List<Hero> HEROES = <Map>[
+  {'id': 11, 'isSecret': false, 'name': 'Mr. Nice'},
+  {'id': 12, 'isSecret': false, 'name': 'Narco'},
+  {'id': 13, 'isSecret': false, 'name': 'Bombasto'},
+  {'id': 14, 'isSecret': false, 'name': 'Celeritas'},
+  {'id': 15, 'isSecret': false, 'name': 'Magneta'},
+  {'id': 16, 'isSecret': false, 'name': 'RubberMan'},
+  {'id': 17, 'isSecret': false, 'name': 'Dynama'},
+  {'id': 18, 'isSecret': true, 'name': 'Dr IQ'},
+  {'id': 19, 'isSecret': true, 'name': 'Magma'},
+  {'id': 20, 'isSecret': true, 'name': 'Tornado'}
+].map(_initHero).toList();
+
+Hero _initHero(Map heroProperties) => new Hero(
+    heroProperties['id'], heroProperties['name'], heroProperties['isSecret']);

--- a/public/docs/_examples/dependency-injection/dart/lib/injector_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/injector_component.dart
@@ -1,6 +1,6 @@
 // #docplaster
 
-//#docregion
+// #docregion
 import 'package:angular2/core.dart';
 
 import 'car/car.dart';
@@ -9,7 +9,7 @@ import 'heroes/hero_service.dart';
 import 'heroes/hero_service_provider.dart';
 import 'logger_service.dart';
 
-//#docregion injector
+// #docregion injector
 @Component(
     selector: 'my-injectors',
     template: '''
@@ -18,39 +18,26 @@ import 'logger_service.dart';
       <div id="hero">{{hero.name}}</div>
       <div id="rodent">{{rodent}}</div>''',
     providers: const [
-      Car,
-      Engine,
-      Tires,
-      const Provider(HeroService, useFactory: heroServiceFactory),
-      Logger
-    ])
+      Car, Engine, Tires, heroServiceProvider, Logger])
 class InjectorComponent {
   final Injector _injector;
   Car car;
   HeroService heroService;
   Hero hero;
 
-  String get rodent {
-    try {
-      _injector.get(ROUS);
-    } on NoProviderError {
-      return "R.O.U.S.'s? I don't think they exist!";
-    }
-    throw new Exception('Aaaargh!');
-  }
-
   InjectorComponent(this._injector) {
     car = _injector.get(Car);
-    //#docregion get-hero-service
+    // #docregion get-hero-service
     heroService = _injector.get(HeroService);
-    //#enddocregion get-hero-service
+    // #enddocregion get-hero-service
     hero = heroService.getHeroes()[0];
   }
-}
-//#enddocregion injector
 
-/**
- * R.O.U.S. - Rodents Of Unusual Size
- * // https://www.youtube.com/watch?v=BOv5ZjAOpC8
- */
+  String get rodent =>
+    _injector.get(ROUS, "R.O.U.S.'s? I don't think they exist!");
+}
+// #enddocregion injector
+
+/// R.O.U.S. - Rodents Of Unusual Size
+/// https://www.youtube.com/watch?v=BOv5ZjAOpC8
 class ROUS {}

--- a/public/docs/_examples/dependency-injection/dart/lib/logger_service.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/logger_service.dart
@@ -3,10 +3,12 @@ import 'package:angular2/core.dart';
 
 @Injectable()
 class Logger {
-  List<String> logs = [];
+  List<String> _logs = [];
+
+  List<String> get logs => _logs;
 
   void log(String message) {
-    logs.add(message);
+    _logs.add(message);
     print(message);
   }
 }

--- a/public/docs/_examples/dependency-injection/dart/lib/logger_service.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/logger_service.dart
@@ -4,7 +4,6 @@ import 'package:angular2/core.dart';
 @Injectable()
 class Logger {
   List<String> _logs = [];
-
   List<String> get logs => _logs;
 
   void log(String message) {

--- a/public/docs/_examples/dependency-injection/dart/lib/providers_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/providers_component.dart
@@ -1,6 +1,5 @@
 // Examples of provider arrays
-
-//#docplaster
+// #docplaster
 import 'package:angular2/core.dart';
 
 import 'app_config.dart';
@@ -9,20 +8,22 @@ import 'heroes/hero_service.dart';
 import 'logger_service.dart';
 import 'user_service.dart';
 
+// TODO file an issue: cannot use the following const in metadata.
+const template = '{{log}}';
+
 @Component(
     selector: 'provider-1',
     template: '{{log}}',
-    providers:
-//#docregion providers-1
-        const [Logger]
-//#enddocregion providers-1
+    // #docregion providers-1, providers-logger
+    providers: const [Logger]
+    // #enddocregion providers-1, providers-logger
 )
 class ProviderComponent1 {
   String log;
 
   ProviderComponent1(Logger logger) {
     logger.log('Hello from logger provided with Logger class');
-    log = logger.logs.last;
+    log = logger.logs[0];
   }
 }
 
@@ -30,29 +31,46 @@ class ProviderComponent1 {
     selector: 'provider-2',
     template: '{{log}}',
     providers:
-//#docregion providers-2
-        const [const Provider(Logger, useClass: Logger)]
-//#enddocregion providers-2
+      // #docregion providers-2
+      const [const Provider(Logger, useClass: Logger)]
+      // #enddocregion providers-2
 )
 class ProviderComponent2 {
   String log;
 
   ProviderComponent2(Logger logger) {
     logger.log('Hello from logger provided with Provider class and useClass');
-    log = logger.logs.last;
+    log = logger.logs[0];
   }
 }
 
+/// Component just used to ensure that shared E2E tests pass.
 @Component(
-    selector: 'provider-3',
-    template: '{{log}}',
-    providers: const [const Provider(Logger, useClass: Logger)])
+  selector: 'provider-3',
+  template: '{{log}}',
+  providers: const [const Provider(Logger, useClass: Logger)]
+)
 class ProviderComponent3 {
   String log;
 
   ProviderComponent3(Logger logger) {
     logger.log('Hello from logger provided with useClass');
-    log = logger.logs.last;
+    log = logger.logs[0];
+  }
+}
+
+/// Component just used to ensure that shared E2E tests pass.
+@Component(
+  selector: 'provider-3a',
+  template: '{{log}}',
+  providers: const [const Provider(Logger, useClass: Logger)]
+)
+class ProviderComponent3a {
+  String log;
+
+  ProviderComponent3a(Logger logger) {
+    logger.log('Hello from logger provided with {provide: Logger, useClass: Logger}');
+    log = logger.logs[0];
   }
 }
 
@@ -63,58 +81,55 @@ class BetterLogger extends Logger {}
     selector: 'provider-4',
     template: '{{log}}',
     providers:
-//#docregion providers-4
-        const [const Provider(Logger, useClass: BetterLogger)]
-//#enddocregion providers-4
+      // #docregion providers-4
+      const [const Provider(Logger, useClass: BetterLogger)]
+      // #enddocregion providers-4
 )
 class ProviderComponent4 {
   String log;
 
   ProviderComponent4(Logger logger) {
     logger.log('Hello from logger provided with useClass:BetterLogger');
-    log = logger.logs.last;
+    log = logger.logs[0];
   }
 }
 
 // #docregion EvenBetterLogger
 @Injectable()
-class EvenBetterLogger implements Logger {
+class EvenBetterLogger extends Logger {
   final UserService _userService;
-  @override List<String> logs = [];
 
   EvenBetterLogger(this._userService);
 
   @override void log(String message) {
-    var msg = 'Message to ${_userService.user.name}: $message.';
-    print(msg);
-    logs.add(msg);
+    var name = _userService.user.name;
+    super.log('Message to $name: $message');
   }
 }
-
 // #enddocregion EvenBetterLogger
+
 @Component(
     selector: 'provider-5',
     template: '{{log}}',
     providers:
-//#docregion providers-5
-        const [UserService, const Provider(Logger, useClass: EvenBetterLogger)]
-//#enddocregion providers-5
+      // #docregion providers-5
+      const [UserService, const Provider(Logger, useClass: EvenBetterLogger)]
+      // #enddocregion providers-5
 )
 class ProviderComponent5 {
   String log;
 
   ProviderComponent5(Logger logger) {
     logger.log('Hello from EvenBetterlogger');
-    log = logger.logs.last;
+    log = logger.logs[0];
   }
 }
 
 @Injectable()
 class NewLogger extends Logger implements OldLogger {}
 
-class OldLogger {
-  List<String> logs = [];
-
+class OldLogger extends Logger {
+  @override
   void log(String message) {
     throw new Exception('Should not call the old logger!');
   }
@@ -124,26 +139,23 @@ class OldLogger {
     selector: 'provider-6a',
     template: '{{log}}',
     providers:
-        //#docregion providers-6a
-        const [NewLogger,
-            // Not aliased! Creates two instances of `NewLogger`
-            const Provider(OldLogger, useClass: NewLogger)]
-        //#enddocregion providers-6a
+      // #docregion providers-6a
+      const [NewLogger,
+        // Not aliased! Creates two instances of `NewLogger`
+        const Provider(OldLogger, useClass: NewLogger)]
+      // #enddocregion providers-6a
 )
 class ProviderComponent6a {
   String log;
 
   ProviderComponent6a(NewLogger newLogger, OldLogger oldLogger) {
-    if (identical(newLogger, oldLogger)) {
+    if (newLogger == oldLogger) {
       throw new Exception('expected the two loggers to be different instances');
     }
     oldLogger.log('Hello OldLogger (but we want NewLogger)');
     // The newLogger wasn't called so no logs[]
-
     // display the logs of the oldLogger.
-    log = newLogger.logs == null || newLogger.logs.isEmpty
-        ? oldLogger.logs[0]
-        : newLogger.logs[0];
+    log = newLogger.logs.isEmpty ? oldLogger.logs[0] : newLogger.logs[0];
   }
 }
 
@@ -151,17 +163,17 @@ class ProviderComponent6a {
     selector: 'provider-6b',
     template: '{{log}}',
     providers:
-        //#docregion providers-6b
-        const [NewLogger,
-            // Alias OldLogger with reference to NewLogger
-            const Provider(OldLogger, useExisting: NewLogger)]
-       //#enddocregion providers-6b
+      // #docregion providers-6b
+      const [NewLogger,
+        // Alias OldLogger with reference to NewLogger
+        const Provider(OldLogger, useExisting: NewLogger)]
+      // #enddocregion providers-6b
 )
 class ProviderComponent6b {
   String log;
 
   ProviderComponent6b(NewLogger newLogger, OldLogger oldLogger) {
-    if (!identical(newLogger, oldLogger)) {
+    if (newLogger != oldLogger) {
       throw new Exception('expected the two loggers to be the same instance');
     }
     oldLogger.log('Hello from NewLogger (via aliased OldLogger)');
@@ -169,139 +181,101 @@ class ProviderComponent6b {
   }
 }
 
-// #docregion opaque-token
-const loggerPrefix = const OpaqueToken('Logger prefix');
-// #enddocregion opaque-token
+// #docregion silent-logger
+// #docregion const-class
+class SilentLogger implements Logger {
+  @override
+  final List<String> logs = const ['Silent logger says "Shhhhh!". Provided via "useValue"'];
 
-// #docregion configurable-logger
-@Injectable()
-class ConfigurableLogger extends Logger {
-  final String _prefix;
-
-// #docregion use-opaque-token
-  ConfigurableLogger(@Inject(loggerPrefix) this._prefix);
-// #enddocregion use-opaque-token
+  const SilentLogger();
 
   @override
-  void log(String msg) {
-    super.log('$_prefix: $msg');
-  }
+  void log(String message) { }
 }
-// #enddocregion configurable-logger
+// #enddocregion const-class
+// #docregion const-object
 
-@Component(selector: 'provider-7', template: '{{message}}',
-//#docregion providers-7
-providers: const [
-  const Provider(Logger, useClass: ConfigurableLogger),
-//#docregion providers-usevalue
-  const Provider(loggerPrefix, useValue: 'Testing')
-//#enddocregion providers-usevalue
-]
-//#enddocregion providers-7
+const silentLogger = const SilentLogger();
+// #enddocregion const-object
+// #enddocregion silent-logger
+
+@Component(
+  selector: 'provider-7',
+  template: '{{log}}',
+  providers:
+    // #docregion providers-7
+    const [const Provider(Logger, useValue: silentLogger)]
+    // #enddocregion providers-7
 )
 class ProviderComponent7 {
-  String message;
+  String log;
 
   ProviderComponent7(Logger logger) {
-    logger.log('Hello from configurable logger.');
-    message = logger.logs.last;
+    logger.log('Hello from logger provided with useValue');
+    log = logger.logs[0];
   }
-}
-
-@Component(selector: 'provider-8', template: '{{log}}', providers: const [
-  const Provider(HeroService, useFactory: heroServiceFactory),
-  Logger,
-  UserService
-])
-class ProviderComponent8 {
-  // #docregion provider-8-ctor
-  ProviderComponent8(HeroService heroService);
-
-  // #enddocregion provider-8-ctor
-
-  // must be true else this component would have blown up at runtime
-  var log = 'Hero service injected successfully';
 }
 
 @Component(
-    selector: 'provider-9',
-    template: '{{log}}',
-    providers:
-// #docregion providers-9
-const [const Provider(AppConfig, useValue: config1)]
-// #enddocregion providers-9
+  selector: 'provider-8',
+  template: '{{log}}',
+  providers: const [heroServiceProvider, Logger, UserService])
+class ProviderComponent8 {
+  // #docregion provider-8-ctor
+  ProviderComponent8(HeroService heroService);
+  // #enddocregion provider-8-ctor
+
+  // must be true else this component would have blown up at runtime
+  var log = 'Hero service injected successfully via heroServiceProvider';
+}
+
+@Component(
+  selector: 'provider-9',
+  template: '{{log}}',
+  // #docregion providers-9
+  providers: const [
+    const Provider(APP_CONFIG, useValue: heroDiConfig)]
+  // #enddocregion providers-9
 )
 class ProviderComponent9 implements OnInit {
-  AppConfig _config;
+  Map _config;
   String log;
 
-  ProviderComponent9(AppConfig this._config);
+  // #docregion provider-9-ctor
+  ProviderComponent9(@Inject(APP_CONFIG) this._config);
+  // #enddocregion provider-9-ctor
 
   @override
   void ngOnInit() {
-    log = 'appConfigToken Application title is ${_config.title}';
+    log = 'APP_CONFIG Application title is ${_config['title']}';
   }
 }
 
-// Normal required logger
-@Component(selector: 'provider-10a', template: '{{log}}',
-//#docregion providers-logger
-    providers: const [Logger]
-//#enddocregion providers-logger
-    )
-class ProviderComponent10a {
-  String log;
-
-  ProviderComponent10a(Logger logger) {
-    logger.log('Hello from the required logger.');
-    log = logger.logs.last;
-  }
-}
-
-// Optional logger, can be null
-@Component(selector: 'provider-10b', template: '{{log}}')
-class ProviderComponent10b {
-  // #docregion provider-10-ctor
+// Sample providers 1 to 7 illustrate a required logger dependency.
+// Optional logger, can be null.
+@Component(selector: 'provider-10', template: '{{log}}')
+class ProviderComponent10 implements OnInit {
   final Logger _logger;
   String log;
 
-  ProviderComponent10b(@Optional() Logger this._logger) {
-    // . . .
-  // #enddocregion provider-10-ctor
-    _logger == null ? log = 'No logger exists' : log = _logger.logs.last;
+  /*
   // #docregion provider-10-ctor
+  HeroService(@Optional() this._logger) {
+  // #enddocregion provider-10-ctor
+   */
+  ProviderComponent10(@Optional() this._logger) {
+    const someMessage = 'Hello from the injected logger';
+    // #docregion provider-10-ctor
+    if (_logger != null)
+      _logger.log(someMessage);
   }
   // #enddocregion provider-10-ctor
-}
 
-// Optional logger, non null
-@Component(selector: 'provider-10c', template: '{{log}}')
-class ProviderComponent10c {
-  // #docregion provider-10-logger
-  final Logger _logger;
-  String log;
-
-  ProviderComponent10c(@Optional() Logger logger) :
-        _logger = logger ?? new DoNothingLogger() {
-    // . . .
-    // #enddocregion provider-10-logger
-    logger == null
-        ? _logger.log('Optional logger was not available.')
-        : _logger.log('Hello from the injected logger.');
-    log = _logger.logs.last;
-    // #docregion provider-10-logger
+  @override
+  void ngOnInit() {
+    log = _logger == null ? 'Optional logger was not available' : _logger.logs[0];
   }
-// #enddocregion provider-10-logger
 }
-
-// #docregion provider-10-logger
-// . . .
-@Injectable()
-class DoNothingLogger extends Logger {
-  @override List<String> logs = [];
-  @override void log(String msg) => logs.add(msg);
-}
-// #enddocregion provider-10-logger
 
 @Component(
     selector: 'my-providers',
@@ -310,20 +284,20 @@ class DoNothingLogger extends Logger {
       <div id="p1"><provider-1></provider-1></div>
       <div id="p2"><provider-2></provider-2></div>
       <div id="p3"><provider-3></provider-3></div>
+      <div id="p3a"><provider-3a></provider-3a></div>
       <div id="p4"><provider-4></provider-4></div>
       <div id="p5"><provider-5></provider-5></div>
       <div id="p6a"><provider-6a></provider-6a></div>
       <div id="p6b"><provider-6b></provider-6b></div>
       <div id="p7"><provider-7></provider-7></div>
       <div id="p8"><provider-8></provider-8></div>
-      <div id="p8"><provider-9></provider-9></div>
-      <div id="p10a"><provider-10a></provider-10a></div>
-      <div id="p10b"><provider-10b></provider-10b></div>
-      <div id="p10c"><provider-10c></provider-10c></div>''',
+      <div id="p9"><provider-9></provider-9></div>
+      <div id="p10"><provider-10></provider-10></div>''',
     directives: const [
       ProviderComponent1,
       ProviderComponent2,
       ProviderComponent3,
+      ProviderComponent3a,
       ProviderComponent4,
       ProviderComponent5,
       ProviderComponent6a,
@@ -331,8 +305,6 @@ class DoNothingLogger extends Logger {
       ProviderComponent7,
       ProviderComponent8,
       ProviderComponent9,
-      ProviderComponent10a,
-      ProviderComponent10b,
-      ProviderComponent10c
+      ProviderComponent10
     ])
 class ProvidersComponent {}

--- a/public/docs/_examples/dependency-injection/dart/lib/test_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/test_component.dart
@@ -1,0 +1,65 @@
+// Simulate a simple test
+// Reader should look to the testing chapter for the real thing
+
+import 'package:angular2/core.dart';
+
+import 'heroes/hero.dart';
+import 'heroes/hero_list_component.dart';
+import 'heroes/hero_service.dart';
+
+@Component(
+    selector: 'my-tests',
+    template: '''
+      <h2>Tests</h2>
+      <p id="tests">Tests {{results['pass']}}: {{results['message']}}</p>
+    ''')
+class TestComponent {
+  var results = runTests();
+}
+
+class MockHeroService implements HeroService {
+  final List<Hero> _heroes;
+  MockHeroService(this._heroes);
+
+  @override
+  List<Hero> getHeroes() => _heroes;
+}
+
+/////////////////////////////////////
+dynamic runTests() {
+  //#docregion spec
+  var expectedHeroes = [new Hero(0, 'A'), new Hero(1, 'B')];
+  var mockService = new MockHeroService(expectedHeroes);
+  it('should have heroes when HeroListComponent created', () {
+    var hlc = new HeroListComponent(mockService);
+    expect(hlc.heroes.length).toEqual(expectedHeroes.length);
+  });
+  //#enddocregion spec
+  return testResults;
+}
+//////////////////////////////////
+
+// Fake Jasmine infrastructure
+String testName;
+dynamic testResults;
+dynamic expect(dynamic actual) => new ExpectResult(actual);
+
+class ExpectResult {
+  final actual;
+  ExpectResult(this.actual);
+
+  void toEqual(dynamic expected) {
+    testResults = actual == expected
+        ? {'pass': 'passed', 'message': testName}
+        : {
+            'pass': 'failed',
+            'message': '$testName; expected $actual to equal $expected.'
+          };
+  }
+}
+
+void it(String label, void test()) {
+  testName = label;
+  test();
+}
+

--- a/public/docs/_examples/dependency-injection/dart/lib/user_service.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/user_service.dart
@@ -1,26 +1,23 @@
 // #docregion
 import 'package:angular2/core.dart';
 
-@Injectable()
-class UserService {
-  UserService() {
-    user = _bob;
-  }
-
-  // Todo: get the user; don't 'new' it.
-  User _alice = new User('Alice', true);
-  User _bob = new User('Bob', false);
-
-  // initial user is Bob
-  User user;
-
-  // swaps users
-  User getNewUser() => user = user == _bob ? _alice : _bob;
-}
-
 class User {
-  String name;
-  bool isAuthorized;
+  final String name;
+  final bool isAuthorized;
 
   User(this.name, [this.isAuthorized = false]);
+}
+
+// Todo: get the user; don't 'new' it.
+final User _alice = new User('Alice', true);
+final User _bob = new User('Bob', false);
+
+@Injectable()
+class UserService {
+  User user;
+
+  UserService() : user = _bob;
+
+  // swap users
+  User getNewUser() => user = user == _bob ? _alice : _bob;
 }

--- a/public/docs/_examples/dependency-injection/dart/test/hero_list_component_test.dart
+++ b/public/docs/_examples/dependency-injection/dart/test/hero_list_component_test.dart
@@ -9,13 +9,8 @@ import 'package:test/test.dart';
 ///////////////////////////////////////
 ////#docregion spec
 List<Hero> expectedHeroes = [
-  new Hero()
-    ..id = 1
-    ..name = 'hero1',
-  new Hero()
-    ..id = 2
-    ..name = 'hero2'
-    ..isSecret = true
+  new Hero(1, 'hero1'),
+  new Hero(2, 'hero2', true)
 ];
 
 class HeroServiceMock implements HeroService {

--- a/public/docs/_examples/dependency-injection/dart/web/main.dart
+++ b/public/docs/_examples/dependency-injection/dart/web/main.dart
@@ -1,10 +1,9 @@
-//#docregion
 import 'package:angular2/platform/browser.dart';
 
 import 'package:dependency_injection/app_component.dart';
 import 'package:dependency_injection/providers_component.dart';
 
-main() {
+void main() {
   //#docregion bootstrap
   bootstrap(AppComponent);
   //#enddocregion bootstrap

--- a/public/docs/_examples/dependency-injection/dart/web/main_1.dart
+++ b/public/docs/_examples/dependency-injection/dart/web/main_1.dart
@@ -1,10 +1,21 @@
-import 'package:angular2/platform/browser.dart';
-import 'package:dependency_injection/app_component.dart';
-import 'package:dependency_injection/heroes/hero_service.dart';
+// **WARNING**
+// To try out this version of the app, ensure that you update:
+// - web/index.html
+// - pubspec.yaml
+// to refer to this file instead of main.dart
 
-main() {
-  //#docregion bootstrap
+import 'package:angular2/platform/browser.dart';
+
+import 'package:dependency_injection/app_component_1.dart';
+import 'package:dependency_injection/heroes/hero_service_1.dart';
+
+void main() {
+  bootstrap(AppComponent);
+}
+
+void main_alt() {
+  // #docregion bootstrap-discouraged
   bootstrap(AppComponent,
-           [HeroService]); // DISCOURAGED (but works)
-  //#enddocregion bootstrap
+    [HeroService]); // DISCOURAGED (but works)
+  // #enddocregion bootstrap-discouraged
 }

--- a/public/docs/_examples/dependency-injection/e2e-spec.ts
+++ b/public/docs/_examples/dependency-injection/e2e-spec.ts
@@ -101,7 +101,7 @@ describe('Dependency Injection Tests', function () {
     });
 
     it('P5 (useClass:EvenBetterLogger - dependency)  displays as expected', function () {
-      expectedMsg = 'Message to Bob: Hello from EvenBetterlogger.';
+      expectedMsg = 'Message to Bob: Hello from EvenBetterlogger';
       expect(element(by.css('#p5')).getText()).toEqual(expectedMsg);
     });
 
@@ -121,28 +121,18 @@ describe('Dependency Injection Tests', function () {
     });
 
     it('P8 (useFactory) displays as expected', function () {
-      expectedMsg = 'Hero service injected successfully';
+      expectedMsg = 'Hero service injected successfully via heroServiceProvider';
       expect(element(by.css('#p8')).getText()).toEqual(expectedMsg);
     });
 
-    it('P9a (string token) displays as expected', function () {
-      expectedMsg = '"app.config" Application title is Dependency Injection';
-      expect(element(by.css('#p9a')).getText()).toEqual(expectedMsg);
-    });
-
-    it('P9b (OpaqueToken) displays as expected', function () {
+    it('P9 (OpaqueToken) displays as expected', function () {
       expectedMsg = 'APP_CONFIG Application title is Dependency Injection';
-      expect(element(by.css('#p9b')).getText()).toEqual(expectedMsg);
+      expect(element(by.css('#p9')).getText()).toEqual(expectedMsg);
     });
 
-    it('P10a (required dependency) displays as expected', function () {
-      expectedMsg = 'Hello from the required logger.';
-      expect(element(by.css('#p10a')).getText()).toEqual(expectedMsg);
-    });
-
-    it('P10b (optional dependency) displays as expected', function () {
-      expectedMsg = 'Optional logger was not available.';
-      expect(element(by.css('#p10b')).getText()).toEqual(expectedMsg);
+    it('P10 (optional dependency) displays as expected', function () {
+      expectedMsg = 'Optional logger was not available';
+      expect(element(by.css('#p10')).getText()).toEqual(expectedMsg);
     })
   });
 

--- a/public/docs/_examples/dependency-injection/ts/app/app.component.1.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/app.component.1.ts
@@ -19,14 +19,3 @@ import { HeroesComponent }   from './heroes/heroes.component.1';
 export class AppComponent {
   title = 'Dependency Injection';
 }
-// #enddocregion
-
-
-/*
-//#docregion ctor-di-fail
-// FAIL! Injectable `config` is not a class!
-constructor(heroService: HeroService, config: config) {
-  this.title = config.title;
-}
-//#enddocregion ctor-di-fail
-*/

--- a/public/docs/_examples/dependency-injection/ts/app/app.component.2.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/app.component.2.ts
@@ -5,7 +5,8 @@ import { CarComponent }      from './car/car.component';
 import { HeroesComponent }   from './heroes/heroes.component.1';
 
 import { provide, Inject }   from '@angular/core';
-import { Config, CONFIG }    from './app.config';
+import { APP_CONFIG, AppConfig,
+         HERO_DI_CONFIG }    from './app.config';
 import { Logger }            from './logger.service';
 // #enddocregion imports
 
@@ -17,23 +18,19 @@ import { Logger }            from './logger.service';
     <my-heroes></my-heroes>
   `,
   directives:[CarComponent, HeroesComponent],
-// #docregion providers
   providers: [
     Logger,
-   // #docregion provider-config
-    provide('app.config', {useValue: CONFIG})
-   // #enddocregion provider-config
+   // #docregion providers
+    provide(APP_CONFIG, {useValue: HERO_DI_CONFIG})
+   // #enddocregion providers
   ]
-// #docregion providers
 })
 export class AppComponent {
   title:string;
 
   // #docregion ctor
-  constructor(@Inject('app.config') config:Config) {
-
+  constructor(@Inject(APP_CONFIG) config:AppConfig) {
     this.title = config.title;
   }
-  // #docregion ctor
+  // #enddocregion ctor
 }
-// #enddocregion

--- a/public/docs/_examples/dependency-injection/ts/app/app.component.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/app.component.ts
@@ -6,8 +6,8 @@ import { Component, Inject, provide } from '@angular/core';
 import { CarComponent }      from './car/car.component';
 import { HeroesComponent }   from './heroes/heroes.component';
 
-import { APP_CONFIG,
-        Config, CONFIG }    from './app.config';
+import { APP_CONFIG, AppConfig,
+         HERO_DI_CONFIG }    from './app.config';
 import { Logger }            from './logger.service';
 
 import { User, UserService } from './user.service';
@@ -33,22 +33,21 @@ import { ProvidersComponent } from './providers.component';
   `,
   directives:[CarComponent, HeroesComponent,
               InjectorComponent, TestComponent, ProvidersComponent],
-// #docregion providers
+  // #docregion providers
   providers: [
     Logger,
     UserService,
-    provide(APP_CONFIG, {useValue: CONFIG})
+    provide(APP_CONFIG, {useValue: HERO_DI_CONFIG})
   ]
-// #enddocregion providers
+  // #enddocregion providers
 })
 export class AppComponent {
   title:string;
 
-  //#docregion ctor
+  // #docregion ctor
   constructor(
-    @Inject(APP_CONFIG) config:Config,
+    @Inject(APP_CONFIG) config:AppConfig,
     private userService: UserService) {
-
     this.title = config.title;
   }
   // #enddocregion ctor
@@ -62,4 +61,3 @@ export class AppComponent {
            `${this.isAuthorized ? '' : 'not'} authorized. `;
   }
 }
-// #enddocregion

--- a/public/docs/_examples/dependency-injection/ts/app/app.config.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/app.config.ts
@@ -1,4 +1,3 @@
-//#docregion
 // #docregion token
 import { OpaqueToken } from '@angular/core';
 
@@ -6,13 +5,12 @@ export let APP_CONFIG = new OpaqueToken('app.config');
 // #enddocregion token
 
 //#docregion config
-export interface Config {
+export interface AppConfig {
   apiEndpoint: string,
   title: string
 }
 
-export const CONFIG:Config = {
+export const HERO_DI_CONFIG: AppConfig = {
   apiEndpoint: 'api.heroes.com',
   title: 'Dependency Injection'
 };
-//#enddocregion config

--- a/public/docs/_examples/dependency-injection/ts/app/car/car-injector.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/car/car-injector.ts
@@ -1,37 +1,27 @@
-// #docplaster
-//#docregion
-import { ReflectiveInjector }         from '@angular/core';
+import { ReflectiveInjector } from '@angular/core';
 
 import { Car, Engine, Tires } from './car';
 import { Logger }             from '../logger.service';
 
-//#docregion injector
+// #docregion injector
 export function useInjector() {
-  var injector:ReflectiveInjector;
-
-//#enddocregion injector
-/*
-//#docregion injector-no-new
-  // Cannot 'new' an ReflectiveInjector like this!
-  var injector = new ReflectiveInjector([Car, Engine, Tires, Logger]);
-//#enddocregion injector-no-new
-*/
-
-//#docregion injector
-  //#docregion injector-create-and-call
-  injector = ReflectiveInjector.resolveAndCreate([Car, Engine, Tires, Logger]);
-  //#docregion injector-call
+  var injector: ReflectiveInjector;
+  // #enddocregion injector
+  /*
+  // #docregion injector-no-new
+  // Cannot instantiate an ReflectiveInjector like this!
+  var injector = new ReflectiveInjector([Car, Engine, Tires]);
+  // #enddocregion injector-no-new
+  */
+  // #docregion injector, injector-create-and-call
+  injector = ReflectiveInjector.resolveAndCreate([Car, Engine, Tires]);
+  // #docregion injector-call
   var car = injector.get(Car);
- //#enddocregion injector-call
- //#enddocregion injector-create-and-call
+  // #enddocregion injector-call, injector-create-and-call
   car.description = 'Injector';
 
+  injector = ReflectiveInjector.resolveAndCreate([Logger]);
   var logger = injector.get(Logger);
   logger.log('Injector car.drive() said: '+car.drive());
-
   return car;
 }
-//#enddocregion injector
-
-
-//#enddocregion

--- a/public/docs/_examples/dependency-injection/ts/app/car/car.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/car/car.ts
@@ -1,21 +1,15 @@
-// #docregion
 import { Injectable } from '@angular/core';
 
-// #docregion engine
 export class Engine {
-  public cylinders = 4; // default
+  public cylinders = 4;
 }
-// #enddocregion engine
 
-// #docregion tires
 export class Tires {
   public make  = 'Flintstone';
   public model = 'Square';
 }
-// #enddocregion tires
 
 @Injectable()
-// #docregion car
 export class Car {
   //#docregion car-ctor
   public description = 'DI';
@@ -29,4 +23,3 @@ export class Car {
       `${this.engine.cylinders} cylinders and ${this.tires.make} tires.`
   }
 }
-// #enddocregion car

--- a/public/docs/_examples/dependency-injection/ts/app/heroes/hero-list.component.1.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/heroes/hero-list.component.1.ts
@@ -9,7 +9,7 @@ import { HEROES }      from './mock-heroes';
   <div *ngFor="let hero of heroes">
     {{hero.id}} - {{hero.name}}
   </div>
-  `,
+  `
 })
 export class HeroListComponent {
   heroes = HEROES;

--- a/public/docs/_examples/dependency-injection/ts/app/heroes/hero-list.component.2.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/heroes/hero-list.component.2.ts
@@ -1,8 +1,16 @@
+// #docplaster
 // #docregion
 import { Component }   from '@angular/core';
 
 import { Hero }        from './hero';
+// #enddocregion
+import { HeroService } from './hero.service.1';
+/*
+// #docregion
 import { HeroService } from './hero.service';
+// #enddocregion
+*/
+// #docregion
 
 @Component({
   selector: 'hero-list',

--- a/public/docs/_examples/dependency-injection/ts/app/heroes/hero-list.component.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/heroes/hero-list.component.ts
@@ -17,8 +17,9 @@ export class HeroListComponent {
   heroes: Hero[];
 
   // #docregion ctor-signature
-  constructor(heroService: HeroService) {
+  constructor(heroService: HeroService)
   // #enddocregion ctor-signature
+  {
     this.heroes = heroService.getHeroes();
   }
 }

--- a/public/docs/_examples/dependency-injection/ts/app/heroes/hero.service.1.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/heroes/hero.service.1.ts
@@ -1,7 +1,10 @@
 // #docregion
-import { Hero }   from './hero';
-import { HEROES } from './mock-heroes';
+import { Injectable } from '@angular/core';
 
+import { Hero }       from './hero';
+import { HEROES }     from './mock-heroes';
+
+@Injectable()
 export class HeroService {
   getHeroes() { return HEROES;  }
 }

--- a/public/docs/_examples/dependency-injection/ts/app/heroes/heroes.component.1.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/heroes/heroes.component.1.ts
@@ -1,12 +1,18 @@
 // #docplaster
-// #docregion
-// #docregion v1
+// #docregion full, v1
 import { Component }          from '@angular/core';
 
+// #enddocregion full, v1
+import { HeroListComponent }  from './hero-list.component.2';
+import { HeroService }        from './hero.service.1';
+/*
+// #docregion full
 import { HeroListComponent }  from './hero-list.component';
-// #enddocregion v1
-import { HeroService }        from './hero.service';
 // #docregion v1
+import { HeroService }        from './hero.service';
+// #enddocregion full, v1
+*/
+// #docregion full, v1
 
 @Component({
   selector: 'my-heroes',
@@ -15,11 +21,8 @@ import { HeroService }        from './hero.service';
   <hero-list></hero-list>
   `,
   // #enddocregion v1
-  // #docregion providers
   providers:[HeroService],
-  // #enddocregion providers
-// #docregion v1
+  // #docregion v1
   directives:[HeroListComponent]
 })
 export class HeroesComponent { }
-// #enddocregion v1

--- a/public/docs/_examples/dependency-injection/ts/app/heroes/mock-heroes.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/heroes/mock-heroes.ts
@@ -2,14 +2,14 @@
 import { Hero } from './hero';
 
 export var HEROES: Hero[] = [
-  { "id": 11, isSecret: false, "name": "Mr. Nice" },
-  { "id": 12, isSecret: false, "name": "Narco" },
-  { "id": 13, isSecret: false, "name": "Bombasto" },
-  { "id": 14, isSecret: false, "name": "Celeritas" },
-  { "id": 15, isSecret: false, "name": "Magneta" },
-  { "id": 16, isSecret: false, "name": "RubberMan" },
-  { "id": 17, isSecret: false, "name": "Dynama" },
-  { "id": 18, isSecret: true,  "name": "Dr IQ" },
-  { "id": 19, isSecret: true,  "name": "Magma" },
-  { "id": 20, isSecret: true,  "name": "Tornado" }
+  { id: 11, isSecret: false, name: "Mr. Nice" },
+  { id: 12, isSecret: false, name: "Narco" },
+  { id: 13, isSecret: false, name: "Bombasto" },
+  { id: 14, isSecret: false, name: "Celeritas" },
+  { id: 15, isSecret: false, name: "Magneta" },
+  { id: 16, isSecret: false, name: "RubberMan" },
+  { id: 17, isSecret: false, name: "Dynama" },
+  { id: 18, isSecret: true,  name: "Dr IQ" },
+  { id: 19, isSecret: true,  name: "Magma" },
+  { id: 20, isSecret: true,  name: "Tornado" }
 ];

--- a/public/docs/_examples/dependency-injection/ts/app/injector.component.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/injector.component.ts
@@ -1,13 +1,14 @@
 // #docplaster
-//#docregion
+// #docregion
 import { Component, Injector }  from '@angular/core';
 
 import { Car, Engine, Tires }   from './car/car';
+import { Hero }                 from './heroes/hero';
 import { HeroService }          from './heroes/hero.service';
 import { heroServiceProvider }  from './heroes/hero.service.provider';
 import { Logger }               from './logger.service';
 
-//#docregion injector
+// #docregion injector
 @Component({
   selector: 'my-injectors',
   template: `
@@ -16,29 +17,24 @@ import { Logger }               from './logger.service';
   <div id="hero">{{hero.name}}</div>
   <div id="rodent">{{rodent}}</div>
   `,
-
-  providers: [Car, Engine, Tires,
-              heroServiceProvider, Logger]
+  providers: [Car, Engine, Tires, heroServiceProvider, Logger]
 })
 export class InjectorComponent {
   constructor(private injector: Injector) { }
 
-  car:Car = this.injector.get(Car);
+  car: Car = this.injector.get(Car);
 
-  //#docregion get-hero-service
-  heroService:HeroService = this.injector.get(HeroService);
-  //#enddocregion get-hero-service
-  hero = this.heroService.getHeroes()[0];
+  // #docregion get-hero-service
+  heroService: HeroService = this.injector.get(HeroService);
+  // #enddocregion get-hero-service
+  hero: Hero = this.heroService.getHeroes()[0];
 
   get rodent() {
-    let rous = this.injector.get(ROUS, null);
-    if (rous) {
-      throw new Error('Aaaargh!')
-    }
-    return "R.O.U.S.'s? I don't think they exist!";
+    let rousDontExist = "R.O.U.S.'s? I don't think they exist!";
+    return this.injector.get(ROUS, rousDontExist);
   }
 }
-//#enddocregion injector
+// #enddocregion injector
 
 /**
  * R.O.U.S. - Rodents Of Unusual Size

--- a/public/docs/_examples/dependency-injection/ts/app/logger.service.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/logger.service.ts
@@ -4,7 +4,8 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class Logger {
   logs:string[] = []; // capture logs for testing
-  log(message: string){
+
+  log(message: string) {
     this.logs.push(message);
     console.log(message);
   }

--- a/public/docs/_examples/dependency-injection/ts/app/main.1.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/main.1.ts
@@ -1,8 +1,12 @@
 import { bootstrap }    from '@angular/platform-browser-dynamic';
-import { AppComponent } from './app.component';
-import { HeroService }  from './heroes/hero.service';
+import { AppComponent } from './app.component.1';
+import { HeroService }  from './heroes/hero.service.1';
 
-//#docregion bootstrap
-bootstrap(AppComponent,
-         [HeroService]); // DISCOURAGED (but works)
-//#enddocregion bootstrap
+bootstrap(AppComponent);
+
+function discouraged() {
+  //#docregion bootstrap-discouraged
+  bootstrap(AppComponent,
+           [HeroService]); // DISCOURAGED (but works)
+  //#enddocregion bootstrap-discouraged
+}

--- a/public/docs/_examples/dependency-injection/ts/app/main.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/main.ts
@@ -1,4 +1,3 @@
-//#docregion
 import { bootstrap }          from '@angular/platform-browser-dynamic';
 import { AppComponent }       from './app.component';
 import { ProvidersComponent } from './providers.component';

--- a/public/docs/_examples/dependency-injection/ts/app/test.component.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/test.component.ts
@@ -35,14 +35,14 @@ function runTests() {
 
 //////////////////////////////////
 // Fake Jasmine infrastructure
-var testName:string;
+var testName: string;
 var testResults: {pass:string; message:string};
 
 function expect(actual:any) {
   return {
     toEqual: function(expected:any){
       testResults = actual === expected?
-        {pass:'passed', message: `${testName}`} :
+        {pass:'passed', message: testName} :
         {pass:'failed', message: `${testName}; expected ${actual} to equal ${expected}.`};
     }
   }

--- a/public/docs/_examples/dependency-injection/ts/app/user.service.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/user.service.ts
@@ -1,23 +1,22 @@
 // #docregion
 import {Injectable} from '@angular/core';
 
-@Injectable()
-export class UserService {
-  // Todo: get the user; don't 'new' it.
-  private _alice = new User('Alice', true);
-  private _bob = new User('Bob', false);
-
-  // initial user is Bob
-  user = this._bob;
-
-  // swaps users
-  getNewUser() {
-    return this.user = this.user === this._bob ? this._alice : this._bob;
-  }
-}
-
 export class User {
   constructor(
     public name:string,
     public isAuthorized:boolean = false) { }
+}
+
+// Todo: get the user; don't 'new' it.
+let alice = new User('Alice', true);
+let bob = new User('Bob', false);
+
+@Injectable()
+export class UserService {
+  user = bob;  // initial user is Bob
+
+  // swap users
+  getNewUser() {
+    return this.user = this.user === bob ? alice : bob;
+  }
 }

--- a/public/docs/dart/latest/guide/dependency-injection.jade
+++ b/public/docs/dart/latest/guide/dependency-injection.jade
@@ -95,8 +95,10 @@ block config-obj-maps
 
 block what-should-we-use-as-token
   :marked
-    But what should we use as the token?
-    We could use the **[Map][]** interface.
+    But what should we use as the token? 
+    While we _could_ use **[Map][]**, we _should not_ because (like
+    `String`) `Map` is too general. Our app might depend on several maps, each
+    for a different purpose.
 
     [Map]: https://api.dartlang.org/stable/dart-core/Map-class.html
 
@@ -107,32 +109,32 @@ block what-should-we-use-as-token
       Dart doesn't have this limitation;
       every class implicitly defines an interface,
       so interface names are just class names.
-
-  :marked
-    The problem with using `Map` as a token, is not that it is an abstract
-    class, but rather that it is very general purpose (like `String`) and so
-    our application may depend on several maps each used for a
-    different purpose.
+      `Map` is a *valid* token even though it's the name of an abstract class;
+      it's just *unsuitable* as a token because it's too general.
 
 block dart-map-alternative
   :marked
     As an alternative to using a configuration `Map`, we can define
-    a custom class type:
+    a custom configuration class:
 
   +makeExample('dependency-injection/ts/app/app.config.ts','config-alt','app/app-config.ts (alternative config)')(format='.')
 
   :marked
-    One of the key benefits of defining a configuration object class, is
-    strong static checking relative to configuration property names and their types.
-    The Dart [cascade operator][cascade-op] provides a convenient means of initializing
-    the configuration object. Use of the cascaded object initialization idiom
+    Defining a configuration class has a few benefits. One key benefit
+    is strong static checking: we'll be warned early if we misspell a property
+    name or assign it a value of the wrong type.
+    The Dart [cascade notation][cascade] (`..`) provides a convenient means of initializing
+    a configuration object. 
+
+    Use of the cascaded initialization idiom
     prevents us from defining our configuration object instance as `const`. 
-    As a consequencem we cannot declare a [value provider](#value-provider),
-    but a [factory provider](#factory-provider) does the trick &mdash; as
-    we illustrate by providing and injecting the configuration object in our
+    As a consequence, we cannot declare a [value provider](#value-provider),
+    but a [factory provider](#factory-provider) does the trick.
+
+    We illustrate this below by providing and injecting the configuration object in our
     top-level `AppComponent`:
 
-    [cascade-op]: https://www.dartlang.org/docs/dart-up-and-running/ch02.html#cascade
+    [cascade]: https://www.dartlang.org/docs/dart-up-and-running/ch02.html#cascade
 
   +makeExcerpt('lib/app_component.dart','providers')
   +makeExcerpt('lib/app_component.dart','ctor')

--- a/public/docs/dart/latest/guide/dependency-injection.jade
+++ b/public/docs/dart/latest/guide/dependency-injection.jade
@@ -126,13 +126,11 @@ block dart-map-alternative
     The Dart [cascade notation][cascade] (`..`) provides a convenient means of initializing
     a configuration object. 
 
-    Use of the cascaded initialization idiom
-    prevents us from defining our configuration object instance as `const`. 
-    As a consequence, we cannot declare a [value provider](#value-provider),
-    but a [factory provider](#factory-provider) does the trick.
-
-    We illustrate this below by providing and injecting the configuration object in our
-    top-level `AppComponent`:
+    If we use cascades, the configuration object can't be declared `const` and
+    we can't use a [value provider](#value-provider). 
+    A solution is to use a [factory provider](#factory-provider).
+    We illustrate this next. We also show how to provide and inject the
+    configuration object in our top-level `AppComponent`:
 
     [cascade]: https://www.dartlang.org/docs/dart-up-and-running/ch02.html#cascade
 

--- a/public/docs/dart/latest/guide/dependency-injection.jade
+++ b/public/docs/dart/latest/guide/dependency-injection.jade
@@ -1,279 +1,138 @@
-include ../_util-fns
+extends ../../../ts/latest/guide/dependency-injection.jade
 
-+includeShared('{ts}', 'intro')
+block includes
+  include ../_util-fns
+  - var _thisDot = '';
 
-:marked
-  The complete source code for the example app in this chapter is
-  [in GitHub](https://github.com/angular/angular.io/tree/master/public/docs/_examples/dependency-injection/dart).
+block ctor-syntax
+  .l-sub-section
+    :marked
+      We also leveraged Dart's constructor syntax for declaring parameters and
+      initializing properties simultaneously.
 
-+includeShared('{ts}', 'why-1')
-+makeExample('dependency-injection/dart/lib/car/car_no_di.dart', 'car', 'lib/car/car.dart (without DI)')
-+includeShared('{ts}', 'why-2')
-+makeTabs(
-  'dependency-injection/dart/lib/car/car.dart, dependency-injection/dart/lib/car/car_no_di.dart',
-  'car-ctor, car-ctor',
-  'lib/car/car.dart (excerpt with DI), lib/car/car.dart (excerpt without DI)')(format=".")
-+includeShared('{ts}', 'why-3-1')
-+includeShared('{ts}', 'why-3-2')
-- var stylePattern = { otl: /(new Car.*$)/gm };
-+makeExample('dependency-injection/dart/lib/car/car_creations.dart', 'car-ctor-instantiation', '', stylePattern)(format=".")
-+includeShared('{ts}', 'why-4')
-.l-sub-section
+block service-in-its-own-file
+  //- N/A
+
+block one-class-per-file-ts-tradeoffs
+  //- N/A
+
+block injectable-not-always-needed-in-ts
+  //- The [Angular 2 Dart Transformer](https://github.com/angular/angular/wiki/Angular-2-Dart-Transformer)
+  //- generates static code to replace the use of dart:mirrors. It requires that types be
+  //- identified as targets for static code generation. Generally this is achieved
+  //- by marking the class as @Injectable (though there are other mechanisms).
+
+block ts-any-decorator-will-do
+  //- N/A
+
+block always-include-paren
   :marked
-    The _consumer_ of `Car` has the problem. The consumer must update the car creation code to
-    something like this:
-  - var stylePattern = { otl: /(new Car.*$)/gm };
-  +makeExample('dependency-injection/dart/lib/car/car_creations.dart', 'car-ctor-instantiation-with-param', '', stylePattern)(format=".")
-  :marked
-    The critical point is this: `Car` itself did not have to change.
-    We'll take care of the consumer's problem soon enough.
-+includeShared('{ts}', 'why-6')
-- var stylePattern = { otl: /(new Car.*$)/gm };
-+makeExample('dependency-injection/dart/lib/car/car_creations.dart', 'car-ctor-instantiation-with-mocks', '', stylePattern)(format=".")
-+includeShared('{ts}', 'why-7')
-+makeExample('dependency-injection/dart/lib/car/car_factory.dart', null, 'lib/car/car_factory.dart')
-+includeShared('{ts}', 'why-8')
-+makeExample('dependency-injection/dart/lib/car/car_injector.dart','injector-call')(format=".")
-+includeShared('{ts}', 'why-9')
-
-+includeShared('{ts}', 'di-1')
-+makeTabs(
-  `dependency-injection/dart/lib/heroes/heroes_component_1.dart,
-  dependency-injection/dart/lib/heroes/hero_list_component_1.dart,
-  dependency-injection/dart/lib/heroes/hero.dart,
-  dependency-injection/dart/lib/heroes/mock_heroes.dart`,
-  'v1,,,',
-  `lib/heroes/heroes_component.dart,
-  lib/heroes/hero_list_component.dart,
-  lib/heroes/hero.dart,
-  lib/heroes/mock_heroes.dart`)
-+includeShared('{ts}', 'di-2')
-+includeShared('{ts}', 'di-3')
-+makeExample('dependency-injection/dart/lib/heroes/hero_service_1.dart',null, 'lib/heroes/hero_service.dart' )
-+includeShared('{ts}', 'di-4')
-.l-sub-section
-  :marked
-    We aren't even pretending this is a real service.
-    If we were actually getting data from a remote server, the API would have to be asynchronous,
-    returning a `Future`.
-    We'd also have to rewrite the way components consume our service.
-    This is important in general, but not to our current story.
-+includeShared('{ts}', 'di-6')
-+includeShared('{ts}', 'di-configure-injector-1')
-+makeExample('dependency-injection/dart/web/main.dart', 'bootstrap', 'web/main.dart (excerpt)')(format='.')
-+includeShared('{ts}', 'di-configure-injector-2')
-+makeExample('dependency-injection/dart/web/main_1.dart', 'bootstrap')(format='.')
-+includeShared('{ts}', 'di-configure-injector-3')
-+includeShared('{ts}', 'di-register-providers-1')
-+makeExample('dependency-injection/dart/lib/heroes/heroes_component_1.dart',null,'lib/heroes/heroes_component.dart')
-+includeShared('{ts}', 'di-register-providers-2')
-+makeExample('dependency-injection/dart/lib/heroes/heroes_component_1.dart','providers')(format='.')
-+includeShared('{ts}', 'di-register-providers-3')
-+includeShared('{ts}', 'di-prepare-for-injection-1')
-+makeTabs(
-  `dependency-injection/dart/lib/heroes/hero_list_component_2.dart,
-  dependency-injection/dart/lib/heroes/hero_list_component_1.dart`,
-  null,
-  `lib/heroes/hero_list_component (with DI),
-   lib/heroes/hero_list_component (without DI)`)
-.l-sub-section
-  :marked
-    ### Focus on the constructor
-
-    Adding a parameter to the constructor isn't all that's happening here.
-  +makeExample('dependency-injection/dart/lib/heroes/hero_list_component_2.dart', 'ctor')(format=".")
-  :marked
-    The constructor parameter has a type: `HeroService`.
-    The `HeroListComponent` class is also annotated with `@Component`
-    (scroll up to confirm that fact).
-    Also recall that the parent component (`HeroesComponent`)
-    has `providers` information for `HeroService`.
-
-    The constructor parameter type, the `@Component` annotation,
-    and the parent's `providers` information combine to tell the
-    Angular injector to inject an instance of
-    `HeroService` whenever it creates a new `HeroListComponent`.
-+includeShared('{ts}', 'di-create-injector-implicitly-1')
-+makeExample('dependency-injection/dart/lib/car/car_injector.dart','injector-create-and-call')(format=".")
-+includeShared('{ts}', 'di-create-injector-implicitly-2')
-+includeShared('{ts}', 'di-singleton-services')
-
-// Skip the testing section, for now.
-// includeShared('{ts}', 'di-testing-component-1')
-// includeShared('{ts}', 'di-testing-component-2')
-
-+includeShared('{ts}', 'di-service-service-1')
-+makeTabs(
-  `dependency-injection/dart/lib/heroes/hero_service_2.dart,
-  dependency-injection/dart/lib/heroes/hero_service_1.dart`,
-  null,
-  `lib/heroes/hero_service (v.2),
-  lib/heroes/hero_service (v.1)`)
-+includeShared('{ts}', 'di-service-service-2')
-+includeShared('{ts}', 'di-injectable-1')
-:marked
-  Forgetting the `@Injectable()` can cause a runtime error:
-code-example(format, language="html").
-  Cannot find reflection information on &lt;Type>
-+includeShared('{ts}', 'di-injectable-2')
-.callout.is-critical
-  header Always include the parentheses
-  :marked
-    Always use `@Injectable()`, not just `@Injectable`.
+    Always write `@Injectable()`, not just `@Injectable`.
     A metadata annotation must be either a reference to a
     compile-time constant variable or a call to a constant
     constructor such as `Injectable()`.
+    
     If we forget the parentheses, the analyzer will complain:
     "Annotation creation must have arguments". If we try to run the
     app anyway, it won't work, and the console will say
     "expression must be a compile-time constant".
-+includeShared('{ts}', 'logger-service-1')
-+makeExample(
-  'dependency-injection/dart/lib/logger_service.dart',null, 'lib/logger_service')
-.l-sub-section
+
+block real-logger
+  .l-sub-section
+    :marked
+      A real implementation would probably use the
+      [logging package](https://pub.dartlang.org/packages/logging).
+
+block optional-logger
+  //- TBC.
+
+block provider-function-etc
+  //- N/A
+
+block provider-ctor-args
+  - var _secondParam = 'named parameter, such as <code>useClass</code>' 
   :marked
-    ### Implementing a logger
+    We supply two arguments (or more) to the `Provider` constructor.
 
-    Our examples use a simple logger.
-    A real implementation would probably use the
-    [logging package](https://pub.dartlang.org/packages/logging).
-:marked
-  We're likely to need the same logger service everywhere in our application,
-  so we put it in the `lib/` folder, and
-  we register it in the `providers` array of the metadata for our application root component, `AppComponent`.
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-logger', 'lib/app_component.dart (excerpt)')
-+includeShared('{ts}', 'logger-service-3')
-+includeShared('{ts}', 'logger-service-4')
-+includeShared('{ts}', 'logger-service-5')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','provider-10-ctor')(format='.')
-+includeShared('{ts}', 'logger-service-6')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','provider-10-logger')(format='.')
-+includeShared('{ts}', 'logger-service-7')
+block dart-diff-const-metadata
+  .callout.is-helpful
+    header Dart difference: Constants in metadata
+    :marked
+      In Dart, the value of a metadata annotation must be a compile-time constant.
+      For that reason, we can't call functions to get values
+      to use within an annotation.
+      Instead, we use constant literals or constant constructors.
+      For example, a TypeScript program might use the
+      function call `provide(Logger, {useClass: BetterLogger})`,
+      which is equivalent to the TypeScript code
+      `new Provider(Logger, {useClass: BetterLogger})`.
+      A Dart annotation would instead use the constant value `const Provider(Logger, useClass: BetterLogger)`.
 
-+includeShared('{ts}', 'providers-1')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-logger')
-+includeShared('{ts}', 'providers-2')
-+includeShared('{ts}', 'providers-provide-1')
-:marked
-  ### The *Provider* class
-+includeShared('{ts}', 'providers-provide-1-1')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-1')
-+includeShared('{ts}', 'providers-provide-2')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-2')
-// includeShared('{ts}', 'providers-provide-3')
-// includeShared('{ts}', 'providers-provide-4-1')
-// Don't discuss provide function.
-:marked
-  We supply two arguments (or more) to the `Provider` constructor.
-+includeShared('{ts}', 'providers-provide-4-2')
-:marked
-  The second is a named parameter, such as `useClass`,
-  that we can think of as a *recipe* for creating the dependency value.
-  There are many ways to create dependency values... and many ways to write a recipe.
-+includeShared('{ts}', 'providers-alternative-1')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-4')
-.callout.is-helpful
-  header Dart difference: Constants in metadata
+block dart-diff-const-metadata-ctor
+  .callout.is-helpful
+    header Dart difference: Constants in metadata
+    :marked
+      Because Dart annotations must be compile-time constants,
+      `useValue` is often used with string or list literals.
+      However, `useValue` works with any constant object.
+
+      To create a class that can provide constant objects,
+      ensure all its instance variables are `final`,
+      and give it a `const` constructor.
+      
+      Create a constant instance of the class by using `const` instead of `new`.
+
+// - var stylePattern = { otl: /(useValue.*\))/gm };
+// +makeExample('dependency-injection/dart/lib/providers_component.dart','providers-9','', stylePattern)(format='.')
+
+block non-class-dep-eg
+  span string, list, map, or maybe a function.
+
+block config-obj-maps
+  | . They can be 
+  | <b><a href="https://api.dartlang.org/stable/dart-core/Map-class.html">Map</a></b>
+  | literals
+
+block what-should-we-use-as-token
   :marked
-    In Dart, the value of a metadata annotation must be a compile-time constant.
-    For that reason, we can't call functions to get values
-    to use within an annotation.
-    Instead, we use constant literals or constant constructors.
-    For example, a TypeScript program might use the
-    function call `provide(Logger, {useClass: BetterLogger})`,
-    which is equivalent to the TypeScript code
-    `new Provider(Logger, {useClass: BetterLogger})`.
-    A Dart annotation would instead use the constant value `const Provider(Logger, useClass: BetterLogger)`.
-+includeShared('{ts}', 'providers-alternative-2')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','EvenBetterLogger')
-+includeShared('{ts}', 'providers-alternative-3')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-5')(format=".")
-+includeShared('{ts}', 'providers-aliased-1')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-6a')(format=".")
-+includeShared('{ts}', 'providers-aliased-2')
-- var stylePattern = { otl: /(useExisting.*\))/gm };
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-6b','', stylePattern)(format=".")
+    But what should we use as the token?
+    We could use the **[Map][]** interface.
 
-+includeShared('{ts}', 'providers-value-1')
-:marked
-  We can provide objects directly,
-  instead of asking the injector to create an instance of a class,
-  by specifying a `useValue` parameter to `Provider`.
+    [Map]: https://api.dartlang.org/stable/dart-core/Map-class.html
 
-  Because Dart annotations must be compile-time constants,
-  `useValue` is often used with string or list literals.
-  However, `useValue` works with any constant object.
+  .callout.is-helpful
+    header Dart difference: Interfaces are valid tokens
+    :marked
+      In TypeScript, interfaces don't work as provider tokens.
+      Dart doesn't have this limitation;
+      every class implicitly defines an interface,
+      so interface names are just class names.
 
-  To create a class that can provide constant objects,
-  make sure all its instance variables are `final`,
-  and give it a `const` constructor:
-
-+makeExample('dependency-injection/dart/lib/app_config.dart','const-class','lib/app_config.dart (excerpt)')(format='.')
-
-:marked
-  Create a constant instance of the class by using `const` instead of `new`:
-
-+makeExample('dependency-injection/dart/lib/app_config.dart','const-object','lib/app_config.dart (excerpt)')(format='.')
-
-:marked
-  Then specify the object using the `useValue` argument to `Provider`:
-
-- var stylePattern = { otl: /(useValue.*\))/gm };
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-9','', stylePattern)(format='.')
-
-:marked
-  See more `useValue` examples in the
-  [Non-class dependencies](#non-class-dependencies) and
-  [OpaqueToken](#opaquetoken) sections.
-
-+includeShared('{ts}', 'providers-factory-1')
-+makeExample('dependency-injection/dart/lib/heroes/hero_service.dart','internals', 'lib/heroes/hero_service.dart (excerpt)')(format='.')
-+includeShared('{ts}', 'providers-factory-2')
-+makeExample('dependency-injection/dart/lib/heroes/hero_service_provider.dart','factory', 'lib/heroes/hero_service_provider.dart (excerpt)')(format='.')
-+includeShared('{ts}', 'providers-factory-3')
-+makeExample('dependency-injection/dart/lib/heroes/hero_service_provider.dart','provider', 'lib/heroes/hero_service_provider.dart (excerpt)')(format='.')
-+includeShared('{ts}', 'providers-factory-4')
-+includeShared('{ts}', 'providers-factory-5')
-- var stylePattern = { otl: /(providers.*),$/gm };
-+makeTabs(
-  `dependency-injection/dart/lib/heroes/heroes_component.dart,
-  dependency-injection/dart/lib/heroes/heroes_component_1.dart`,
-  null,
-  `lib/heroes/heroes_component (v.3),
-  lib/heroes/heroes_component (v.2)`,
-  stylePattern)
-+includeShared('{ts}', 'tokens-1')
-+makeExample('dependency-injection/dart/lib/injector_component.dart','get-hero-service')(format='.')
-+includeShared('{ts}', 'tokens-2')
-// [PENDING: How about a better name than ProviderComponent8?]
-+makeExample('dependency-injection/dart/lib/providers_component.dart','provider-8-ctor')(format=".")
-+includeShared('{ts}', 'tokens-3')
-.callout.is-helpful
-  header Dart difference: Interfaces are valid tokens
   :marked
-    In TypeScript, interfaces don't work as provider tokens.
-    Dart doesn't have this problem;
-    every class implicitly defines an interface,
-    so interface names are just class names.
-+includeShared('{ts}', 'tokens-non-class-deps-1')
-:marked
-  We know we can register an object with a [value provider](#value-provider).
-  But what do we use for the token?
-+includeShared('{ts}', 'tokens-opaque-1')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','opaque-token')(format='.')
-+includeShared('{ts}', 'tokens-opaque-2')
-+makeExample('dependency-injection/dart/lib/providers_component.dart','use-opaque-token')(format=".")
-:marked
-  Here's an example of providing configuration information
-  for an injected class. First define the class:
-+makeExample('dependency-injection/dart/lib/providers_component.dart','configurable-logger')(format=".")
-:marked
-  Then inject that class and its configuration information:
-+makeExample('dependency-injection/dart/lib/providers_component.dart','providers-7')(format=".")
+    The problem with using `Map` as a token, is not that it is an abstract
+    class, but rather that it is very general purpose (like `String`) and so
+    our application may depend on several maps each used for a
+    different purpose.
 
+block dart-map-alternative
+  :marked
+    As an alternative to using a configuration `Map`, we can define
+    a custom class type:
 
-+includeShared('{ts}', 'summary')
+  +makeExample('dependency-injection/ts/app/app.config.ts','config-alt','app/app-config.ts (alternative config)')(format='.')
 
-+includeShared('{ts}', 'appendix-explicit-injector-1')
-+makeExample('dependency-injection/dart/lib/injector_component.dart', 'injector', 'lib/injector_component.dart')
-+includeShared('{ts}', 'appendix-explicit-injector-2')
+  :marked
+    One of the key benefits of defining a configuration object class, is
+    strong static checking relative to configuration property names and their types.
+    The Dart [cascade operator][cascade-op] provides a convenient means of initializing
+    the configuration object. Use of the cascaded object initialization idiom
+    prevents us from defining our configuration object instance as `const`. 
+    As a consequencem we cannot declare a [value provider](#value-provider),
+    but a [factory provider](#factory-provider) does the trick &mdash; as
+    we illustrate by providing and injecting the configuration object in our
+    top-level `AppComponent`:
+
+    [cascade-op]: https://www.dartlang.org/docs/dart-up-and-running/ch02.html#cascade
+
+  +makeExcerpt('lib/app_component.dart','providers')
+  +makeExcerpt('lib/app_component.dart','ctor')

--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -34,7 +34,7 @@ p Run the #[+liveExampleLink2()].
 
   Our `Car` needs an engine and tires. Instead of asking for them,
   the `Car` constructor instantiates its own copies from
-  the very specific classes, `Engine` and `Tires`.
+  the very specific classes `Engine` and `Tires`.
 
   What if the `Engine` class evolves and its constructor requires a parameter?
   Our `Car` is broken and stays broken until we rewrite it along the lines of
@@ -422,9 +422,9 @@ block injectable-not-always-needed-in-ts
 
   We *can* add it if we really want to. It isn't necessary because the
   `HeroesComponent` is already marked with `@Component`, and this
-  !{_decorator} class (like `@Directive` and `@Pipe` which we will study later
-  on) is a subtype of <a href="#{injMetaUrl}">InjectableMetadata</a>.  It is in
-  fact <a href="#{injMetaUrl}">InjectableMetadata</a> #{_decorator}s that
+  !{_decorator} class (like `@Directive` and `@Pipe`, which we'll learn about later)
+  is a subtype of <a href="#{injMetaUrl}">InjectableMetadata</a>.  It is in
+  fact `InjectableMetadata` #{_decorator}s that
   identify a class as a target for instantiation by an injector.
 
 block ts-any-decorator-will-do
@@ -701,7 +701,7 @@ block dart-diff-const-metadata-ctor
 +makeTabs(
   `dependency-injection/ts/app/heroes/heroes.component.ts,
   dependency-injection/ts/app/heroes/heroes.component.1.ts`,
-  null,
+  ',full',
   `app/heroes/heroes.component (v3),
   app/heroes/heroes.component (v2)`,
   stylePattern)
@@ -779,7 +779,8 @@ block what-should-we-use-as-token
 :marked
   ### OpaqueToken
 
-  The solution is to define and use an !{opaquetoken}.
+  One solution to choosing a provider token for non-class dependencies is
+  to define and use an !{opaquetoken}.
   The definition looks like this:
 
 +makeExample('dependency-injection/ts/app/app.config.ts','token')(format='.')
@@ -798,8 +799,8 @@ block what-should-we-use-as-token
 - var configType = _docsFor == 'dart' ? '<code>Map</code>' : '<code>AppConfig</code>'
 .l-sub-section
   :marked
-    Although it plays no role in dependency injection,
-    the !{configType} interface supports typing of the configuration object within the class.
+    Although the !{configType} interface plays no role in dependency injection,
+    it supports typing of the configuration object within the class.
 
 block dart-map-alternative
   :marked
@@ -813,16 +814,17 @@ block dart-map-alternative
 
   Our `HeroService` *requires* a `Logger`, but what if it could get by without
   a logger?
-  As is illustrated next, we can indicate that to the dependency injection
-  framework by marking the constructor's argument as optional.
+  We can tell Angular that the dependency is optional by annotating the 
+  constructor argument with `@Optional()`:
 
 +ifDocsFor('ts')
   +makeExample('dependency-injection/ts/app/providers.component.ts','import-optional', '')
 +makeExample('dependency-injection/ts/app/providers.component.ts','provider-10-ctor', '')(format='.')
 
 :marked
-  Be prepared for a null logger. If we don't register one somewhere up the line,
-  the injector will inject `null`.
+  When using `@Optional()`, our code must be prepared for a null value. If we
+  don't register a logger somewhere up the line, the injector will set the
+  value of `logger` to null.
 
 .l-main-section
 :marked

--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -1,6 +1,7 @@
-include ../_util-fns
+block includes
+  include ../_util-fns
+  - var _thisDot = 'this.';
 
-// #docregion intro
 :marked
   **Dependency injection** is an important application design pattern.
   Angular has its own dependency injection framework, and
@@ -9,34 +10,35 @@ include ../_util-fns
 
   In this chapter we'll learn what DI is and why we want it.
   Then we'll learn [how to use it](#angular-di) in an Angular app.
-// #enddocregion intro
-:marked
-  [Run the live example](/resources/live-examples/dependency-injection/ts/plnkr.html)
-// #docregion why-1
-<a id="why-di"></a>
-.l-main-section
+
+  - [Why dependency injection?](#why-dependency-injection)
+  - [Angular dependency injection](#angular-dependency-injection)
+  - [Injector providers](#injector-providers)
+  - [Dependency injection tokens](#dependency-injection-tokens)
+  - [Summary](#summary)
+
+p Run the #[+liveExampleLink2()].
+
+.l-main-section#why-di
 :marked
   ## Why dependency injection?
 
   Let's start with the following code.
-// #enddocregion why-1
+
 +makeExample('dependency-injection/ts/app/car/car-no-di.ts', 'car', 'app/car/car.ts (without DI)')
-// #docregion why-2
-- var lang = current.path[1]
-- var prefix = lang == 'dart' ? '' : 'this.'
+
 :marked
   Our `Car` creates everything it needs inside its constructor.
   What's the problem?
-
   The problem is that our `Car` class is brittle, inflexible, and hard to test.
 
   Our `Car` needs an engine and tires. Instead of asking for them,
-  the `Car` constructor creates its own copies by "new-ing" them from
+  the `Car` constructor instantiates its own copies from
   the very specific classes, `Engine` and `Tires`.
 
   What if the `Engine` class evolves and its constructor requires a parameter?
   Our `Car` is broken and stays broken until we rewrite it along the lines of
-  `#{prefix}engine = new Engine(theNewParameter)`.
+  `#{_thisDot}engine = new Engine(theNewParameter)`.
   We didn't care about `Engine` constructor parameters when we first wrote `Car`.
   We don't really care about them now.
   But we'll *have* to start caring because
@@ -67,31 +69,30 @@ include ../_util-fns
 
   How can we make `Car` more robust, flexible, and testable?
 
+  <a id="ctor-injection"></a>
   That's super easy. We change our `Car` constructor to a version with DI:
 
-  <a id="ctor-injection"></a>
-// #enddocregion why-2
 +makeTabs(
   'dependency-injection/ts/app/car/car.ts, dependency-injection/ts/app/car/car-no-di.ts',
   'car-ctor, car-ctor',
   'app/car/car.ts (excerpt with DI), app/car/car.ts (excerpt without DI)')(format=".")
-// #docregion why-3-1
+
 :marked
   See what happened? We moved the definition of the dependencies to the constructor.
   Our `Car` class no longer creates an engine or tires.
   It just consumes them.
-// #enddocregion why-3-1
-// TypeScript only
-.l-sub-section
-  :marked
-    We also leverage TypeScript's constructor syntax for declaring parameters and properties simultaneously.
-// #docregion why-3-2
+
+block ctor-syntax
+  .l-sub-section
+    :marked
+      We also leveraged TypeScript's constructor syntax for declaring
+      parameters and properties simultaneously.
+
 :marked
   Now we create a car by passing the engine and tires to the constructor.
-// #enddocregion why-3-2
-- var stylePattern = { otl: /(new Car.*$)/gm };
-+makeExample('dependency-injection/ts/app/car/car-creations.ts', 'car-ctor-instantiation', '', stylePattern)(format=".")
-// #docregion why-4
+
++makeExample('dependency-injection/ts/app/car/car-creations.ts', 'car-ctor-instantiation', '')(format=".")
+
 :marked
   How cool is that?
   The definition of the engine and tire dependencies are
@@ -100,8 +101,7 @@ include ../_util-fns
   conform to the general API requirements of an engine or tires.
 
   If someone extends the `Engine` class, that is not `Car`'s problem.
-// #enddocregion why-4
-// Must copy the following, due to indented +make.
+
 .l-sub-section
   :marked
     The _consumer_ of `Car` has the problem. The consumer must update the car creation code to
@@ -113,16 +113,16 @@ include ../_util-fns
   :marked
     The critical point is this: `Car` itself did not have to change.
     We'll take care of the consumer's problem soon enough.
-// #docregion why-6
+
 :marked
   The `Car` class is much easier to test because we are in complete control
   of its dependencies.
   We can pass mocks to the constructor that do exactly what we want them to do
   during each test:
-// #enddocregion why-6
+
 - var stylePattern = { otl: /(new Car.*$)/gm };
 +makeExample('dependency-injection/ts/app/car/car-creations.ts', 'car-ctor-instantiation-with-mocks', '', stylePattern)(format=".")
-// #docregion why-7
+
 :marked
   **We just learned what dependency injection is**.
 
@@ -136,9 +136,9 @@ include ../_util-fns
   We need something that takes care of assembling these parts for us.
 
   We could write a giant class to do that:
-// #enddocregion why-7
+
 +makeExample('dependency-injection/ts/app/car/car-factory.ts', null, 'app/car/car-factory.ts')
-// #docregion why-8
+
 :marked
   It's not so bad now with only three creation methods.
   But maintaining it will be hairy as the application grows.
@@ -153,9 +153,9 @@ include ../_util-fns
   We register some classes with this injector, and it figures out how to create them.
 
   When we need a `Car`, we simply ask the injector to get it for us and we're good to go.
-// #enddocregion why-8
+
 +makeExample('dependency-injection/ts/app/car/car-injector.ts','injector-call')(format=".")
-// #docregion why-9
+
 :marked
   Everyone wins. The `Car` knows nothing about creating an `Engine` or `Tires`.
   The consumer knows nothing about creating a `Car`.
@@ -166,10 +166,8 @@ include ../_util-fns
 
   Now that we know what dependency injection is and appreciate its benefits,
   let's see how it is implemented in Angular.
-// #enddocregion why-9
-// #docregion di-1
-<a id="angular-di"></a>
-.l-main-section
+
+.l-main-section#angular-di
 :marked
   ## Angular dependency injection
 
@@ -181,7 +179,7 @@ include ../_util-fns
 
   We'll begin with a simplified version of the `HeroesComponent`
   that we built in the [The Tour of Heroes](../tutorial/).
-// #enddocregion di-1
+
 +makeTabs(
   `dependency-injection/ts/app/heroes/heroes.component.1.ts,
   dependency-injection/ts/app/heroes/hero-list.component.1.ts,
@@ -192,14 +190,13 @@ include ../_util-fns
   app/heroes/hero-list.component.ts,
   app/heroes/hero.ts,
   app/heroes/mock-heroes.ts`)
-// #docregion di-2
+
 :marked
   The `HeroesComponent` is the root component of the *Heroes* feature area.
   It governs all the child components of this area.
   Our stripped down version has only one child, `HeroListComponent`,
   which displays a list of heroes.
-// #enddocregion di-2
-// #docregion di-3
+
 :marked
   Right now `HeroListComponent` gets heroes from `HEROES`, an in-memory collection
   defined in another file.
@@ -209,51 +206,57 @@ include ../_util-fns
   fix every other use of the `HEROES` mock data.
 
   Let's make a service that hides how we get hero data.
-// #enddocregion di-3
 
-// Unnecessary for Dart
 .l-sub-section
   :marked
-    Write this service in its own file. See [this note](#forward-ref) to understand why.
+    Given that the service is a
+    [separate concern](https://en.wikipedia.org/wiki/Separation_of_concerns),
+    we suggest that you
+    write the service code in its own file.
+  +ifDocsFor('ts')
+    :marked
+      See [this note](#one-class-per-file) for details.
+
 +makeExample('dependency-injection/ts/app/heroes/hero.service.1.ts',null, 'app/heroes/hero.service.ts' )
-// #docregion di-4
+
 :marked
   Our `HeroService` exposes a `getHeroes` method that returns
   the same mock data as before, but none of its consumers need to know that.
-// #enddocregion di-4
-// #docregion di-5
+.l-sub-section
+  :marked
+    Notice the `@Injectable()` #{_decorator} above the service class.
+    We'll discuss its purpose [shortly](#injectable).
+
+- var _perhaps = _docsFor == 'dart' ? '' : 'perhaps';
 .l-sub-section
   :marked
     We aren't even pretending this is a real service.
-    If we were actually getting data from a remote server, the API would have to be asynchronous,
-    perhaps returning
-    [ES2015 promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+    If we were actually getting data from a remote server, the API would have to be 
+    asynchronous, #{_perhaps} returning a !{_PromiseLinked}.
     We'd also have to rewrite the way components consume our service.
     This is important in general, but not to our current story.
-// #enddocregion di-5
-// #docregion di-6
+
 :marked
   A service is nothing more than a class in Angular 2.
   It remains nothing more than a class until we register it with an Angular injector.
-// #enddocregion di-6
-// #docregion di-configure-injector-1
+
+#bootstrap
 :marked
   ### Configuring the injector
 
-  <a id="bootstrap"></a>
   We don't have to create an Angular injector.
   Angular creates an application-wide injector for us during the bootstrap process.
-// #enddocregion di-configure-injector-1
+
 +makeExample('dependency-injection/ts/app/main.ts', 'bootstrap', 'app/main.ts (excerpt)')(format='.')
-// #docregion di-configure-injector-2
+
 :marked
   We do have to configure the injector by registering the **providers**
   that create the services our application requires.
   We'll explain what [providers](#providers) are later in this chapter.
   Before we do, let's see an example of provider registration during bootstrapping:
-// #enddocregion di-configure-injector-2
-+makeExample('dependency-injection/ts/app/main.1.ts', 'bootstrap')(format='.')
-// #docregion di-configure-injector-3
+
++makeExample('dependency-injection/ts/app/main.1.ts', 'bootstrap-discouraged')(format='.')
+
 :marked
   The injector now knows about our `HeroService`.
   An instance of our `HeroService` will be available for injection across our entire application.
@@ -266,81 +269,78 @@ include ../_util-fns
   The preferred approach is to register application providers in application components.
   Because the `HeroService` is used within the *Heroes* feature area &mdash;
   and nowhere else &mdash; the ideal place to register it is in the top-level `HeroesComponent`.
-// #enddocregion di-configure-injector-3
-// #docregion di-register-providers-1
+
 :marked
   ### Registering providers in a component
   Here's a revised `HeroesComponent` that registers the `HeroService`.
-// #enddocregion di-register-providers-1
-+makeExample('dependency-injection/ts/app/heroes/heroes.component.1.ts',null,'app/heroes/heroes.component.ts')
-// #docregion di-register-providers-2
+
+- var stylePattern = { otl: /(providers:.*),/ };
++makeExample('dependency-injection/ts/app/heroes/heroes.component.1.ts', 'full','app/heroes/heroes.component.ts', stylePattern)(format='.')
+
 :marked
-  Look closely at the `providers` part of the `@Component` metadata:
-// #enddocregion di-register-providers-2
-+makeExample('dependency-injection/ts/app/heroes/heroes.component.1.ts','providers')(format='.')
-// #docregion di-register-providers-3
-:marked
+  Look closely at the `providers` part of the `@Component` metadata.
   An instance of the `HeroService` is now available for injection in this `HeroesComponent`
   and all of its child components.
 
   The `HeroesComponent` itself doesn't happen to need the `HeroService`.
   But its child `HeroListComponent` does, so we head there next.
-// #enddocregion di-register-providers-3
-// #docregion di-prepare-for-injection-1
+
 :marked
   ### Preparing the HeroListComponent for injection
 
   The `HeroListComponent` should get heroes from the injected `HeroService`.
-  Per the dependency injection pattern, the component must ask for the service in its constructor, [as we explained
-  earlier](#ctor-injection).
+  Per the dependency injection pattern, the component must ask for the service in its 
+  constructor, [as we explained earlier](#ctor-injection).
   It's a small change:
-// #enddocregion di-prepare-for-injection-1
+
 +makeTabs(
   `dependency-injection/ts/app/heroes/hero-list.component.2.ts,
   dependency-injection/ts/app/heroes/hero-list.component.1.ts`,
   null,
   `app/heroes/hero-list.component (with DI),
    app/heroes/hero-list.component (without DI)`)
-// Must copy the following, due to indented +make.
+
 .l-sub-section
   :marked
-    ### Focus on the constructor
+    #### Focus on the constructor
 
     Adding a parameter to the constructor isn't all that's happening here.
 
   +makeExample('dependency-injection/ts/app/heroes/hero-list.component.2.ts', 'ctor')(format=".")
 
-  // TypeScript only
   :marked
-    We're writing in TypeScript and have followed the parameter name with a type annotation, `:HeroService`.
-    The class is also decorated with the `@Component` decorator (scroll up to confirm that fact).
+    Note that the constructor parameter has the type `HeroService`, and that
+    the `HeroListComponent` class has an `@Component` #{_decorator}
+    (scroll up to confirm that fact).
+    Also recall that the parent component (`HeroesComponent`)
+    has `providers` information for `HeroService`.
 
-    When the TypeScript compiler evaluates this class, it sees the `@Component` decorator and adds class metadata
-    into the generated JavaScript code. Within that metadata lurks the information that
-    associates the `heroService` parameter with the `HeroService` class.
+    The constructor parameter type, the `@Component` #{_decorator},
+    and the parent's `providers` information combine to tell the
+    Angular injector to inject an instance of
+    `HeroService` whenever it creates a new `HeroListComponent`.
 
-    That's how the Angular injector knows to inject an instance of the `HeroService` when it
-    creates a new `HeroListComponent`.
-// #docregion di-create-injector-implicitly-1
+#di-metadata
 :marked
-  <a id="di-metadata"></a>
-  ### Creating the injector (implicitly)
-  When we introduced the idea of an injector above, we showed how to create
-  an injector and use it to create a new `Car`.
-// #enddocregion di-create-injector-implicitly-1
+  ### Implicit injector creation
+
+  When we introduced the idea of an injector above, we showed how to
+  use it to create a new `Car`. Here we also show how such an injector
+  would be explicitly created:
+
 +makeExample('dependency-injection/ts/app/car/car-injector.ts','injector-create-and-call')(format=".")
-// #docregion di-create-injector-implicitly-2
+
 :marked
   We won't find code like that in the Tour of Heroes or any of our other samples.
-  We *could* write [code with an explicit injector](#explicit-injector) if we *had* to, but we rarely do.
+  We *could* write code that [explicitly creates an injector](#explicit-injector) if we *had* to, but we rarely do.
   Angular takes care of creating and calling injectors
   when it creates components for us &mdash; whether through HTML markup, as in `<hero-list></hero-list>`,
   or after navigating to a component with the [router](./router.html).
   If we let Angular do its job, we'll enjoy the benefits of automated dependency injection.
-// #enddocregion di-create-injector-implicitly-2
-// #docregion di-singleton-services
+
 :marked
   ### Singleton services
+
   Dependencies are singletons within the scope of an injector.
   In our example, a single `HeroService` instance is shared among the
   `HeroesComponent` and its `HeroListComponent` children.
@@ -348,27 +348,25 @@ include ../_util-fns
   However, Angular DI is an hierarchical injection
   system, which means that nested injectors can create their own service instances.
   Learn more about that in the [Hierarchical Injectors](./hierarchical-dependency-injection.html) chapter.
-// #enddocregion di-singleton-services
 
-// Skip this for Dart, for now
-// #docregion di-testing-component-1
 :marked
   ### Testing the component
+
   We emphasized earlier that designing a class for dependency injection makes the class easier to test.
   Listing dependencies as constructor parameters may be all we need to test application parts effectively.
 
   For example, we can create a new `HeroListComponent` with a mock service that we can manipulate
   under test:
-// #enddocregion di-testing-component-1
+
 +makeExample('dependency-injection/ts/app/test.component.ts', 'spec')(format='.')
-// #docregion di-testing-component-2
+
 .l-sub-section
   :marked
     Learn more in [Testing](../testing/index.html).
-// #enddocregion di-testing-component-2
-// #docregion di-service-service-1
+
 :marked
   ### When the service needs a service
+
   Our `HeroService` is very simple. It doesn't have any dependencies of its own.
 
 
@@ -377,144 +375,110 @@ include ../_util-fns
   adding a constructor that takes a `Logger` parameter.
 
   Here is the revision compared to the original.
-// #enddocregion di-service-service-1
+
 +makeTabs(
   `dependency-injection/ts/app/heroes/hero.service.2.ts,
   dependency-injection/ts/app/heroes/hero.service.1.ts`,
   null,
-  `app/heroes/hero.service (v.2),
-  app/heroes/hero.service (v.1)`)
-// #docregion di-service-service-2
+  `app/heroes/hero.service (v2),
+  app/heroes/hero.service (v1)`)
+
 :marked
-  The constructor now asks for an injected instance of a `Logger` and stores it in a private property called `logger`.
+  The constructor now asks for an injected instance of a `Logger` and stores it in a private property called `#{_priv}logger`.
   We call that property within our `getHeroes` method when anyone asks for heroes.
-// #enddocregion di-service-service-2
-// #docregion di-injectable-1
-- var lang = current.path[1]
-- var decoration = lang == 'dart' ? 'annotation' : 'decoration'
-- var tsmetadata = lang == 'ts' ? 'As <a href="#di-metadata">we mentioned earlier</a>, <b>TypeScript only generates metadata for classes that have a decorator.</b>' : ''
+
+//- FIXME refer to Dart API when that page becomes available.
+- var injMetaUrl = 'https://angular.io/docs/ts/latest/api/core/index/InjectableMetadata-class.html';
+h3#injectable Why @Injectable()?
 :marked
-  <a id="injectable"></a>
-  ### Why @Injectable?
-  Notice the `@Injectable()` #{decoration} above the service class.
-  We haven't seen `@Injectable()` before.
-  As it happens, we could have added it to our first version of `HeroService`.
-  We didn't bother because we didn't need it then.
+  **<a href="#{injMetaUrl}">@Injectable()</a>** marks a class as available to an
+  injector for instantiation. Generally speaking, an injector will report an
+  error when trying to instantiate a class that is not marked as
+  `@Injectable()`.
 
-  We need it now... now that our service has an injected dependency.
-  We need it because Angular requires constructor parameter metadata in order to inject a `Logger`. !{tsmetadata}
-// #enddocregion di-injectable-1
+block injectable-not-always-needed-in-ts
+  .l-sub-section
+    :marked
+      As it happens, we could have omitted `@Injectable()` from our first
+      version of `HeroService` because it had no injected parameters.
+      But we must have it now that our service has an injected dependency.
+      We need it because Angular requires constructor parameter metadata 
+      in order to inject a `Logger`.
 
-// #docregion di-injectable-2
-- var lang = current.path[1]
-- var a_decorator = lang == 'dart' ? 'an annotation' : 'a decorator'
-- var decorated = lang == 'dart' ? 'annotated' : 'decorated'
-- var any_decorator = lang == 'dart' ? '' : 'TypeScript generates metadata for any class with a decorator, and any decorator will do.'
-.callout.is-helpful
-  header Suggestion: add @Injectable() to every service class
-  :marked
-    We recommend adding `@Injectable()` to every service class, even those that don't have dependencies
-    and, therefore, do not technically require it. Here's why:
-  ul(style="font-size:inherit")
-    li <b>Future proofing:</b> No need to remember <code>@Injectable()</code> when we add a dependency later.
-    li <b>Consistency:</b> All services follow the same rules, and we don't have to wonder why #{a_decorator} is missing.
+  .callout.is-helpful
+    header Suggestion: add @Injectable() to every service class
+    :marked
+      We recommend adding `@Injectable()` to every service class, even those that don't have dependencies
+      and, therefore, do not technically require it. Here's why:
 
-  :marked
-    Although we recommend applying `@Injectable` to all service classes, do not feel bound by it.
-    Some developers prefer to add it only where needed and that's a reasonable policy too.
+    ul(style="font-size:inherit")
+      li <b>Future proofing:</b> No need to remember <code>@Injectable()</code> when we add a dependency later.
+      li <b>Consistency:</b> All services follow the same rules, and we don't have to wonder why #{_a} #{_decorator} is missing.
 
-.l-sub-section
-  :marked
-    The `HeroesComponent` has an injected dependency too. Why don't we add `@Injectable()` to the `HeroesComponent`?
+:marked
+  Injectors are also responsible for instantiating components
+  like `HeroesComponent`. Why haven't we marked `HeroesComponent` as
+  `@Injectable()`?
 
-    We *can* add it if we really want to. It isn't necessary because
-    the `HeroesComponent` is already #{decorated} with `@Component`. #{any_decorator}
-// #enddocregion di-injectable-2
+  We *can* add it if we really want to. It isn't necessary because the
+  `HeroesComponent` is already marked with `@Component`, and this
+  !{_decorator} class (like `@Directive` and `@Pipe` which we will study later
+  on) is a subtype of <a href="#{injMetaUrl}">InjectableMetadata</a>.  It is in
+  fact <a href="#{injMetaUrl}">InjectableMetadata</a> #{_decorator}s that
+  identify a class as a target for instantiation by an injector.
+
+block ts-any-decorator-will-do
+  .l-sub-section
+    :marked
+      Injectors use a class's constructor metadata to determine dependent types as
+      identified by the constructor's parameter types.
+      TypeScript generates such metadata for any class with a decorator, and any decorator will do.
+      But of course, it is more meaningful to mark a class using the appropriate
+      <a href="#{injMetaUrl}">InjectableMetadata</a> #{_decorator}.
+
 .callout.is-critical
   header Always include the parentheses
-  :marked
-    Always use `@Injectable()`, not just `@Injectable`.
-    Our application will fail mysteriously if we forget the parentheses.
+  block always-include-paren
+    :marked
+      Always write `@Injectable()`, not just `@Injectable`.
+      Our application will fail mysteriously if we forget the parentheses.
 
-// #docregion logger-service-1
-.l-main-section
+.l-main-section#logger-service
 :marked
   ## Creating and registering a logger service
+
   We're injecting a logger into our `HeroService` in two steps:
   1. Create the logger service.
   1. Register it with the application.
 
-  The logger service implementation is no big deal.
-// #enddocregion logger-service-1
-+makeExample(
-  'dependency-injection/ts/app/logger.service.ts',null, 'app/logger.service')
+  Our logger service is quite simple:
 
-// Copied into Dart, due to different directory structure
++makeExample('dependency-injection/ts/app/logger.service.ts', null, 'app/logger.service.ts')
+
+block real-logger
+  //- N/A
+
 :marked
   We're likely to need the same logger service everywhere in our application,
-  so we put it at the root level of the application in the `app/` folder, and
-  we register it in the `providers` array of the metadata for our application root component, `AppComponent`.
-+makeExample('dependency-injection/ts/app/providers.component.ts','providers-logger', 'app/app.component.ts (excerpt)')
-// #docregion logger-service-3
+  so we put it in the project's `#{_appDir}` folder, and
+  we register it in the `providers` #{_array} of the metadata for our application root component, `AppComponent`.
+
++makeExcerpt('app/providers.component.ts','providers-logger','app/app.component.ts (excerpt)')
+
 :marked
   If we forget to register the logger, Angular throws an exception when it first looks for the logger:
-code-example(format, language="html").
+code-example(format="nocode").
   EXCEPTION: No provider for Logger! (HeroListComponent -> HeroService -> Logger)
-// #enddocregion logger-service-3
-// #docregion logger-service-4
+
 :marked
   That's Angular telling us that the dependency injector couldn't find the *provider* for the logger.
   It needed that provider to create a `Logger` to inject into a new
   `HeroService`, which it needed to
   create and inject into a new `HeroListComponent`.
 
-  The chain of creations started with the `Logger` provider. The *provider* is the subject of our next section.
+  The chain of creations started with the `Logger` provider. *Providers* are the subject of our next section.
 
-  But wait!  What if the logger is optional?
-  <a id="optional"></a>
-  ### Optional dependencies
-
-  Our `HeroService` currently requires a `Logger`. What if we could get by without a logger?
-  We'd use it if we had it, ignore it if we didn't. We can do that.
-// #enddocregion logger-service-4
-
-// TypeScript only?
-:marked
-  First import the `@Optional()` decorator.
-+makeExample('dependency-injection/ts/app/providers.component.ts','import-optional')(format='.')
-
-// #docregion logger-service-5
-- var lang = current.path[1]
-- var rewrite = lang == 'dart' ? 'Just rewrite' : 'Then rewrite'
-- var decorator = lang == 'dart' ? 'annotation' : 'decorator'
-:marked
-  #{rewrite} the constructor with the `@Optional()` #{decorator} preceding the private `logger` parameter.
-  That tells the injector that `logger` is optional.
-// #enddocregion logger-service-5
-+makeExample('dependency-injection/ts/app/providers.component.ts','provider-10-ctor')(format='.')
-// #docregion logger-service-6
-:marked
-  Be prepared for a null logger. If we don't register one somewhere up the line,
-  the injector will inject `null`. We have a method that logs.
-  What can we do to avoid a null reference exception?
-
-  We could substitute a *do-nothing* logger stub so that calling methods continue to work:
-// #enddocregion logger-service-6
-+makeExample('dependency-injection/ts/app/providers.component.ts','provider-10-logger')(format='.')
-// #docregion logger-service-7
-:marked
-  Obviously we'd take a more sophisticated approach if the logger were optional
-  in multiple locations.
-
-  But enough about optional loggers. In our sample application, the `Logger` is required.
-  We must register a `Logger` with the application injector using *providers*,
-  as we learn in the next section.
-// #enddocregion logger-service-7
-
-// #docregion providers-1
-:marked
-<a id="providers"></a>
-.l-main-section
+.l-main-section#providers
 :marked
   ## Injector providers
 
@@ -524,20 +488,16 @@ code-example(format, language="html").
 
   We must register a service *provider* with the injector, or it won't know how to create the service.
 
-  Earlier we registered the `Logger` service in the `providers` array of the metadata for the `AppComponent` like this:
-// #enddocregion providers-1
-+makeExample('dependency-injection/ts/app/providers.component.ts','providers-logger')
-// #docregion providers-2
-- var lang = current.path[1]
-- var implements = lang == 'dart' ? 'implements' : 'looks and behaves like a '
-- var objectlike = lang == 'dart' ? '' : 'an object that behaves like '
-- var loggerlike = lang == 'dart' ? '' : 'We could provide a logger-like object. '
-:marked
-  The `providers` array appears to hold a service class.
-  In reality it holds an instance of the [Provider](../api/core/Provider-class.html) class that can create that service.
+  Earlier we registered the `Logger` service in the `providers` #{_array} of the metadata for the `AppComponent` like this:
 
++makeExample('dependency-injection/ts/app/providers.component.ts','providers-logger')
+
+- var implements = _docsFor == 'dart' ? 'implements' : 'looks and behaves like a '
+- var objectlike = _docsFor == 'dart' ? '' : 'an object that behaves like '
+- var loggerlike = _docsFor == 'dart' ? '' : 'We could provide a logger-like object. '
+:marked
   There are many ways to *provide* something that #{implements} `Logger`.
-  The `Logger` class itself is an obvious and natural provider &mdash; it has the right shape and it's designed to be created.
+  The `Logger` class itself is an obvious and natural provider.
   But it's not the only way.
 
   We can configure the injector with alternative providers that can deliver #{objectlike} a `Logger`.
@@ -546,80 +506,79 @@ code-example(format, language="html").
   Any of these approaches might be a good choice under the right circumstances.
 
   What matters is that the injector has a provider to go to when it needs a `Logger`.
-// #enddocregion providers-2
-// #docregion providers-provide-1
-:marked
-  <a id="provide"></a>
-// #enddocregion providers-provide-1
 
-// Don't mention provide function in Dart
+//- Dart limitation: the provide function isn't const so it cannot be used in an annotation.
+- var __andProvideFn = _docsFor == 'dart' ? '' : 'and <i>provide</i> function';
+#provide
 :marked
-  ### The *Provider* class and *provide* function
-// #docregion providers-provide-1-1
+  ### The *Provider* class !{__andProvideFn}
+
 :marked
-  We wrote the `providers` array like this:
-// #enddocregion providers-provide-1-1
+  We wrote the `providers` #{_array} like this:
+
 +makeExample('dependency-injection/ts/app/providers.component.ts','providers-1')
-// #docregion providers-provide-2
+
 :marked
   This is actually a short-hand expression for a provider registration that creates a new instance of the
   [Provider](../api/core/Provider-class.html) class.
-// #enddocregion providers-provide-2
+
 +makeExample('dependency-injection/ts/app/providers.component.ts','providers-2')
-// #docregion providers-provide-3
-// Skip for Dart, where the provide() function won't pass type checking.
-:marked
-  The [provide](../api/core/provide-function.html) function is the typical way to create a `Provider`:
-// #enddocregion providers-provide-3
-+makeExample('dependency-injection/ts/app/providers.component.ts','providers-3')
-// #docregion providers-provide-4-1
-// Modified for Dart.
 
-:marked
- Or we can declare a provider in an _object literal_ and skip the `provide` function.
-+makeExample('dependency-injection/ts/app/providers.component.ts','providers-3a')  
+block provider-function-etc
+  :marked
+    The [provide](../api/core/provide-function.html) function is the typical way 
+    to create a `Provider`:
 
-:marked
-  Pick the syntax that you prefer. They all do the same thing.
-  
-  In each syntax, we supply two types of values.
-// #enddocregion providers-provide-4-1
-// #docregion providers-provide-4-2
+  +makeExample('dependency-injection/ts/app/providers.component.ts','providers-3')
+
+  :marked
+   Or we can declare a provider in an _object literal_ and skip the `provide` function.
+
+  +makeExample('dependency-injection/ts/app/providers.component.ts','providers-3a')  
+
+  :marked
+    Pick the syntax that you prefer. They all do the same thing.
+
+block provider-ctor-args
+  - var _secondParam = 'provider definition object';
+  :marked
+    In each syntax, we supply two types of values.
+
+//- var _secondParam = _docsFor == 'dart' ? 'named parameter, such as <code>useClass</code>' : 'provider definition object';
 :marked
   The first is the [token](#token) that serves as the key for both locating a dependency value
   and registering the provider.
-// #enddocregion providers-provide-4-2
 
-// Dart is different here (uses an optional parameter)
+  The second is a !{_secondParam}, 
+  which we can think of as a *recipe* for creating the dependency value. 
+  There are many ways to create dependency values ... and many ways to write a recipe.
+
+#class-provider
 :marked
-  The second is a provider definition object,
-  which we can think of as a *recipe* for creating the dependency value.
-  There are many ways to create dependency values... and many ways to write a recipe.
-  
-// #docregion providers-alternative-1
-:marked
-  <a id="class-provider"></a>
   ### Alternative class providers
 
   Occasionally we'll ask a different class to provide the service.
   The following code tells the injector
   to return a `BetterLogger` when something asks for the `Logger`.
-// #enddocregion providers-alternative-1
+
 +makeExample('dependency-injection/ts/app/providers.component.ts','providers-4')
-// #docregion providers-alternative-2
+
+block dart-diff-const-metadata
+  //- N/A
+
 :marked
   ### Class provider with dependencies
   Maybe an `EvenBetterLogger` could display the user name in the log message.
   This logger gets the user from the injected `UserService`,
   which happens also to be injected at the application level.
-// #enddocregion providers-alternative-2
+
 +makeExample('dependency-injection/ts/app/providers.component.ts','EvenBetterLogger')(format='.')
-// #docregion providers-alternative-3
+
 :marked
   Configure it like we did `BetterLogger`.
-// #enddocregion providers-alternative-3
+
 +makeExample('dependency-injection/ts/app/providers.component.ts','providers-5')(format=".")
-// #docregion providers-aliased-1
+
 :marked
   ### Aliased class providers
 
@@ -636,30 +595,40 @@ code-example(format, language="html").
 
   We certainly do not want two different `NewLogger` instances in our app.
   Unfortunately, that's what we get if we try to alias `OldLogger` to `NewLogger` with `useClass`.
-// #enddocregion providers-aliased-1
+
 +makeExample('dependency-injection/ts/app/providers.component.ts','providers-6a')(format=".")
-// #docregion providers-aliased-2
+
 :marked
-  The solution: Alias with the `useExisting` option.
-// #enddocregion providers-aliased-2
-+makeExample('dependency-injection/ts/app/providers.component.ts','providers-6b')(format=".")
-// #docregion providers-value-1
-<a id="value-provider"></a>
+  The solution: alias with the `useExisting` option.
+
+- var stylePattern = { otl: /(useExisting: \w*)/gm };
++makeExample('dependency-injection/ts/app/providers.component.ts','providers-6b', '', stylePattern)(format=".")
+
+#value-provider
 :marked
   ### Value providers
-// #enddocregion providers-value-1
 
-// Typescript only
 :marked
   Sometimes it's easier to provide a ready-made object rather than ask the injector to create it from a class.
+
+block dart-diff-const-metadata-ctor
+  //- N/A
+
 +makeExample('dependency-injection/ts/app/providers.component.ts','silent-logger')(format=".")
+
 :marked
   Then we register a provider with the `useValue` option,
   which makes this object play the logger role.
-+makeExample('dependency-injection/ts/app/providers.component.ts','providers-7')(format=".")
 
-// #docregion providers-factory-1
-<a id="factory-provider"></a>
+- var stylePattern = { otl: /(useValue: \w*)/gm };
++makeExample('dependency-injection/ts/app/providers.component.ts','providers-7', '', stylePattern)(format=".")
+
+:marked
+  See more `useValue` examples in the
+  [Non-class dependencies](#non-class-dependencies) and
+  [OpaqueToken](#opaquetoken) sections.
+
+#factory-provider
 :marked
   ### Factory providers
 
@@ -672,7 +641,7 @@ code-example(format, language="html").
   This situation calls for a **factory provider**.
 
   Let's illustrate by adding a new business requirement:
-  The HeroService must hide *secret* heroes from normal users.
+  the HeroService must hide *secret* heroes from normal users.
   Only authorized users should see secret heroes.
 
   Like the `EvenBetterLogger`, the `HeroService` needs a fact about the user.
@@ -683,61 +652,61 @@ code-example(format, language="html").
   Unlike `EvenBetterLogger`, we can't inject the `UserService` into the `HeroService`.
   The `HeroService` won't have direct access to the user information to decide
   who is authorized and who is not.
+
 .l-sub-section
   :marked
     Why? We don't know either. Stuff like this happens.
+
 :marked
   Instead the `HeroService` constructor takes a boolean flag to control display of secret heroes.
-// #enddocregion providers-factory-1
+
 +makeExample('dependency-injection/ts/app/heroes/hero.service.ts','internals', 'app/heroes/hero.service.ts (excerpt)')(format='.')
-// #docregion providers-factory-2
+
 :marked
   We can inject the `Logger`, but we can't inject the  boolean `isAuthorized`.
   We'll have to take over the creation of new instances of this `HeroService` with a factory provider.
 
   A factory provider needs a factory function:
-// #enddocregion providers-factory-2
+
 +makeExample('dependency-injection/ts/app/heroes/hero.service.provider.ts','factory', 'app/heroes/hero.service.provider.ts (excerpt)')(format='.')
-// #docregion providers-factory-3
+
 :marked
   Although the `HeroService` has no access to the `UserService`, our factory function does.
 
   We inject both the `Logger` and the `UserService` into the factory provider and let the injector pass them along to the factory function:
-// #enddocregion providers-factory-3
+
 +makeExample('dependency-injection/ts/app/heroes/hero.service.provider.ts','provider', 'app/heroes/hero.service.provider.ts (excerpt)')(format='.')
-// #docregion providers-factory-4
+
 .l-sub-section
   :marked
     The `useFactory` field tells Angular that the provider is a factory function
     whose implementation is the `heroServiceFactory`.
 
-    The `deps` property is an array of [provider tokens](#token).
+    The `deps` property is #{_an} #{_array} of [provider tokens](#token).
     The `Logger` and `UserService` classes serve as tokens for their own class providers.
     The injector resolves these tokens and injects the corresponding services into the matching factory function parameters.
-// #enddocregion providers-factory-4
-// #docregion providers-factory-5
-- var lang = current.path[1]
-- var anexportedvar = lang == 'dart' ? 'a constant' : 'an exported variable'
-- var variable = lang == 'dart' ? 'constant' : 'variable'
+
+- var exportedvar = _docsFor == 'dart' ? 'constant' : 'exported variable'
+- var variable = _docsFor == 'dart' ? 'constant' : 'variable'
 :marked
-  Notice that we captured the factory provider in #{anexportedvar}, `heroServiceProvider`.
+  Notice that we captured the factory provider in #{_an} #{exportedvar}, `heroServiceProvider`.
   This extra step makes the factory provider reusable.
   We can register our `HeroService` with this #{variable} wherever we need it.
 
   In our sample, we need it only in the `HeroesComponent`,
-  where it replaces the previous `HeroService` registration in the metadata `providers` array.
+  where it replaces the previous `HeroService` registration in the metadata `providers` #{_array}.
   Here we see the new and the old implementation side-by-side:
-// #enddocregion providers-factory-5
+
+- var stylePattern = { otl: /(providers.*),$/gm };
 +makeTabs(
   `dependency-injection/ts/app/heroes/heroes.component.ts,
   dependency-injection/ts/app/heroes/heroes.component.1.ts`,
   null,
-  `app/heroes/heroes.component (v.3),
-  app/heroes/heroes.component (v.2)`)
+  `app/heroes/heroes.component (v3),
+  app/heroes/heroes.component (v2)`,
+  stylePattern)
 
-// #docregion tokens-1
-<a id="token"></a>
-.l-main-section
+.l-main-section#token
 :marked
   ## Dependency injection tokens
 
@@ -748,105 +717,117 @@ code-example(format, language="html").
   In all previous examples, the dependency value has been a class *instance*, and
   the class *type* served as its own lookup key.
   Here we get a `HeroService` directly from the injector by supplying the `HeroService` type as the token:
-// #enddocregion tokens-1
+
 +makeExample('dependency-injection/ts/app/injector.component.ts','get-hero-service')(format='.')
-// #docregion tokens-2
+
 :marked
   We have similar good fortune when we write a constructor that requires an injected class-based dependency.
   We define a constructor parameter with the `HeroService` class type,
   and Angular knows to inject the
   service associated with that `HeroService` class token:
-// #enddocregion tokens-2
-+makeExample('dependency-injection/ts/app/providers.component.ts','provider-8-ctor')(format=".")
-// #docregion tokens-3
+
++makeExample('dependency-injection/ts/app/heroes/hero-list.component.ts', 'ctor-signature')
+
 :marked
   This is especially convenient when we consider that most dependency values are provided by classes.
-// #enddocregion tokens-3
 
-// #docregion tokens-non-class-deps-1
-- var lang = current.path[1]
-- var objectexamples = lang == 'dart' ? 'a string or list literal, or maybe a function' : 'a string, a function, or an object'
-// Is function injection useful? Should we show it?
+//- TODO: if function injection is useful explain or illustrate why.
 :marked
   ### Non-class dependencies
+p
+  | What if the dependency value isn't a class? Sometimes the thing we want to inject is a 
+  block non-class-dep-eg
+    span string, function, or object.
+p
+  | Applications often define configuration objects with lots of small facts 
+  | (like the title of the application or the address of a web API endpoint)
+  block config-obj-maps
+    | &nbsp;but these configuration objects aren't always instances of a class.
+    | They can be object literals 
+  | &nbsp;such as this one:
 
-  What if the dependency value isn't a class?
-  Sometimes the thing we want to inject is #{objectexamples}.
-// #enddocregion tokens-non-class-deps-1
-
-// TS/JS only
-:marked
-  Applications often define configuration objects with lots of small facts like the title of the application or the address of a web API endpoint.
-  These configuration objects aren't always instances of a class. They tend to be object hashes like this one:
 +makeExample('dependency-injection/ts/app/app.config.ts','config','app/app-config.ts (excerpt)')(format='.')
 
-// TypeScript only?
 :marked
-  We'd like to make this `config` object available for injection.
+  We'd like to make this configuration object available for injection.
   We know we can register an object with a [value provider](#value-provider).
-  But what do we use for the token?
-  We don't have a class to serve as a token. There is no `Config` class.
 
-// Typescript only
-<a id="interface"></a>
-.l-sub-section
+block what-should-we-use-as-token
   :marked
-    ### TypeScript interfaces aren't valid tokens
+    But what should we use as the token?
+    We don't have a class to serve as a token.
+    There is no `AppConfig` class.
 
-    The `CONFIG` constant has an interface, `Config`. Unfortunately, we
-    cannot use a TypeScript interface as a token:
-  +makeExample('dependency-injection/ts/app/providers.component.ts','providers-9a-interface')(format=".")
-  +makeExample('dependency-injection/ts/app/providers.component.ts','provider-9a-ctor-interface')(format=".")
-  :marked
-    That seems strange if we're used to dependency injection in strongly typed languages, where
-    an interface is the preferred dependency lookup key.
+  .l-sub-section#interface
+    :marked
+      ### TypeScript interfaces aren't valid tokens
 
-    It's not Angular's fault. An interface is a TypeScript design-time artifact. JavaScript doesn't have interfaces.
-    The TypeScript interface disappears from the generated JavaScript.
-    There is no interface type information left for Angular to find at runtime.
-// end Typescript only
+      The `HERO_DI_CONFIG` constant has an interface, `AppConfig`. Unfortunately, we
+      cannot use a TypeScript interface as a token:
+    +makeExample('dependency-injection/ts/app/providers.component.ts','providers-9-interface')(format=".")
+    +makeExample('dependency-injection/ts/app/providers.component.ts','provider-9-ctor-interface')(format=".")
+    :marked
+      That seems strange if we're used to dependency injection in strongly typed languages, where
+      an interface is the preferred dependency lookup key.
 
-// #docregion tokens-opaque-1
-<a id="opaque-token"></a>
-- var lang = current.path[1]
-- var opaquetoken = lang == 'dart' ? '<code>OpaqueToken</code>' : '<a href="../api/core/OpaqueToken-class.html"><code>OpaqueToken</code></a>'
-h3 OpaqueToken
-p.
+      It's not Angular's fault. An interface is a TypeScript design-time artifact. JavaScript doesn't have interfaces.
+      The TypeScript interface disappears from the generated JavaScript.
+      There is no interface type information left for Angular to find at runtime.
+
+//- FIXME simplify once APIs are defined for Dart.
+- var opaquetoken = _docsFor == 'dart' ? '<b>OpaqueToken</b>' : '<a href="../api/core/OpaqueToken-class.html"><b>OpaqueToken</b></a>'
+:marked
+  ### OpaqueToken
+
   The solution is to define and use an !{opaquetoken}.
   The definition looks like this:
-// #enddocregion tokens-opaque-1
+
 +makeExample('dependency-injection/ts/app/app.config.ts','token')(format='.')
+
 :marked
   We register the dependency provider using the `OpaqueToken` object:
-+makeExample('dependency-injection/ts/app/providers.component.ts','providers-9b')(format=".")
-// #docregion tokens-opaque-2
-- var lang = current.path[1]
-- var decorated = lang == 'dart' ? 'annotated' : 'decorated'
-- var configuration = lang == 'dart' ? '' : 'configuration'
-:marked
-  Now we can inject the #{configuration} object into any constructor that needs it, with
-  the help of an `@Inject` #{decorator} that tells Angular how to find the #{configuration} dependency value.
-// #enddocregion tokens-opaque-2
-+makeExample('dependency-injection/ts/app/providers.component.ts','provider-9b-ctor')(format=".")
 
-// begin Typescript only
++makeExample('dependency-injection/ts/app/providers.component.ts','providers-9')(format=".")
+
+:marked
+  Now we can inject the configuration object into any constructor that needs it, with
+  the help of an `@Inject` #{_decorator}:
+
++makeExample('dependency-injection/ts/app/app.component.2.ts','ctor')(format=".")
+
+- var configType = _docsFor == 'dart' ? '<code>Map</code>' : '<code>AppConfig</code>'
 .l-sub-section
   :marked
     Although it plays no role in dependency injection,
-    the `Config` interface supports strong typing of the configuration object within the class.
-:marked
-// end typescript only
+    the !{configType} interface supports typing of the configuration object within the class.
 
-// Skip for Dart (we have another example)
-:marked
-  Or we can provide and inject the configuration object in our top-level `AppComponent`.
-+makeExample('dependency-injection/ts/app/app.component.ts','providers', 'app/app.component.ts (providers)')(format=".")
-+makeExample('dependency-injection/ts/app/app.component.ts','ctor', 'app/app.component.ts (constructor)')(format=".")
+block dart-map-alternative
+  :marked
+    Or we can provide and inject the configuration object in our top-level `AppComponent`.
 
-// #docregion summary
+  +makeExcerpt('app/app.component.ts','providers')
+
+#optional
+:marked
+  ## Optional dependencies
+
+  Our `HeroService` *requires* a `Logger`, but what if it could get by without
+  a logger?
+  As is illustrated next, we can indicate that to the dependency injection
+  framework by marking the constructor's argument as optional.
+
++ifDocsFor('ts')
+  +makeExample('dependency-injection/ts/app/providers.component.ts','import-optional', '')
++makeExample('dependency-injection/ts/app/providers.component.ts','provider-10-ctor', '')(format='.')
+
+:marked
+  Be prepared for a null logger. If we don't register one somewhere up the line,
+  the injector will inject `null`.
+
 .l-main-section
 :marked
   ## Summary
+
   We learned the basics of Angular dependency injection in this chapter.
   We can register various kinds of providers,
   and we know how to ask for an injected object (such as a service) by
@@ -856,20 +837,18 @@ p.
   We can learn more about its advanced features, beginning with its support for
   nested injectors, in the
   [Hierarchical Dependency Injection](hierarchical-dependency-injection.html) chapter.
-// #enddocregion summary
 
-// #docregion appendix-explicit-injector-1
-.l-main-section
-<a id="explicit-injector"></a>
+.l-main-section#explicit-injector
 :marked
-  ### Appendix: Working with injectors directly
-  We rarely work directly with an injector.
-  Here's an `InjectorComponent` that does.
-// #enddocregion appendix-explicit-injector-1
+  ## Appendix: Working with injectors directly
+
+  We rarely work directly with an injector, but
+  here's an `InjectorComponent` that does.
+
 +makeExample('dependency-injection/ts/app/injector.component.ts', 'injector', 'app/injector.component.ts')
-// #docregion appendix-explicit-injector-2
+
 :marked
-  The `Injector` is itself an injectable service.
+  An `Injector` is itself an injectable service.
 
   In this example, Angular injects the component's own `Injector` into the component's constructor.
   The component then asks the injected injector for the services it wants.
@@ -896,26 +875,24 @@ p.
 
     Framework developers may take this approach when they
     must acquire services generically and dynamically.
-// #enddocregion appendix-explicit-injector-2
 
-// TypeScript only? Unnecessary for Dart
-.l-main-section
-<a id="forward-ref"></a>
-:marked
-  ### Appendix: Why we recommend one class per file
-
-  Having multiple classes in the same file is confusing and best avoided.
-  Developers expect one class per file. Keep them happy.
-
-  If we scorn this advice and, say,
-  combine our `HeroService` class with the `HeroesComponent` in the same file,
-  **define the component last!**
-  If we define the component before the service,
-  we'll get a runtime null reference error.
-
-.l-sub-section
+block one-class-per-file-ts-tradeoffs
+  .l-main-section#one-class-per-file
   :marked
-    We actually can define the component first with the help of the `forwardRef()` method as explained
-    in this [blog post](http://blog.thoughtram.io/angular/2015/09/03/forward-references-in-angular-2.html).
-    But why flirt with trouble?
-    Avoid the problem altogether by defining components and services in separate files.
+    ## Appendix: Why we recommend one class per file
+
+    Having multiple classes in the same file is confusing and best avoided.
+    Developers expect one class per file. Keep them happy.
+
+    If we scorn this advice and, say,
+    combine our `HeroService` class with the `HeroesComponent` in the same file,
+    **define the component last!**
+    If we define the component before the service,
+    we'll get a runtime null reference error.
+
+  .l-sub-section
+    :marked
+      We actually can define the component first with the help of the `forwardRef()` method as explained
+      in this [blog post](http://blog.thoughtram.io/angular/2015/09/03/forward-references-in-angular-2.html).
+      But why flirt with trouble?
+      Avoid the problem altogether by defining components and services in separate files.


### PR DESCRIPTION
Contributes to #1508 and #1522.

- The main change on the TS side is to present best practices first, rather than presenting sample code and then saying "don't do that".
- The "Optional dependencies" section has been moved towards the end of the provider variants section and its sample code has been simplified.
- Reworked *_1.{ts,dart} sources so that main_1.{ts,dart} can actually be run, which helped find some bugs in those sources.
- Despite https://github.com/angular/angular/issues/8928, the Dart and TS OpaqueToken sections have been left in the prose. They can be revisited later.

Enhancements to the Dart code include:

- Added TestComponent.
- Added a provider sample that makes use of an app config Map (to match TS); also added the more Dart-like use of a custom app configuration class, whose instance is initialized via the cascade operator.
- Fixed Engine class hierarchy so that a single field named `cylinders` is defined (rather than two fields: one in the Engine supertype and one in the subclass), because having two fields is a bad design smell.
- Similarly, fixed Logger hierarchy so that a single field named `logs` is defined. Also made `logs` a read-only field.
- Reintroduced the SilentLogger().