### PR TITLE
api-builder: ignore additional platform browser private exports

### DIFF
--- a/tools/api-builder/angular.io-package/index.js
+++ b/tools/api-builder/angular.io-package/index.js
@@ -51,6 +51,9 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
     '___esModule',
     '___core_private_types__',
     '___platform_browser_private__',
+    '___platform_browser_private_types__',
+    '___platform_browser_dynamic_private__',
+    '___platform_browser_dynamic_private_types__',
     '___compiler_private__',
     '__core_private__',
     '___core_private__'


### PR DESCRIPTION
These exports should not be part of the docs and
cause the doc-gen to fail.

Closes #1667