### PR TITLE
chore: fix git-changed-examples

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1074,7 +1074,7 @@ function getChangedExamplesForCommit(commit, relativePath) {
   return commit.getDiff().then(function(diffList) {
     var filePaths = [];
     diffList.forEach(function (diff) {
-      diff.patches().forEach(function (patch) {
+      diff.patches().then(function (patch) {
         if (patch.isAdded() || patch.isModified) {
           var filePath = path.normalize(patch.newFile().path());
           var isExample = filePath.indexOf(relativePath) >= 0;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "minimatch": "^2.0.10",
     "mkdirp": "^0.5.1",
     "node-html-encoder": "0.0.2",
-    "nodegit": "0.5.0",
+    "nodegit": "0.13.0",
     "path": "^0.11.14",
     "prompt": "^0.2.14",
     "protractor": "^3.0.0",


### PR DESCRIPTION
A really needed version bump (with a fix on the task that was broken).

Now installing the deps (and travis) will take like 5 minutes less.