### PR TITLE
docs(style-guide): remove routing from TOC

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -56,7 +56,6 @@ a(id='toc')
     1. [Services](#services)
     1. [Data Services](#data-services)
     1. [Lifecycle Hooks](#lifecycle-hooks)
-    1. [Routing](#routing)
     1. [Appendix](#appendix)
 
 .l-main-section


### PR DESCRIPTION
It is a bit misleading having an entry in the TOC with no styles for it.