### PR TITLE
fix ngOnInit method from tutorial

### DIFF
--- a/public/docs/_examples/toh-4/ts/app/app.component.1.ts
+++ b/public/docs/_examples/toh-4/ts/app/app.component.1.ts
@@ -52,7 +52,7 @@ export class AppComponent implements OnInit {
   // #docregion on-init
   ngOnInit() {
     // #enddocregion on-init
-    this.getHeroes();
+    this.heroes = this.heroService.getHeroes();
     // #docregion on-init
   }
   // #enddocregion on-init


### PR DESCRIPTION
<img width="872" alt="screen shot 2016-07-05 at 13 00 20" src="https://cloud.githubusercontent.com/assets/4334635/16581116/79feb088-42b0-11e6-9b68-1afe9f11988e.png">

In tutorial i was instructed to call `this.getHeroes();`, but `getHeroes` method is defined in service not on component.