### PR TITLE
news(rc4): update blog post title to point to correct version

### DIFF
--- a/public/news.jade
+++ b/public/news.jade
@@ -11,7 +11,7 @@
         a(
         target="_blank"
         href="http://angularjs.blogspot.com/2016/06/rc4-now-available.html"
-        ) RC2 Now Available
+        ) RC4 Now Available
       p Today we’re happy to announce that we are shipping Angular 2.0.0-rc4. This release begins to lay the foundation for improved Angular Compilation, and makes improvements to testing....
       .author
         img(src="/resources/images/bios/stephenfluin.jpg")


### PR DESCRIPTION
I think there has been a typo in the tittle as the URL points to the new release, RC4, so the title should say the same :)