### PR TITLE
chore(travis): add preview builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,19 @@ env:
     - DISPLAY=:99.0
     - CHROME_BIN=chromium-browser
   matrix:
-    - SCRIPT="lint"
+    - SCRIPT=lint
     - SCRIPT="run-e2e-tests --fast"
+    - SCRIPT="run-e2e-tests --fast" PREVIEW=true
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: "SCRIPT=\"run-e2e-tests --fast\" PREVIEW=true"    
 before_install:
   - npm install -g gulp --no-optional
 before_script:
   - sh -e /etc/init.d/xvfb start
 install:
   - ./script/install.sh
+  - if [[ $PREVIEW == true ]]; then npm install --prefix public/docs/_examples angular/{core,common,compiler,platform-browser,platform-browser-dynamic,http,forms,router-deprecated,router,upgrade}-builds; fi
 script:
   - gulp $SCRIPT

--- a/script/install.sh
+++ b/script/install.sh
@@ -3,7 +3,7 @@
 set -ex -o pipefail
 
 npm install --no-optional
-(cd public/docs/_examples && npm install)
-(cd public/docs/_examples/_protractor && npm install)
+(cd public/docs/_examples && npm install --no-optional)
+(cd public/docs/_examples/_protractor && npm install --no-optional)
 npm run webdriver:update --prefix public/docs/_examples/_protractor
 gulp add-example-boilerplate


### PR DESCRIPTION
This PR adds a new matrix entry to travis builds that runs docs e2e tests against the latest preview builds. It is meant to add early warning about possible breakage on next release, and to automatically be triggered on master via a webhook on Angular 2 builds (see https://github.com/angular/angular/issues/9322).

This new build is set to be allowed to fail, and a PR will not wait for it to be finished before being marked passing the CI.