### PR TITLE
chore(api doc gen): log "no api docs" as `info` not `warning`

### DIFF
--- a/tools/api-builder/docs-package/processors/addNotYetDocumentedProperty.js
+++ b/tools/api-builder/docs-package/processors/addNotYetDocumentedProperty.js
@@ -23,8 +23,7 @@ module.exports = function addNotYetDocumentedProperty(EXPORT_DOC_TYPES, log, cre
         }
 
         if (doc.notYetDocumented) {
-          // TODO: (ericjim) should I remove this?
-          log.warn(createDocMessage("Not yet documented", doc));
+          log.info(createDocMessage("Not yet documented", doc));
         }
       });
 


### PR DESCRIPTION
There are too many undocumented interfaces to consider lack of API docs in a source file to be worth a warning. The original author even questions whether there should be such a warning. It is now logged at
the `info` level.