### PR TITLE
docs(dependency-injection): OpaqueToken registration.

### DIFF
--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -774,9 +774,17 @@ block what-should-we-use-as-token
 +makeExample('dependency-injection/ts/app/app.config.ts','token')(format='.')
 
 :marked
-  We register the dependency provider using the `OpaqueToken` object:
+  We can register the dependency provider, in a component, using the `OpaqueToken` object:
 
 +makeExample('dependency-injection/ts/app/providers.component.ts','providers-9')(format=".")
+
+block dart-map-alternative
+  :marked
+    Or we can provide and inject the configuration object in our top-level `AppComponent`.
+
+  +makeExcerpt('app/app.component.ts','providers')
+
+#optional
 
 :marked
   Now we can inject the configuration object into any constructor that needs it, with
@@ -790,13 +798,6 @@ block what-should-we-use-as-token
     Although the !{configType} interface plays no role in dependency injection,
     it supports typing of the configuration object within the class.
 
-block dart-map-alternative
-  :marked
-    Or we can provide and inject the configuration object in our top-level `AppComponent`.
-
-  +makeExcerpt('app/app.component.ts','providers')
-
-#optional
 :marked
   ## Optional dependencies
 


### PR DESCRIPTION
Moved block of text that explains `OpaqueToken `registration in `AppComponent` further up, so that it can be clear that you can use it either in a component or in the main component of the application.