### PR TITLE
chore(e2e): append errors after a failed spec

### DIFF
--- a/public/docs/_examples/_protractor/protractor.config.js
+++ b/public/docs/_examples/_protractor/protractor.config.js
@@ -157,6 +157,11 @@ function Reporter(options) {
 
     _currentSuite.specs.push(currentSpec);
     log(spec.status + ' - ' + spec.description);
+    if (spec.status === 'failed') {
+      spec.failedExpectations.forEach(function(err) {
+        log(err.message);
+      });
+    }
   };
 
   this.jasmineDone = function() {


### PR DESCRIPTION
My motivation for this is that travis doesn't give any information. It says `failed` and nothing else. We need some extra information to debug.

I can add this under a flag so it only do that on travis.