### PR TITLE
example(dart/quickstart): use <script defer> rather than async

### DIFF
--- a/public/docs/_examples/quickstart/dart/web/index.html
+++ b/public/docs/_examples/quickstart/dart/web/index.html
@@ -6,8 +6,8 @@
     <link rel="stylesheet" href="styles.css">
 
     <!-- #docregion loaddart -->
-    <script async src="main.dart" type="application/dart"></script>
-    <script async src="packages/browser/dart.js"></script>
+    <script defer src="main.dart" type="application/dart"></script>
+    <script defer src="packages/browser/dart.js"></script>
     <!-- #enddocregion loaddart -->
   </head>
   <body>


### PR DESCRIPTION
See https://github.com/dart-lang/www.dartlang.org/issues/1526.