### PR TITLE
example(toh-4/dart): add missing title and styles link

### DIFF
--- a/public/docs/_examples/toh-4/dart/web/index.html
+++ b/public/docs/_examples/toh-4/dart/web/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title>Angular 2 Tour of Heroes</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="styles.css">
+
     <script defer src="main.dart" type="application/dart"></script>
     <script defer src="packages/browser/dart.js"></script>
   </head>


### PR DESCRIPTION
Now the toh-4 `index.html` is identical to those of the previous parts.
Fixes #1609.