### PR TITLE
fix(e2e): update broken node typings

### DIFF
--- a/public/docs/_examples/_protractor/typings.json
+++ b/public/docs/_examples/_protractor/typings.json
@@ -3,7 +3,7 @@
     "angular-protractor": "registry:dt/angular-protractor#1.5.0+20160425143459",
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
-    "node": "registry:dt/node#4.0.0+20160509154515",
+    "node": "registry:dt/node#6.0.0+20160613154055",
     "selenium-webdriver": "registry:dt/selenium-webdriver#2.44.0+20160317120654"
   }
 }

--- a/public/docs/_examples/quickstart/ts/typings.1.json
+++ b/public/docs/_examples/quickstart/ts/typings.1.json
@@ -2,6 +2,6 @@
   "globalDependencies": {
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
-    "node": "registry:dt/node#4.0.0+20160509154515"
+    "node": "registry:dt/node#6.0.0+20160613154055"
   }
 }

--- a/public/docs/_examples/typings.json
+++ b/public/docs/_examples/typings.json
@@ -2,6 +2,6 @@
   "globalDependencies": {
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
-    "node": "registry:dt/node#6.0.0+20160608110640"
+    "node": "registry:dt/node#6.0.0+20160613154055"
   }
 }

--- a/public/docs/_examples/webpack/ts/typings.1.json
+++ b/public/docs/_examples/webpack/ts/typings.1.json
@@ -2,6 +2,6 @@
   "globalDependencies": {
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
-    "node": "registry:dt/node#4.0.0+20160509154515"
+    "node": "registry:dt/node#6.0.0+20160613154055"
   }
 }


### PR DESCRIPTION
Current typings were causing the following error:

```
[13:06:52] [13:06:52] E/launcher - Error: TSError: ⨯ Unable to compile TypeScript
typings\globals\node\index.d.ts (415,11): Interface 'NodeBuffer' incorrectly extends interface 'Uint8Array'.
  Types of property 'fill' are incompatible.
```

/cc @Foxandxss 