### PR TITLE
fix text to match code for HeroListComponent

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -1377,10 +1377,10 @@ code-example(format="." language="bash").
   This time we'll be navigating in the opposite direction, from the `HeroDetailComponent` to the `HeroListComponent`.
   This time we'll inject the `Router` service in the constructor of the `HeroListComponent`.
 
-  First we extend the router import statement to include the `ActivatedRoute` service symbol;
+  First we import the `Router` into the `HeroListComponent`:
 +makeExample('router/ts/app/heroes/hero-list.component.ts','import-router', 'hero-list.component.ts (import)')(format=".")
 :marked
-  Then we use the `routerState` to access the globally available query parameters `Observable` so we can subscribe
+  Then we add the `Router` into the constructor and use the `routerState` to access the globally available query parameters `Observable` so we can subscribe
   and extract the `id` parameter as the `selectedId`:
 +makeExample('router/ts/app/heroes/hero-list.component.ts','ctor', 'hero-list.component.ts (constructor)')(format=".")
 .l-sub-section


### PR DESCRIPTION
current text refers to importing the ActivatedRoute service, but the actual code imports Router instead.  This text was added as part of the v.3 router doc update in https://github.com/angular/angular.io/commit/c61d8195f3b63c3e03bf2a3c12ef2596796c741d