### PR TITLE
docs(typescript-configuration): TypeScript handbook documentation link change

### DIFF
--- a/public/docs/ts/latest/guide/typescript-configuration.jade
+++ b/public/docs/ts/latest/guide/typescript-configuration.jade
@@ -23,7 +23,7 @@ a(id="tsconfig")
 .l-sub-section
   :marked
     Get details about `tsconfig.json` from the official
-    [TypeScript wiki](https://github.com/Microsoft/TypeScript/wiki/tsconfig.json).
+    [TypeScript wiki](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 :marked
   We created the following `tsconfig.json` for the [QuickStart](../quickstart.html):
 +makeJson('quickstart/ts/tsconfig.1.json', null, 'tsconfig.json')(format=".")


### PR DESCRIPTION
Page has moved to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html