### PR TITLE
docs: Change LoggerService to Logger service

### DIFF
--- a/public/docs/ts/latest/guide/architecture.jade
+++ b/public/docs/ts/latest/guide/architecture.jade
@@ -402,7 +402,7 @@ figure
 +makeExample('architecture/ts/app/logger.service.ts', 'class', 'app/logger.service.ts (class only)')(format=".")
 :marked
   Here's a `HeroService` that fetches heroes and returns them in a resolved [promise](http://exploringjs.com/es6/ch_promises.html). 
-  The `HeroService` depends on the `LoggerService` and another `BackendService` that handles the server communication grunt work.
+  The `HeroService` depends on the `Logger` service and another `BackendService` that handles the server communication grunt work.
 +makeExample('architecture/ts/app/hero.service.ts', 'class', 'app/hero.service.ts (class only)')(format=".")
 :marked
   Services are everywhere. 


### PR DESCRIPTION
`LoggerService` implies that it will be written as such in the code, yet the hero.service.ts example has a service simply called `Logger` (which matches the Style Guide).