### PR TITLE
chore(examples): revert back to stable TS

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -72,7 +72,7 @@
     "style-loader": "^0.13.1",
     "ts-loader": "^0.8.2",
     "ts-node": "^0.7.3",
-    "typescript": "^1.9.0-dev.20160409",
+    "typescript": "^1.8.10",
     "typings": "^1.0.4",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.14.1",


### PR DESCRIPTION
The new router once required TS1.9 but it doesn't anymore. It's best to revert our examples to TS 1.8 since that is what we tell users to install, and we want to be testing on the current setup.

@brandonroberts @Foxandxss @wardbell 