### PR TITLE
chore: better protractor task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,6 +89,8 @@ var _exampleProtractorBoilerplateFiles = [
   'tsconfig.json'
 ];
 
+var _exampleConfigFilename = 'example-config.json';
+
 /**
  * Run Protractor End-to-End Specs for Doc Samples
  * Alias for 'run-e2e-tests'
@@ -221,17 +223,18 @@ function findAndRunE2eTests(filter, outputFile) {
 // fileName; then shut down the example.  All protractor output is appended
 // to the outputFile.
 function runE2eTsTests(appDir, outputFile) {
-  // spawn tasks to start the app
-  var appBuildSpawnInfo;
-  var appRunSpawnInfo;
-
-  if (fs.existsSync(path.join(appDir, 'angular-cli.json'))) {
-    appBuildSpawnInfo = spawnExt('npm', ['run', 'build:cli'], { cwd: appDir });
-    appRunSpawnInfo = spawnExt('npm', ['run', 'http-server:cli', '--', '-s'], { cwd: appDir });
-  } else {
-    appBuildSpawnInfo = spawnExt('npm',['run','tsc'], { cwd: appDir });
-    appRunSpawnInfo = spawnExt('npm',['run','http-server:e2e', '--', '-s' ], { cwd: appDir });
+  // Grab protractor configuration or defaults to systemjs config.
+  try {
+    var exampleConfig = fs.readJsonSync(`${appDir}/${_exampleConfigFilename}`);
+  } catch (e) {
+    exampleConfig = {
+      build: 'tsc',
+      run: 'http-server:e2e'
+    };
   }
+
+  var appBuildSpawnInfo = spawnExt('npm', ['run', exampleConfig.build], { cwd: appDir });
+  var appRunSpawnInfo = spawnExt('npm', ['run', exampleConfig.run, '--', '-s'], { cwd: appDir });
 
   return runProtractor(appBuildSpawnInfo.promise, appDir, appRunSpawnInfo, outputFile);
 }
@@ -841,7 +844,7 @@ function getTypingsPaths(basePath) {
 
 function getExamplePaths(basePath, includeBase) {
   // includeBase defaults to false
-  return getPaths(basePath, "example-config.json", includeBase)
+  return getPaths(basePath, _exampleConfigFilename, includeBase)
 }
 
 function getDartExampleWebPaths(basePath) {

--- a/public/docs/_examples/cli-quickstart/ts/.gitignore
+++ b/public/docs/_examples/cli-quickstart/ts/.gitignore
@@ -36,3 +36,4 @@ Thumbs.db
 !config/karma.conf.js
 !config/protractor.conf.js
 !src/typings.d.ts
+!src/tsconfig.json

--- a/public/docs/_examples/cli-quickstart/ts/example-config.json
+++ b/public/docs/_examples/cli-quickstart/ts/example-config.json
@@ -1,0 +1,4 @@
+{
+  "build": "build:cli",
+  "run": "http-server:cli"
+}

--- a/public/docs/_examples/cli-quickstart/ts/src/tsconfig.json
+++ b/public/docs/_examples/cli-quickstart/ts/src/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "declaration": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": false,
+    "outDir": "../dist/",
+    "rootDir": ".",
+    "sourceMap": true,
+    "target": "es5",
+    "inlineSources": true
+  },
+
+  "files": [
+    "main.ts",
+    "typings.d.ts"
+  ]
+}

--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -18,7 +18,7 @@
     "webdriver:update": "webdriver-manager update",
     "start:webpack": "webpack-dev-server --inline --progress --port 8080",
     "test:webpack": "karma start karma.webpack.conf.js",
-    "build:webpack": "rimraf dist && webpack --config config/webpack.prod.js --progress --profile --bail",
+    "build:webpack": "rimraf dist && webpack --config config/webpack.prod.js --bail",
     "build:cli": "ng build"
   },
   "keywords": [],

--- a/public/docs/_examples/webpack/e2e-spec.ts
+++ b/public/docs/_examples/webpack/e2e-spec.ts
@@ -1,0 +1,18 @@
+/// <reference path="../_protractor/e2e.d.ts" />
+describe('QuickStart E2E Tests', function () {
+
+  let expectedMsg = 'Hello from Angular 2 App with Webpack';
+
+  beforeEach(function () {
+    browser.get('');
+  });
+
+  it(`should display: ${expectedMsg}`, function () {
+    expect(element(by.css('h1')).getText()).toEqual(expectedMsg);
+  });
+
+  it('should display an image', function () {
+    expect(element(by.css('img')).isPresent()).toBe(true);
+  });
+
+});

--- a/public/docs/_examples/webpack/ts/example-config.json
+++ b/public/docs/_examples/webpack/ts/example-config.json
@@ -1,0 +1,4 @@
+{
+  "build": "build:webpack",
+  "run": "http-server:cli"
+}


### PR DESCRIPTION
Let's use the `example-config.json` to contain options in how to run protractor as well.

Empty file === normal systemjs config

Then we can configure it to use the Cli:

```
{
  "build": "build:cli",
  "run": "http-server:cli"
}
```

And for webpack (this is new, I created tests for it too):

```
{
  "build": "build:webpack",
  "run": "http-server:cli"
}
```

I will take this PR to debug the webdriver issue that happens on travis.