### PR TITLE
docs(testing): refer to 'lite-server' instead of 'live-server'.

### DIFF
--- a/public/docs/_examples/testing/ts/liteserver-test-config.json
+++ b/public/docs/_examples/testing/ts/liteserver-test-config.json
@@ -1,0 +1,3 @@
+{
+    "startPath": "unit-tests.html"
+}

--- a/public/docs/ts/latest/testing/first-app-tests.jade
+++ b/public/docs/ts/latest/testing/first-app-tests.jade
@@ -15,7 +15,7 @@ include ../_util-fns
     We're also assuming that you're already comfortable with basic Angular 2 concepts and the tools
     we introduced in the [QuickStart](../quickstart.html) and
     the [Tour of Heroes](../tutorial/) tutorial
-    such as <code>npm</code>, <code>gulp</code>, and <code>live-server</code>.
+    such as <code>npm</code>, <code>gulp</code>, and <code>lite-server</code>.
 
 .l-main-section
 :marked
@@ -41,16 +41,26 @@ pre.prettyprint.lang-bash
 
 .alert.is-important Be sure to install <code>jasmine-core</code> , not <code>jasmine</code>!
 
+.l-main-section
+:marked
+  ## Configure `lite-server` for serving our test harness
+
+:marked
+  First create a configuration file for serving up our test harness through `lite-server`.
+
++makeExample('testing/ts/liteserver-test-config.json', '', 'liteserver-test-config.json')
+
 :marked
   Let's make one more change to the `package.json` script commands.
 
-  **Open the `package.json` ** and scroll to the `scripts` node and add in a new one:
+  **Open the `package.json` ** and scroll to the `scripts` node and add the following two entries:
 
 code-example(format="").
-  "test": "live-server --open=unit-tests.html"
+  "lite-server-test": "lite-server --config=liteserver-test-config.json",
+  "test": "tsc && concurrently \"npm run tsc:w\" \"npm run lite-server-test\" "
 
 :marked
-  That command will launch `live-server` and open a browser to the `unit-tests.html` page we just wrote.
+  The `npm test` command will launch `lite-server` and open a browser to the `unit-tests.html` page we just wrote. It will also take care of recompiling your source code and reloading your browser after any change.
 
 .l-main-section
 :marked
@@ -127,7 +137,7 @@ code-example(format="").
 :marked
   ### Run and Fail
 
-  Look over at the browser (live-server will have reloaded it).  The browser displays
+  Look over at the browser (lite-server will have reloaded it).  The browser displays
 
 figure.image-display
   img(src='/resources/images/devguide/first-app-tests/Jasmine-not-running-tests.png' style="width:400px;" alt="Jasmine not running any tests")

--- a/public/docs/ts/latest/testing/jasmine-testing-101.jade
+++ b/public/docs/ts/latest/testing/jasmine-testing-101.jade
@@ -113,7 +113,7 @@ pre.prettyprint.lang-bash
 
   We’ll be evolving these tests rapidly and it would be nice to have the browser refresh automatically as we make changes and recompile.
 
-  Let’s launch with **live-server** in a second terminal window:
+  Let’s launch with **lite-server** in a second terminal window:
 
 pre.prettyprint.lang-bash
   code npm start

--- a/public/docs/ts/latest/testing/testing-an-angular-pipe.jade
+++ b/public/docs/ts/latest/testing/testing-an-angular-pipe.jade
@@ -48,7 +48,7 @@ include ../_util-fns
     We're also assuming that you're already comfortable with basic Angular 2 concepts and the tools
     we introduced in the [QuickStart](../quickstart.html) and
     the [Tour of Heroes](../tutorial/) tutorial
-    such as <code>npm</code>, <code>gulp</code>, and <code>live-server</code>.
+    such as <code>npm</code>, <code>gulp</code>, and <code>lite-server</code>.
 
 :marked
   ## Add another spec file


### PR DESCRIPTION
Since the QuickStart uses 'lite-server', the 'lite-server' module should also be used in the testing guide.