### PR TITLE
docs(toh-5): use `Array.prototype.find()` instead of `filter`

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-5/ts/app/hero.service.ts
@@ -20,7 +20,7 @@ export class HeroService {
   // #docregion get-hero
   getHero(id: number) {
     return this.getHeroes()
-               .then(heroes => heroes.filter(hero => hero.id === id)[0]);
+               .then(heroes => heroes.find(hero => hero.id === id));
   }
   // #enddocregion get-hero
 }


### PR DESCRIPTION
We are in *TypeScript*, so we can avoid worrying about ECMAScript methods being implemented or not (as `find()` is already implemented in TypeScript) and, personally, my eyes hurt when I see a `filter()` returning its first element `[0]` without checking if it returned **something** before.