### PR TITLE
chore(glossary/ts): redirect old glossary to correct location

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -20,7 +20,13 @@
     },
     {
       "source": "/docs/ts/latest/guide/setup.html",
-      "destination": "/docs/ts/latest/index.html"
+      "destination": "/docs/ts/latest/index.html",
+      "type": 301
+    },    
+    {
+      "source": "/docs/ts/latest/glossary.html",
+      "destination": "/docs/ts/latest/guide/glossary.html",
+      "type": 301
     },
     {
       "source": "/docs/ts/latest/testing",


### PR DESCRIPTION
Redirect old glossary to correct location within the guide folder. This addresses the problem with bad fragments for people who are still navigating here from an old link.

Difficult to test because no firebase redirects work with CheckDeploy. Need to at least have a test server.