### PR TITLE
Correct sample reference for milestone #2

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -617,7 +617,7 @@ h3#merge-hero-routes Merge hero routes into application routes
   We'll need to merge them into the application routes we defined in `app.routes.ts`.
 
   Update `app.routes.ts` as follows:
-+makeExample('router/ts/app/app.routes.3.ts', '', 'app/app.routes.ts (v.2)')(format=".")
++makeExample('router/ts/app/app.routes.2.ts', '', 'app/app.routes.ts (v.2)')(format=".")
 :marked
   We replace the `HeroListComponent` import with an `HeroesRoutes` import.
 
@@ -796,8 +796,8 @@ h3#nav-to-list Navigating back to the list component
   ### The Heroes App code
   Here are the relevant files for this version of the sample application.
 +makeTabs(
-  `router/ts/app/app.component.1.ts,
-   router/ts/app/app.routes.3.ts,
+  `router/ts/app/app.component.2.ts,
+   router/ts/app/app.routes.2.ts,
    router/ts/app/heroes/hero-list.component.1.ts,
    router/ts/app/heroes/hero-detail.component.1.ts,
    router/ts/app/heroes/hero.service.ts,


### PR DESCRIPTION
We have received an issue at angular-cn: [issue #13](https://github.com/angular/angular-cn/issues/13) thanks to [gogobook](https://github.com/gogobook).

1. in the final code samples of milestone 2, `providers:[HeroService]` is missed in `app.component`
2. `crisis-center` folder does not exist yet at milestone 2, therefore reference to `app.routes.ts` is not correct.