### PR TITLE
docs(all): link cleanup - broken and outdated

### DIFF
--- a/public/docs/dart/latest/cookbook/dynamic-form-deprecated.html
+++ b/public/docs/dart/latest/cookbook/dynamic-form-deprecated.html
@@ -1,0 +1,1 @@
+!= partial("../../../_includes/_ts-temp")

--- a/public/docs/dart/latest/guide/animations.jade
+++ b/public/docs/dart/latest/guide/animations.jade
@@ -1,0 +1,1 @@
+!= partial("../../../_includes/_ts-temp")

--- a/public/docs/dart/latest/guide/component-styles.jade
+++ b/public/docs/dart/latest/guide/component-styles.jade
@@ -19,7 +19,7 @@ block css-import-url
   .alert.is-important
     :marked
       URLs are currently not interpreted in this way, see 
-      [issue 8518](href="https://github.com/angular/angular/issues/8518").
+      [issue 8518](https://github.com/angular/angular/issues/8518).
       Until this issue is fixed, absolute package-reference style URLs must 
       be given as is illustrated below.
     

--- a/public/docs/dart/latest/guide/forms-deprecated.html
+++ b/public/docs/dart/latest/guide/forms-deprecated.html
@@ -1,0 +1,1 @@
+!= partial("../../../_includes/_ts-temp")

--- a/public/docs/dart/latest/guide/forms.jade
+++ b/public/docs/dart/latest/guide/forms.jade
@@ -517,7 +517,7 @@ figure.image-display
     Recall from the previous section that `ngControl` registered this input box with the
     `NgForm` directive as "name".
 
-    We didn't add the **[`NgForm`](../api/common/NgForm-directive.html) directive*
+    We didn't add the **[`NgForm`](../api/common/index/NgForm-directive.html) directive*
     explicitly. Angular added it surreptitiously, wrapping it around the `<form>` element.
 
     The `NgForm` directive  supplements the `<form>` element with additional features.

--- a/public/docs/dart/latest/guide/server-communication.jade
+++ b/public/docs/dart/latest/guide/server-communication.jade
@@ -33,7 +33,7 @@ block http-providers
 block getheroes-and-addhero
   :marked
     The hero service `getHeroes()` and `addHero()` asynchronous methods return the
-    [`Future`](https://api.dartlang.org/stable/1.16.0/dart-async/Future-class.html)
+    [`Future`](https://api.dartlang.org/stable/dart-async/Future-class.html)
     values of the current hero list and the newly added hero,
     respectively. The hero list component methods of the same name specifying
     the actions to be taken when the asynchronous method calls succeed or fail.

--- a/public/docs/dart/latest/guide/template-syntax.jade
+++ b/public/docs/dart/latest/guide/template-syntax.jade
@@ -5,7 +5,7 @@ block includes
   - var _JavaScript = 'Dart';
   - var __chaining_op = '<code>;</code>';
   - var __new_op = '<code>new</code> or <code>const</code>';
-  - var mapApiRef = 'https://api.dartlang.org/stable/1.16.0/dart-core/Map-class.html';
+  - var mapApiRef = 'https://api.dartlang.org/stable/dart-core/Map-class.html';
   - var __objectAsMap = '<b><a href="' + mapApiRef + '">Map</a></b>'
 
 block notable-differences
@@ -69,7 +69,7 @@ block style-property-name-dart-diff
       and `setProperty()`. Hence, we recommend only using dash-case for style
       property names.
       
-      [CssSD]: https://api.dartlang.org/stable/1.16.1/dart-html/CssStyleDeclaration-class.html
+      [CssSD]: https://api.dartlang.org/stable/dart-html/CssStyleDeclaration-class.html
 
 
 block dart-no-truthy-falsey

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -17,8 +17,8 @@ block setup-tooling
     You can also download [Dart plugins for other IDEs and editors][DT].
 
     [WS]: https://confluence.jetbrains.com/display/WI/Getting+started+with+Dart
-    [DT]: https://www.dartlang.org/tools
-    [pub]: https://www.dartlang.org/tools/pub
+    [DT]: https://www.dartlang.org/tools/
+    [pub]: https://www.dartlang.org/tools/pub/
 
 block download-source
   // exclude this section from Dart

--- a/public/docs/dart/latest/tutorial/toh-pt5.jade
+++ b/public/docs/dart/latest/tutorial/toh-pt5.jade
@@ -442,7 +442,7 @@ code-example(format='').
   :marked
     Going back too far could take us out of the application.
     That's acceptable in a demo. We'd guard against it in a real application,
-    perhaps with the [*routerCanDeactivate* hook](../api/router/CanDeactivate-interface.html).
+    perhaps with the [*routerCanDeactivate* hook](../api/router/index/CanDeactivate-interface.html).
 :marked
   Then we wire this method with an event binding to a *Back* button that we add to the bottom of the component template.
 +makeExample('toh-5/dart/lib/hero_detail_component.html', 'back-button')(format=".")

--- a/public/docs/js/latest/cookbook/dynamic-form-deprecated.html
+++ b/public/docs/js/latest/cookbook/dynamic-form-deprecated.html
@@ -1,0 +1,1 @@
+!= partial("../../../_includes/_ts-temp")

--- a/public/docs/js/latest/guide/animations.jade
+++ b/public/docs/js/latest/guide/animations.jade
@@ -1,0 +1,1 @@
+!= partial("../../../_includes/_ts-temp")

--- a/public/docs/js/latest/guide/forms-deprecated.jade
+++ b/public/docs/js/latest/guide/forms-deprecated.jade
@@ -493,7 +493,7 @@ figure.image-display
   :marked
     ### The NgForm directive
     We just set a template local variable with the value of an `NgForm` directive. 
-    Why did that work? We didn't add the **[`NgForm`](../api/common/NgForm-directive.html) directive** explicitly.
+    Why did that work? We didn't add the **[`NgForm`](../api/common/index/NgForm-directive.html) directive** explicitly.
     
     Angular added it surreptitiously, wrapping it around the `<form>` element
 

--- a/public/docs/js/latest/guide/forms.jade
+++ b/public/docs/js/latest/guide/forms.jade
@@ -491,7 +491,7 @@ figure.image-display
 .l-sub-section
   :marked
     Why "ngModel"? 
-    A directive's [exportAs](../api/core/DirectiveMetadata-class.html#!#exportAs) property 
+    A directive's [exportAs](../api/core/index/DirectiveMetadata-class.html#!#exportAs) property 
     tells Angular how to link the reference variable to the directive.
     We set `name` to `ngModel` because the `ngModel` directive's `exportAs` property happens to be "ngModel".
     
@@ -503,7 +503,7 @@ figure.image-display
   :marked
     ### The NgForm directive
     We just set a template local variable with the value of an `NgForm` directive. 
-    Why did that work? We didn't add the **[`NgForm`](../api/common/NgForm-directive.html) directive** explicitly.
+    Why did that work? We didn't add the **[`NgForm`](../api/common/index/NgForm-directive.html) directive** explicitly.
     
     Angular added it surreptitiously, wrapping it around the `<form>` element
 

--- a/public/docs/ts/latest/cookbook/set-document-title.jade
+++ b/public/docs/ts/latest/cookbook/set-document-title.jade
@@ -34,7 +34,7 @@ code-example(format='')
 :marked
   ## Use the *Title* service
   Fortunately, Angular 2 bridges the gap by providing a `Title` service as part of the *Browser platform*.
-  The [Title](../api/platform/browser/Title-class.html) service is a simple class that provides an API
+  The [Title](../api/platform-browser/index/Title-class.html) service is a simple class that provides an API
   for getting and setting the current HTML document title:
 
   * `getTitle() : string` &mdash; Gets the title of the current HTML document.

--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -525,7 +525,7 @@ code-example(format="nocode").
   </span>
   <span if-docs="dart">
     that creates a new instance of the
-    [Provider](../api/core/Provider-class.html) class:
+    [Provider](../api/core/index/Provider-class.html) class:
   </span>
 
 +makeExample('dependency-injection/ts/app/providers.component.ts','providers-3')

--- a/public/docs/ts/latest/guide/forms-deprecated.jade
+++ b/public/docs/ts/latest/guide/forms-deprecated.jade
@@ -380,7 +380,7 @@ figure.image-display
     We'll talk about `NgForm` [later in the chapter](#ngForm).
 
     The `ngControl` *attribute* in our template actually maps to the 
-    [NgControlName](../api/common/NgControlName-directive.html) directive.
+    [NgControlName](../api/common/index/NgControlName-directive.html) directive.
     There is also a `NgControl` *abstract* directive which is *not the same thing*.
     We often ignore this technical distinction and refer to `NgControlName` more conveniently (albeit incorrectly) as the *NgControl* directive.
     
@@ -483,7 +483,7 @@ figure.image-display
 .l-sub-section
   :marked
     Why "ngForm"? 
-    A directive's [exportAs](../api/core/DirectiveMetadata-class.html#!#exportAs) property 
+    A directive's [exportAs](../api/core/index/DirectiveMetadata-class.html#!#exportAs) property 
     tells Angular how to link the reference variable to the directive.
     We set `name` to `ngForm` because the `NgControlName` directive's `exportAs` property happens to be "ngForm".
     
@@ -589,7 +589,7 @@ figure.image-display
 .l-sub-section
   :marked
     ### The NgForm directive
-    What `NgForm` directive? We didn't add an [NgForm](../api/common/NgForm-directive.html) directive!
+    What `NgForm` directive? We didn't add an [NgForm](../api/common/index/NgForm-directive.html) directive!
     
     Angular did. Angular creates and attaches an `NgForm` directive to the `<form>` tag automatically.
 

--- a/public/docs/ts/latest/guide/forms.jade
+++ b/public/docs/ts/latest/guide/forms.jade
@@ -593,7 +593,7 @@ figure.image-display
 .l-sub-section
   :marked
     ### The NgForm directive
-    What `NgForm` directive? We didn't add an [NgForm](../api/common/NgForm-directive.html) directive!
+    What `NgForm` directive? We didn't add an [NgForm](../api/common/index/NgForm-directive.html) directive!
     
     Angular did. Angular creates and attaches an `NgForm` directive to the `<form>` tag automatically.
 

--- a/public/docs/ts/latest/guide/pipes.jade
+++ b/public/docs/ts/latest/guide/pipes.jade
@@ -36,7 +36,7 @@ block includes
 
 :marked
   Inside the interpolation expression we flow the component's `birthday` value through the
-  [pipe operator](./template-syntax.html#pipe) ( | ) to the [Date pipe](../api/common/DatePipe-class.html)
+  [pipe operator](./template-syntax.html#pipe) ( | ) to the [Date pipe](../api/common/index/DatePipe-class.html)
   function on the right. All pipes work this way.
 
 .l-main-section
@@ -95,7 +95,7 @@ figure.image-display
 
 .l-sub-section
   :marked
-    Learn more about the `DatePipes` format options in the [API Docs](../api/common/DatePipe-class.html).
+    Learn more about the `DatePipes` format options in the [API Docs](../api/common/index/DatePipe-class.html).
 
 :marked
   ## Chaining pipes
@@ -395,7 +395,7 @@ figure.image-display
 .callout.is-helpful
   header Debugging with the json pipe
   :marked
-    The [JsonPipe](../api/common/JsonPipe-class.html)
+    The [JsonPipe](../api/common/index/JsonPipe-class.html)
     provides an easy way to diagnosis a mysteriously failing data binding or
     inspect an object for future binding.
 

--- a/public/docs/ts/latest/guide/router-deprecated.jade
+++ b/public/docs/ts/latest/guide/router-deprecated.jade
@@ -1465,7 +1465,7 @@ code-example(format=".", language="bash").
 
 .l-sub-section
   :marked
-    Learn about the [APP_BASE_HREF](../api/router/APP_BASE_HREF-let.html)
+    Learn about the [APP_BASE_HREF](../api/router-deprecated/index/APP_BASE_HREF-let.html)
     in the API Guide.
 :marked
   ### *HashLocationStrategy*

--- a/public/docs/ts/latest/guide/server-communication.jade
+++ b/public/docs/ts/latest/guide/server-communication.jade
@@ -392,7 +392,7 @@ code-example(format="." language="javascript").
 
 +ifDocsFor('ts')
   :marked
-    [Headers](../api/http/Headers-class.html) are one of the [RequestOptions](../api/http/RequestOptions-class.html).
+    [Headers](../api/http/index/Headers-class.html) are one of the [RequestOptions](../api/http/index/RequestOptions-class.html).
     Compose the options object and pass it in as the *third* parameter of the `post` method, as shown above.
 
 :marked

--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -63,7 +63,7 @@ a(id='toc')
 :marked
   ## Single Responsibility
 
-  We apply the [Single Responsibility Principle](https:\/\/en.wikipedia.org/wiki/Single_responsibility_principle) to all Components, Services, and other symbols we create. This helps make our app cleaner, easier to read and maintain, and more testable.
+  We apply the [Single Responsibility Principle](https://wikipedia.org/wiki/Single_responsibility_principle) to all Components, Services, and other symbols we create. This helps make our app cleaner, easier to read and maintain, and more testable.
 
   ### <a id="01-01"></a>Rule of One
   #### <a href="#01-01">Style 01-01</a>


### PR DESCRIPTION
Fixes all broken links except genuine errors (see #1840), have been resolved as of 2016-07-06 (https://github.com/angular/angular/commit/2708ce6a17667a2369c83bcf244c9366b058d4c9).

Fixes #1574