### PR TITLE
docs(dart/{quickstart,toh-[56]}): fix project names

### DIFF
--- a/public/docs/_examples/quickstart/dart/lib/app_component.dart
+++ b/public/docs/_examples/quickstart/dart/lib/app_component.dart
@@ -1,5 +1,4 @@
-// #docregion
-// #docregion import
+// #docregion , import
 import 'package:angular2/core.dart';
 // #enddocregion import
 

--- a/public/docs/_examples/quickstart/dart/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 # #docregion
-name: angular2_getting_started
+name: angular2_quickstart
 description: QuickStart
 version: 0.0.1
 environment:

--- a/public/docs/_examples/quickstart/dart/web/main.dart
+++ b/public/docs/_examples/quickstart/dart/web/main.dart
@@ -1,7 +1,7 @@
 // #docregion
 import 'package:angular2/platform/browser.dart';
 
-import 'package:angular2_getting_started/app_component.dart';
+import 'package:angular2_quickstart/app_component.dart';
 
 void main() {
   bootstrap(AppComponent);

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -167,7 +167,7 @@ block server-watching
 
 block project-file-structure
   .filetree
-    .file angular2-quickstart
+    .file angular2_quickstart
     .children
       .file lib
       .children

--- a/public/docs/dart/latest/tutorial/toh-pt5.jade
+++ b/public/docs/dart/latest/tutorial/toh-pt5.jade
@@ -27,7 +27,7 @@ p Run the #[+liveExampleLink2('', 'toh-5')] for this part.
   and hero detail component. If not, we’ll need to go back and follow the previous chapters.
 
 .filetree
-    .file angular2-tour-of-heroes
+    .file angular2_tour_of_heroes
     .children
         .file lib
         .children
@@ -659,7 +659,7 @@ p.
 
 :marked
 .filetree
-  .file angular2-tour-of-heroes
+  .file angular2_tour_of_heroes
   .children
     .file lib
     .children

--- a/public/docs/dart/latest/tutorial/toh-pt6.jade
+++ b/public/docs/dart/latest/tutorial/toh-pt6.jade
@@ -91,7 +91,7 @@ block review
 
 block filetree
   .filetree
-    .file angular2-tour-of-heroes
+    .file angular2_tour_of_heroes
     .children
       .file lib
       .children

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -94,9 +94,10 @@ h2#create-and-configure Step 1: Create and configure the project
 
 h3 (a) Create the project folder
 
+- var _ = _docsFor == 'dart' ? '_' : '-';
 code-example(language="sh").
-  mkdir angular2-quickstart
-  cd    angular2-quickstart
+  mkdir angular2!{_}quickstart
+  cd    angular2!{_}quickstart
 
 h3#add-config-files (b) Add #{_package_and_config_files}
 block package-and-config-files


### PR DESCRIPTION
Changes:
- Renamed `angular2_getting_started` to `angular2_quickstart` (to match TS).
- s/-/_/g in project names elsewhere (only toh-5 & -6 needed to be updated).

Checks:
- Generated docs have not BAD FILENAME
- Ran Dart e2e tests; suites passed:
  - public/docs/_examples/quickstart/dart

Fixes #378.