### PR TITLE
chore: dgeni tag definitions for ts2dart tags

### DIFF
--- a/tools/api-builder/angular.io-package/tag-defs/Annotation.js
+++ b/tools/api-builder/angular.io-package/tag-defs/Annotation.js
@@ -1,0 +1,4 @@
+// A ts2dart compiler annotation that can be ignored in API docs.
+module.exports = function() {
+  return { name: 'Annotation', ignore: true };
+};

--- a/tools/api-builder/angular.io-package/tag-defs/index.js
+++ b/tools/api-builder/angular.io-package/tag-defs/index.js
@@ -1,9 +1,11 @@
 module.exports = [
+  require('./Annotation'),
   require('./deprecated'),
   require('./howToUse'),
   require('./whatItDoes'),
   require('./internal'),
   require('./stable'),
+  require('./ts2dart_const'),
   require('./experimental'),
   require('./docsNotRequired'),
   require('./security'),

--- a/tools/api-builder/angular.io-package/tag-defs/ts2dart_const.js
+++ b/tools/api-builder/angular.io-package/tag-defs/ts2dart_const.js
@@ -1,0 +1,4 @@
+// A ts2dart compiler annotation that can be ignored in API docs.
+module.exports = function() {
+  return { name: 'ts2dart_const', ignore: true };
+};


### PR DESCRIPTION
New `dgeni` tag definitions for `ts2dart` tags which are currently causing spurious warnings when generating API docs.