### PR TITLE
[WIP] chore(ci): add check-deploy to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,24 @@ env:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
     - DISPLAY=:99.0
     - CHROME_BIN=chromium-browser
+    - LATEST_RELEASE=2.0.0-rc.4
   matrix:
-    - SCRIPT=lint
-    - SCRIPT="run-e2e-tests --fast"
-    - SCRIPT="run-e2e-tests --fast" PREVIEW=true
+    - TASK=lint
+    - TASK="run-e2e-tests --fast" SCRIPT=examples-install.sh
+    - TASK="run-e2e-tests --fast" SCRIPT=examples-install-preview.sh
+    - TASK=harp-compile SCRIPT=deploy-install.sh
+    - TASK=harp-compile SCRIPT=deploy-install-preview.sh
 matrix:
   fast_finish: true
   allow_failures:
-    - env: "SCRIPT=\"run-e2e-tests --fast\" PREVIEW=true"
+    - env: "TASK=\"run-e2e-tests --fast\" SCRIPT=examples-install-preview.sh"
+    - env: "TASK=harp-compile SCRIPT=deploy-install-preview.sh"
 before_install:
   - npm install -g gulp --no-optional
+install:
+  - npm install --no-optional
+  - if [[ $SCRIPT ]]; then ./scripts/$SCRIPT; fi
 before_script:
   - sh -e /etc/init.d/xvfb start
-install:
-  - ./scripts/install.sh
-  - if [[ $PREVIEW == true ]]; then npm install --prefix public/docs/_examples angular/{core,common,compiler,platform-browser,platform-browser-dynamic,http,forms,router-deprecated,router,upgrade}-builds; fi
 script:
-  - gulp $SCRIPT
+  - gulp $TASK

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ This project generates a lot of untracked files, if you wish to reset it to a mi
 
 - `git clean -xdf`
 
-Also, there is a script available for Linux and OSX users that will setup the project using the steps shown in this section:
+Also, there is a script available for Linux, OSX and Windows Gitbash users that will setup the project using the steps shown in this section:
 
-- `./scripts/install.sh`
+- `npm install --no-optional && ./scripts/examples-install.sh`
 
 
 ## Technology Used

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -564,16 +564,16 @@ gulp.task('git-changed-examples', ['_shred-devguide-examples'], function(){
   });
 });
 
+gulp.task('harp-compile', ['build-docs'], function() {
+  return harpCompile();
+});
+
 gulp.task('check-deploy', ['build-docs'], function() {
   return harpCompile().then(function() {
     gutil.log('compile ok');
-    if(argv.dryRun) {
-      return false;
-    } else {
-      gutil.log('running live server ...');
-      execPromise('npm run live-server ./www');
-      return askDeploy();
-    }
+    gutil.log('running live server ...');
+    execPromise('npm run live-server ./www');
+    return askDeploy();
   }).then(function(shouldDeploy) {
     if (shouldDeploy) {
       gutil.log('deploying...');

--- a/scripts/deploy-install-preview.sh
+++ b/scripts/deploy-install-preview.sh
@@ -1,0 +1,6 @@
+ #!/usr/bin/env bash
+
+set -ex -o pipefail
+
+./scripts/deploy-install.sh
+(cd ../angular && git checkout master)

--- a/scripts/deploy-install.sh
+++ b/scripts/deploy-install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ex -o pipefail
+
+(cd ../ && git clone https://github.com/angular/angular.git --branch $LATEST_RELEASE)

--- a/scripts/examples-install-preview.sh
+++ b/scripts/examples-install-preview.sh
@@ -1,0 +1,6 @@
+ #!/usr/bin/env bash
+
+set -ex -o pipefail
+
+./scripts/examples-install.sh
+(cd public/docs/_examples && npm install angular/{core,common,compiler,platform-browser,platform-browser-dynamic,http,forms,router-deprecated,router,upgrade}-builds --no-optional)

--- a/scripts/examples-install.sh
+++ b/scripts/examples-install.sh
@@ -2,7 +2,6 @@
 
 set -ex -o pipefail
 
-npm install --no-optional
 (cd public/docs/_examples && npm install --no-optional)
 (cd public/docs/_examples/_protractor && npm install --no-optional)
 npm run webdriver:update --prefix public/docs/_examples/_protractor


### PR DESCRIPTION
This PR adds CI entries to the existing matrix that run `gulp check-deploy` for the latest release and for the master branch of angular.io.