### PR TITLE
chore(install): put all install commands into a single script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ before_install:
 before_script:
   - sh -e /etc/init.d/xvfb start
 install:
-  - npm install --no-optional
-  - npm install --prefix public/docs/_examples
-  - npm install --prefix public/docs/_examples/_protractor
-  - npm run webdriver:update --prefix public/docs/_examples/_protractor
-  - gulp add-example-boilerplate
+  - ./script/install.sh
 script:
   - gulp $SCRIPT

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex -o pipefail
+
+npm install --no-optional
+(cd public/docs/_examples && npm install)
+(cd public/docs/_examples/_protractor && npm install)
+npm run webdriver:update --prefix public/docs/_examples/_protractor
+gulp add-example-boilerplate


### PR DESCRIPTION
This PR makes it easier to get a local repo back into a sane state after a change in typings (something that a few of us have had some challenges with recently :). Specifically, this PR addresses two things.

(1) On June 18th, @filipesilva made the following comment on the docs-authoring slack channel:
> in regards to setup, if you're ever uncertain just check `travis.yml`. It's the definite resource

I agree with this approach of relying on the travis config file. Furthermore, I think that it should be easy to manually create a clean repo (when cloning afresh isn't an option). This PR puts the 5 travis install commands into a single script: `./script/install.sh`. Note that the `angular` team has a similarly named script that they also use for travis installs.

With this PR, one can get a refreshed repo by issuing the following commands from the repo dir:
```bash
git clean -xdf
./script/install.sh
```

(2) I changed two of the install commands as follows:
```diff
  npm install --no-optional
- npm install --prefix public/docs/_examples
- npm install --prefix public/docs/_examples/_protractor
+ (cd public/docs/_examples && npm install)
+ (cd public/docs/_examples/_protractor && npm install)
  npm run webdriver:update --prefix public/docs/_examples/_protractor
  gulp add-example-boilerplate
```

While travis builds seemed to be working, I'm a bit puzzled as to why the two `npm install --prefix foo` commands gave the desired effect. It is my understanding that such invocations of `npm install` would use the top-level `package.json` file (which I don't think is what we wanted). Anyhow, these two `npm install --prefix foo` commands **did not** work when run on a local repo. The adjusted commands work both locally and for travis.