### PR TITLE
[WIP] chore(dart/api): enable API doc generation for Dart

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -496,7 +496,7 @@ gulp.task('build-docs', ['build-devguide-docs', 'build-api-docs', 'build-plunker
 // Stop zipping examples Feb 28, 2016
 //gulp.task('build-docs', ['build-devguide-docs', 'build-api-docs', 'build-plunkers', '_zip-examples']);
 
-gulp.task('build-api-docs', ['build-js-api-docs', 'build-ts-api-docs', 'build-dart-cheatsheet']);
+gulp.task('build-api-docs', ['build-js-api-docs', 'build-ts-api-docs', 'build-dart-api-docs']);
 
 gulp.task('build-devguide-docs', ['_shred-devguide-examples', '_shred-devguide-shared-jade'], function() {
   return buildShredMaps(true);
@@ -510,12 +510,12 @@ gulp.task('build-js-api-docs', ['_shred-api-examples'], function() {
   return buildApiDocs('js');
 });
 
-gulp.task('build-plunkers', ['_copy-example-boilerplate'], function() {
-  return plunkerBuilder.buildPlunkers(EXAMPLES_PATH, LIVE_EXAMPLES_PATH, { errFn: gutil.log });
+gulp.task('build-dart-api-docs', ['_shred-api-examples'], function() {
+  return buildApiDocs('dart');
 });
 
-gulp.task('build-dart-cheatsheet', [], function() {
-  return buildApiDocs('dart');
+gulp.task('build-plunkers', ['_copy-example-boilerplate'], function() {
+  return plunkerBuilder.buildPlunkers(EXAMPLES_PATH, LIVE_EXAMPLES_PATH, { errFn: gutil.log });
 });
 
 gulp.task('git-changed-examples', ['_shred-devguide-examples'], function(){
@@ -966,7 +966,7 @@ function apiSourceWatch(postBuildAction) {
     gutil.log('Event type: ' + event.event); // added, changed, or deleted
     gutil.log('Event path: ' + event.path); // The path of the modified file
 
-    return Q.all([buildApiDocs('ts'), buildApiDocs('js')]).then(postBuildAction);
+    return Q.all([buildApiDocs('ts'), buildApiDocs('js'), buildApiDocs('dart')]).then(postBuildAction);
   });
 }
 
@@ -1023,7 +1023,7 @@ function devGuideSharedJadeWatch(shredOptions, postShredAction) {
 // Generate the API docs for the specified language, if not specified then it defaults to ts
 function buildApiDocs(targetLanguage) {
   var ALLOWED_LANGUAGES = ['ts', 'js', 'dart'];
-  var GENERATE_API_LANGUAGES = ['ts', 'js'];
+  var GENERATE_API_LANGUAGES = ['ts', 'js', 'dart'];
   checkAngularProjectPath();
   try {
     // Build a specialized package to generate different versions of the API docs

--- a/public/docs/dart/latest/api/index.jade
+++ b/public/docs/dart/latest/api/index.jade
@@ -2,9 +2,9 @@
   > **Known issues:** Although this generated API reference displays Dart APIs
   and includes some Dart examples, the text reflects the TypeScript APIs. The
   angular.io issue tracker contains [all known issues][api-issues]; if you
-  notice others, please [report them][ngio-issues]. Thanks!
+  notice others, please [report them][new-issue]. Thanks!
 
-  [ngio-issues]: https://github.com/angular/angular.io/issues
-  [api-issues]: https://github.com/angular/angular.io/labels/api
+  [new-issue]: https://github.com/angular/angular.io/issues/new?labels=dart,api&title=%5BDart%5D%5BAPI%5D%20
+  [api-issues]: https://github.com/angular/angular.io/issues?q=label%3Aapi+label%3Adart
 
 api-list(src="api-list.json")

--- a/public/docs/dart/latest/api/index.jade
+++ b/public/docs/dart/latest/api/index.jade
@@ -1,10 +1,10 @@
-.l-main-section
-  h2 Beta
+:marked
+  > **Known issues:** Although this generated API reference displays Dart APIs
+  and includes some Dart examples, the text reflects the TypeScript APIs. The
+  angular.io issue tracker contains [all known issues][api-issues]; if you
+  notice others, please [report them][ngio-issues]. Thanks!
 
-  p.
-    The proposed Angular 2 API does not yet have Dart-specific documentation.
-    However, because the Dart and JavaScript APIs are generated from the same source,
-    you might find the JavaScript API docs helpful:
+  [ngio-issues]: https://github.com/angular/angular.io/issues
+  [api-issues]: https://github.com/angular/angular.io/labels/api
 
-  p.text-center
-    <b><a href="/docs/js/latest/api/">Angular 2 API Preview (JavaScript)</a></b>
+api-list(src="api-list.json")


### PR DESCRIPTION
This is a first step of many that will incrementally introduce proper API docs for Dart. This first step enables rudimentary API pages for Dart (generated from the TS source but that will be using Dart API examples).