### PR TITLE
docs(upgrade): escape script tags

### DIFF
--- a/public/docs/ts/latest/guide/upgrade.jade
+++ b/public/docs/ts/latest/guide/upgrade.jade
@@ -96,7 +96,7 @@ include ../_util-fns
   up with a project structure with a large number of relatively small files. This is
   a much neater way to organize things than a small number of large files, but it
   doesn't work that well if you have to load all those files to the HTML page with
-  `<script>` tags. Especially when you also have to maintain those tags in the correct
+  &lt;script&gt; tags. Especially when you also have to maintain those tags in the correct
   order. That's why it's a good idea to start using a *module loader*.
 
   Using a module loader such as [SystemJS](https://github.com/systemjs/systemjs),
@@ -1171,7 +1171,7 @@ code-example(format="").
      version of the `Phone` Angular 2 service.
 
   Now that we are loading `phone.service.ts` through an import that is resolved
-  by SystemJS, we should **remove the `<script>` tag** for the service from `index.html`.
+  by SystemJS, we should **remove the &lt;script&gt; tag** for the service from `index.html`.
   This is something we'll do to all our components as we upgrade them. Simultaneously
   with the Angular 1 to 2 upgrade we're also migrating our code from scripts to modules.
 
@@ -1257,7 +1257,7 @@ code-example(format="").
   know that the return value of the downgrade method call will be something that can be
   used as a directive factory.
 
-  At this point, also remove the `<script>` tag for the phone list component from `index.html`.
+  At this point, also remove the &lt;script&gt; tag for the phone list component from `index.html`.
 
   Now we can start looking at our other component, which is the one for
   the phone details. Set the contents of `phone-detail.component.ts` as follows:
@@ -1314,7 +1314,7 @@ code-example(format="").
 +makeExample('upgrade-phonecat-2-hybrid/ts/app/main.ts', 'phone-detail', 'app/main.ts')
 
 :marked
-  We should now also remove the phone detail component `<script>` tag from `index.html`.
+  We should now also remove the phone detail component &lt;script&gt; tag from `index.html`.
 
   There's one additional step we need to take, which is to upgrade the
   `checkmark` filter that the template is using. We need an Angular 2
@@ -1330,7 +1330,7 @@ code-example(format="").
 
 :marked
   In the component we should now import and declare our newly created pipe (as well as
-  remove the filter `<script>` tag from `index.html`):
+  remove the filter &lt;script&gt; tag from `index.html`):
 
 +makeExample('upgrade-phonecat-2-hybrid/ts/app/phone-detail/phone-detail.component.ts', 'checkmark-pipe', 'app/phone-detail/phone-detail.component.ts')
 


### PR DESCRIPTION
Doesn't change the content, but .jade gets crazy if you put script tags like that and our tooling will start complaining about broken examples, but it is basically because they can't parse it anymore.

I had to remove the backstick tho.