### PR TITLE
chore(dart pubspec.yaml): consistent baseline

### DIFF
--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/component-styles/dart/pubspec.yaml
+++ b/public/docs/_examples/component-styles/dart/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/dependency-injection/dart/pubspec.yaml
@@ -10,8 +10,10 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes: 'package:angular2/common.dart#COMMON_PIPES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter
 dev_dependencies:

--- a/public/docs/_examples/displaying-data/dart/pubspec.yaml
+++ b/public/docs/_examples/displaying-data/dart/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -11,7 +11,9 @@ dependencies:
 transformers:
 - angular2:
     platform_directives:
-    - 'package:angular2/common.dart#CORE_DIRECTIVES'
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
     - 'package:angular2/common.dart#FORM_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
 transformers:
 - angular2:
     platform_directives:
-    - 'package:angular2/common.dart#CORE_DIRECTIVES'
-    - 'package:angular2/common.dart#FORM_DIRECTIVES'
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -10,7 +10,9 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes: 'package:angular2/common.dart#COMMON_PIPES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/quickstart/dart/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/pubspec.yaml
@@ -1,6 +1,4 @@
-# #docplaster
 # #docregion
-# #docregion no-rewriter
 name: angular2_getting_started
 description: QuickStart
 version: 0.0.1
@@ -9,11 +7,12 @@ environment:
 dependencies:
   angular2: 2.0.0-beta.17
   browser: ^0.10.0
-# #enddocregion no-rewriter
   dart_to_js_script_rewriter: ^1.0.1
-# #docregion no-rewriter
 transformers:
 - angular2:
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
-# #enddocregion no-rewriter
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/server-communication/dart/pubspec.yaml
+++ b/public/docs/_examples/server-communication/dart/pubspec.yaml
@@ -16,10 +16,10 @@ dependencies:
 transformers:
 - angular2:
     platform_directives:
-    - 'package:angular2/common.dart#CORE_DIRECTIVES'
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
     platform_pipes:
     - 'package:angular2/common.dart#COMMON_PIPES'
-    entry_points: 'web/main.dart'
+    entry_points: web/main.dart
     resolved_identifiers:
         BrowserClient: 'package:http/browser_client.dart'
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -10,9 +10,10 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_pipes: 'package:angular2/common.dart#COMMON_PIPES'
     platform_directives:
     - 'package:angular2/common.dart#COMMON_DIRECTIVES'
     - 'package:angular2/common.dart#FORM_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/toh-1/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-1/dart/pubspec.yaml
@@ -1,5 +1,6 @@
 # #docregion
 name: angular2_tour_of_heroes
+description: Tour of Heroes
 version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
@@ -10,7 +11,8 @@ dependencies:
 transformers:
 - angular2:
     platform_directives:
-    - package:angular2/common.dart#COMMON_DIRECTIVES
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
     platform_pipes:
-     - package:angular2/common.dart#COMMON_PIPES
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/public/docs/_examples/toh-2/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-2/dart/pubspec.yaml
@@ -1,4 +1,6 @@
+# #docregion
 name: angular2_tour_of_heroes
+description: Tour of Heroes
 version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
@@ -9,7 +11,8 @@ dependencies:
 transformers:
 - angular2:
     platform_directives:
-    - package:angular2/common.dart#COMMON_DIRECTIVES
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
     platform_pipes:
-     - package:angular2/common.dart#COMMON_PIPES
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/public/docs/_examples/toh-3/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-3/dart/pubspec.yaml
@@ -1,4 +1,6 @@
+# #docregion
 name: angular2_tour_of_heroes
+description: Tour of Heroes
 version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
@@ -9,7 +11,8 @@ dependencies:
 transformers:
 - angular2:
     platform_directives:
-    - package:angular2/common.dart#COMMON_DIRECTIVES
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
     platform_pipes:
-     - package:angular2/common.dart#COMMON_PIPES
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/public/docs/_examples/toh-4/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-4/dart/pubspec.yaml
@@ -1,4 +1,6 @@
+# #docregion
 name: angular2_tour_of_heroes
+description: Tour of Heroes
 version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
@@ -9,7 +11,8 @@ dependencies:
 transformers:
 - angular2:
     platform_directives:
-    - package:angular2/common.dart#COMMON_DIRECTIVES
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
     platform_pipes:
-     - package:angular2/common.dart#COMMON_PIPES
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/public/docs/_examples/toh-5/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-5/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 # #docregion
 name: angular2_tour_of_heroes
-description: Tour of Heroes 5
+description: Tour of Heroes
 version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
@@ -11,8 +11,8 @@ dependencies:
 transformers:
 - angular2:
     platform_directives:
-    - package:angular2/common.dart#COMMON_DIRECTIVES
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
     platform_pipes:
-     - package:angular2/common.dart#COMMON_PIPES
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives: 'package:angular2/common.dart#CORE_DIRECTIVES'
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter


### PR DESCRIPTION
Make all `pubspec.yaml` files consistent with the [stagehand](http://stagehand.pub/) `web-angular` default.

Fixes #1642.