### PR TITLE
docs(upgrade): restrict component directive to elements

### DIFF
--- a/public/docs/_examples/upgrade-adapter/ts/app/hero-detail.directive.ts
+++ b/public/docs/_examples/upgrade-adapter/ts/app/hero-detail.directive.ts
@@ -1,6 +1,7 @@
 // #docregion
 export function heroDetailDirective() {
   return {
+    restrict: 'E',
     scope: {},
     bindToController: {
       hero: '=',


### PR DESCRIPTION
The `heroDetail` directive is shown as an example of a component directive, such as those built using the `.component()` helper in v1.5+. In order for the directive to be functionaly equivalent with the component directive created with `.component`, it needs to be restricted to elements only. (If the `restrict` is omitted, it defaults to `'AE'`, which would also match attributes.)

/cc @teropa