### PR TITLE
chore: add async/await support to e2e tests

### DIFF
--- a/public/docs/_examples/_protractor/tsconfig.json
+++ b/public/docs/_examples/_protractor/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/public/docs/_examples/_protractor/typings.json
+++ b/public/docs/_examples/_protractor/typings.json
@@ -1,7 +1,6 @@
 {
   "globalDependencies": {
     "angular-protractor": "registry:dt/angular-protractor#1.5.0+20160425143459",
-    "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
     "node": "registry:dt/node#4.0.0+20160509154515",
     "selenium-webdriver": "registry:dt/selenium-webdriver#2.44.0+20160317120654"

--- a/public/docs/_examples/animations/e2e-spec.ts
+++ b/public/docs/_examples/animations/e2e-spec.ts
@@ -1,4 +1,5 @@
 /// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 /**
  * The tests here basically just checking that the end styles
  * of each animation are in effect.
@@ -274,7 +275,9 @@ describe('Animation Tests', () => {
     return protractor.promise.all([
       getBoundingClientWidth(el),
       getOffsetWidth(el)
-    ]).then(function([clientWidth, offsetWidth]) {
+    ]).then(function(promiseResolutions) {
+      let clientWidth = promiseResolutions[0];
+      let offsetWidth = promiseResolutions[1];
       return clientWidth / offsetWidth;
     });
   }

--- a/public/docs/_examples/architecture/e2e-spec.ts
+++ b/public/docs/_examples/architecture/e2e-spec.ts
@@ -1,4 +1,5 @@
 /// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Architecture', function () {
 
   let title = 'Hero List';

--- a/public/docs/_examples/attribute-directives/e2e-spec.ts
+++ b/public/docs/_examples/attribute-directives/e2e-spec.ts
@@ -1,4 +1,5 @@
 /// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Attribute directives', function () {
 
   let _title = 'My First Attribute Directive';

--- a/public/docs/_examples/cb-a1-a2-quick-reference/e2e-spec.ts
+++ b/public/docs/_examples/cb-a1-a2-quick-reference/e2e-spec.ts
@@ -1,4 +1,5 @@
 /// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Angular 1 to 2 Quick Reference Tests', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/cb-component-communication/e2e-spec.ts
+++ b/public/docs/_examples/cb-component-communication/e2e-spec.ts
@@ -1,4 +1,5 @@
 /// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Component Communication Cookbook Tests', function () {
 
   // Note: '?e2e' which app can read to know it is running in protractor

--- a/public/docs/_examples/cb-component-relative-paths/e2e-spec.ts
+++ b/public/docs/_examples/cb-component-relative-paths/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Cookbook: component-relative paths', function () {
 
   interface Page {

--- a/public/docs/_examples/cb-dependency-injection/e2e-spec.ts
+++ b/public/docs/_examples/cb-dependency-injection/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Dependency Injection Cookbook', function () {
 
     beforeAll(function () {

--- a/public/docs/_examples/cb-dynamic-form/e2e-spec.ts
+++ b/public/docs/_examples/cb-dynamic-form/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 /* tslint:disable:quotemark */
 describe('Dynamic Form', function () {
 

--- a/public/docs/_examples/cb-set-document-title/e2e-spec.ts
+++ b/public/docs/_examples/cb-set-document-title/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 // gulp run-e2e-tests --filter=cb-set-document-title
 describe('Set Document Title', function () {
 

--- a/public/docs/_examples/cb-ts-to-js/e2e-spec.ts
+++ b/public/docs/_examples/cb-ts-to-js/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('TypeScript to Javascript tests', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/cli-quickstart/e2e-spec.ts
+++ b/public/docs/_examples/cli-quickstart/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('cli-quickstart App', () => {
   beforeEach(() => {
     return browser.get('/');

--- a/public/docs/_examples/component-styles/e2e-spec.ts
+++ b/public/docs/_examples/component-styles/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Component Style Tests', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/dependency-injection/e2e-spec.ts
+++ b/public/docs/_examples/dependency-injection/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Dependency Injection Tests', function () {
 
 

--- a/public/docs/_examples/displaying-data/e2e-spec.ts
+++ b/public/docs/_examples/displaying-data/e2e-spec.ts
@@ -1,4 +1,5 @@
 /// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Displaying Data Tests', function () {
   let _title = 'Tour of Heroes';
   let _defaultHero = 'Windstorm';

--- a/public/docs/_examples/forms/e2e-spec.ts
+++ b/public/docs/_examples/forms/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describeIf(browser.appIsTs || browser.appIsJs, 'Forms Tests', function () {
 
   beforeEach(function () {

--- a/public/docs/_examples/hierarchical-dependency-injection/e2e-spec.ts
+++ b/public/docs/_examples/hierarchical-dependency-injection/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Hierarchical dependency injection', function () {
 
   beforeEach(function () {

--- a/public/docs/_examples/homepage-hello-world/e2e-spec.ts
+++ b/public/docs/_examples/homepage-hello-world/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Homepage Hello World', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/homepage-tabs/e2e-spec.ts
+++ b/public/docs/_examples/homepage-tabs/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Homepage Tabs', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/homepage-todo/e2e-spec.ts
+++ b/public/docs/_examples/homepage-todo/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Homepage Todo', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/lifecycle-hooks/e2e-spec.ts
+++ b/public/docs/_examples/lifecycle-hooks/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Lifecycle hooks', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/pipes/e2e-spec.ts
+++ b/public/docs/_examples/pipes/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Pipes', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/quickstart/e2e-spec.ts
+++ b/public/docs/_examples/quickstart/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('QuickStart E2E Tests', function () {
 
   let expectedMsg = 'My First Angular 2 App';

--- a/public/docs/_examples/router-deprecated/e2e-spec.ts
+++ b/public/docs/_examples/router-deprecated/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Router', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/router/e2e-spec.ts
+++ b/public/docs/_examples/router/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Router', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/server-communication/e2e-spec.ts
+++ b/public/docs/_examples/server-communication/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Server Communication', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/structural-directives/e2e-spec.ts
+++ b/public/docs/_examples/structural-directives/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Structural Directives', function () {
 
   // tests interact - so we need beforeEach instead of beforeAll

--- a/public/docs/_examples/style-guide/e2e-spec.ts
+++ b/public/docs/_examples/style-guide/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Style Guide', function () {
   it('01-01', function () {
     browser.get('#/01-01');

--- a/public/docs/_examples/styleguide/e2e-spec.ts
+++ b/public/docs/_examples/styleguide/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Documentation StyleGuide E2E Tests', function() {
 
   let expectedMsg = 'My First Angular 2 App';

--- a/public/docs/_examples/template-syntax/e2e-spec.ts
+++ b/public/docs/_examples/template-syntax/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 // Not yet complete
 describe('Template Syntax', function () {
 

--- a/public/docs/_examples/toh-1/e2e-spec.ts
+++ b/public/docs/_examples/toh-1/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Tutorial part 1', () => {
 
   let expectedH1 = 'Tour of Heroes';

--- a/public/docs/_examples/toh-5/e2e-spec.ts
+++ b/public/docs/_examples/toh-5/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Tutorial', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/toh-6/e2e-spec.ts
+++ b/public/docs/_examples/toh-6/e2e-spec.ts
@@ -1,4 +1,5 @@
 /// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('TOH Http Chapter', function () {
 
   beforeEach(function () {

--- a/public/docs/_examples/upgrade-adapter/e2e-spec.ts
+++ b/public/docs/_examples/upgrade-adapter/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('Upgrade Tests', function () {
 
   // Protractor doesn't support the UpgradeAdapter's asynchronous

--- a/public/docs/_examples/upgrade-phonecat-1-typescript/e2e-spec.ts
+++ b/public/docs/_examples/upgrade-phonecat-1-typescript/e2e-spec.ts
@@ -1,4 +1,4 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
 'use strict';
 
 // Angular E2E Testing Guide:

--- a/public/docs/_examples/upgrade-phonecat-2-hybrid/e2e-spec.ts
+++ b/public/docs/_examples/upgrade-phonecat-2-hybrid/e2e-spec.ts
@@ -1,4 +1,4 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
 'use strict';
 
 // Angular E2E Testing Guide:

--- a/public/docs/_examples/upgrade-phonecat-3-final/e2e-spec.ts
+++ b/public/docs/_examples/upgrade-phonecat-3-final/e2e-spec.ts
@@ -1,4 +1,4 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
 'use strict';
 
 // Angular E2E Testing Guide:

--- a/public/docs/_examples/user-input/e2e-spec.ts
+++ b/public/docs/_examples/user-input/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('User Input Tests', function () {
 
   beforeAll(function () {

--- a/public/docs/_examples/webpack/e2e-spec.ts
+++ b/public/docs/_examples/webpack/e2e-spec.ts
@@ -1,4 +1,5 @@
-/// <reference path="../_protractor/e2e.d.ts" />
+/// <reference path='../_protractor/e2e.d.ts' />
+'use strict';
 describe('QuickStart E2E Tests', function () {
 
   let expectedMsg = 'Hello from Angular 2 App with Webpack';


### PR DESCRIPTION
This PR adds support for async/await usage in our e2e tests. 

To use it you will need to:
- run `gulp add-example-boilerplate` to correctly propagate the `tsconfig.json` changes to all the existing `e2e-spec.ts` folders
- delete `public/docs/_examples/_protractor/typings/` and run `npm run postinstall` on `public/docs/_examples/_protractor`

/cc @chalin @Foxandxss @wardbell 