### PR TITLE
api-builder: fix jade formatting of indented constructor code

### DIFF
--- a/tools/api-builder/angular.io-package/templates/class.template.html
+++ b/tools/api-builder/angular.io-package/templates/class.template.html
@@ -33,7 +33,8 @@ div(layout="row" layout-xs="column" class="ng-cloak")
       pre(class="prettyprint no-bg-with-indent")
         a(class="code-anchor" href="#constructor")
           code(class="code-background api-doc-code") {$ doc.constructorDoc.name $}
-        code(class="api-doc-code") {$ paramList(doc.constructorDoc.parameters) | indent(8, false) | trim $}
+        code(class="api-doc-code").
+          {$ paramList(doc.constructorDoc.parameters) | indent(8, false) | trim $}
     {% endif %}
     {% if doc.members.length %}
     div(layout="column")


### PR DESCRIPTION
Closes #1662