### PR TITLE
docs(util-fns): generalize getExampleName()

### DIFF
--- a/public/_includes/_util-fns.jade
+++ b/public/_includes/_util-fns.jade
@@ -100,10 +100,11 @@ mixin makeExcerpt(_filePath, _region, _title, stylePatterns)
   - if (title) title = title + ' (' + excerpt + ')';
   +makeExample(filePath, region, title, stylePatterns)(format='.')
 
-//- Extract the doc example name from `current`.
+//- Get the doc example name either from `_example` if set, or
+//- extract the example name from `current`.
 - var getExampleName = function() {
 -   var dir = current.path[current.path.length - 1];
--   return dir == 'latest' ? current.source : dir;
+-   return _example ? _example : dir == 'latest' ? current.source : dir;
 - };
 
 mixin makeTabs(filePaths, regions, tabNames, stylePatterns)


### PR DESCRIPTION
For some chapters the Jade source file name (e.g., `toh-pt6.jade`) does not match with the example directory name (`toh-6`). For such cases, we can now set `_example` to, say `toh-6`; `getExampleName()` will now use `_example` if set, otherwise determine the name from `current` as it did before.