### PR TITLE
docs(guide/lifecycle-hooks): follow-up to #1654

### DIFF
--- a/public/docs/_examples/lifecycle-hooks/dart/lib/after_content_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/after_content_component.dart
@@ -20,7 +20,7 @@ class ChildComponent {
       <div>-- projected content begins --</div>
         <ng-content></ng-content>
       <div>-- projected content ends --</div>
-      <p *ngIf="comment != null" class="comment">{{comment}}</p>
+      <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>
     '''
 // #enddocregion template
     )

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/after_view_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/after_view_component.dart
@@ -22,16 +22,16 @@ class ChildViewComponent {
     <div>-- child view begins --</div>
       <my-child></my-child>
     <div>-- child view ends --</div>
-    <p *ngIf="comment != null" class="comment">{{comment}}</p>''',
+    <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>''',
 // #enddocregion template
   directives: const [ChildViewComponent])
 // #docregion hooks
 class AfterViewComponent implements AfterViewChecked, AfterViewInit {
   var _prevHero = '';
-  
+
   // Query for a VIEW child of type `ChildViewComponent`
   @ViewChild(ChildViewComponent) ChildViewComponent viewChild;
-  
+
 // #enddocregion hooks
   final LoggerService _logger;
 

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/counter_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/counter_component.dart
@@ -17,8 +17,8 @@ import 'spy_directive.dart';
     styles: const [
       '.counter {background: LightYellow; padding: 8px; margin-top: 8px}'
     ],
-    directives: const [Spy])
-class MyCounter implements OnChanges {
+    directives: const [SpyDirective])
+class MyCounterComponent implements OnChanges {
   @Input() num counter;
   List<String> changeLog = [];
 
@@ -53,7 +53,7 @@ class MyCounter implements OnChanges {
     </div>
     ''',
     styles: const ['.parent {background: gold;}'],
-    directives: const [MyCounter],
+    directives: const [MyCounterComponent],
     providers: const [LoggerService])
 class CounterParentComponent {
   final LoggerService _logger;

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/spy_component.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/spy_component.dart
@@ -11,7 +11,7 @@ import 'spy_directive.dart';
       '.parent {background: khaki}',
       '.heroes {background: LightYellow; padding: 0 8px}'
     ],
-    directives: const [Spy],
+    directives: const [SpyDirective],
     providers: const [LoggerService])
 class SpyParentComponent {
   final LoggerService _logger;
@@ -31,7 +31,7 @@ class SpyParentComponent {
   }
 
   // removeHero(String hero) { } is not used.
-  
+
   void reset() {
     _logger.log('-- reset --');
     heroes.clear();

--- a/public/docs/_examples/lifecycle-hooks/dart/lib/spy_directive.dart
+++ b/public/docs/_examples/lifecycle-hooks/dart/lib/spy_directive.dart
@@ -9,10 +9,10 @@ int _nextId = 1;
 // Spy on any element to which it is applied.
 // Usage: <div mySpy>...</div>
 @Directive(selector: '[mySpy]')
-class Spy implements OnInit, OnDestroy {
+class SpyDirective implements OnInit, OnDestroy {
   final LoggerService _logger;
 
-  Spy(this._logger);
+  SpyDirective(this._logger);
 
   ngOnInit() => _logIt('onInit');
 


### PR DESCRIPTION
Dart-side updates following #1654:
- Updates to follow style guide
- Enabled e2e tests (#1523).
- Fixes to ensure tests pass: in after_view_component.dart and
after_content_component.dart
  - Changed test over comment field in template to be:<br>
`*ngIf="comment.isNotEmpty"`
- Suites passed:
  - public/docs/_examples/lifecycle-hooks/dart
  - public/docs/_examples/lifecycle-hooks/ts