### PR TITLE
chore: lock router-deprecated to rc.2 for plunkers

### DIFF
--- a/public/docs/_examples/systemjs.config.plunker.js
+++ b/public/docs/_examples/systemjs.config.plunker.js
@@ -8,6 +8,7 @@
   var ngVer = '@2.0.0-rc.3'; // lock in the angular package version; do not let it float to current!
   var routerVer = '@3.0.0-alpha.7'; // lock router version
   var formsVer = '@0.1.1'; // lock forms version
+  var routerDeprecatedVer = '@2.0.0-rc.2'; // temporarily until we update all the guides
 
   //map tells the System loader where to look for things
   var  map = {
@@ -16,6 +17,7 @@
     '@angular':                   'https://npmcdn.com/@angular', // sufficient if we didn't pin the version
     '@angular/router':            'https://npmcdn.com/@angular/router' + routerVer,
     '@angular/forms':             'https://npmcdn.com/@angular/forms' + formsVer,
+    '@angular/router-deprecated': 'https://npmcdn.com/@angular/router-deprecated' + routerDeprecatedVer,
     'angular2-in-memory-web-api': 'https://npmcdn.com/angular2-in-memory-web-api', // get latest
     'rxjs':                       'https://npmcdn.com/rxjs@5.0.0-beta.6',
     'ts':                         'https://npmcdn.com/plugin-typescript@4.0.10/lib/plugin.js',
@@ -36,7 +38,6 @@
     'http',
     'platform-browser',
     'platform-browser-dynamic',
-    'router-deprecated',
     'upgrade',
   ];
 
@@ -61,6 +62,9 @@
 
   // Forms not on rc yet
   packages['@angular/forms'] = { main: 'index.js', defaultExtension: 'js' };
+
+  // Temporarily until we update the guides
+  packages['@angular/router-deprecated'] = { main: '/bundles/router-deprecated' + '.umd.js', defaultExtension: 'js' };
 
   var config = {
     // DEMO ONLY! REAL CODE SHOULD NOT TRANSPILE IN THE BROWSER


### PR DESCRIPTION
This will lock the router-deprecated on plunkers. All plunkers using the old router are broken right now, so until we can safely update all the guides, this is needed.

@naomiblack could you please test, merge and push live?