### PR TITLE
chore(gulpfile): add install-example-angular task to install build packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ Also, there is a script available for Linux and OSX users that will setup the pr
 
 - `./scripts/install.sh`
 
+### Run with current build instead of release packages
+Can switch the `@angular` packages in `~/public/docs/_examples/node_modules` to the current build packages with
+```
+gulp install-example-angular --build
+```
+Restore to RELEASE packages with
+```
+gulp install-example-angular
+```
+>These commands will fail if something is locking any of the packages ... as an IDE often does.
+>
+>The symptom typically is an error trying to `rm -rf node_modules/@angular`.
+>
+>_Solution_: unlock the hold on the package(s). In VS Code, re-load the window (`cmd-P` then enter `>relow`).
+
 
 ## Technology Used
 - Angular 1.x: The production ready version of Angular

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -451,6 +451,34 @@ gulp.task('remove-example-boilerplate', function() {
   deleteExampleBoilerPlate();
 });
 
+// Npm install Angular libraries into examples/node_modules,
+// either release or current build packages
+// Examples:
+//   gulp install-example-angular --build  // use current build packages
+//   gulp install-example-angular          // restore release packages
+gulp.task('install-example-angular', installExampleAngular);
+
+function installExampleAngular() {
+  var sources;
+  var template;
+  var libs = [
+    'core', 'common', 'compiler',
+    'platform-browser', 'platform-browser-dynamic',
+    'forms', 'http', 'router'];
+
+  // Like: "angular/core-builds" or "@angular/core"
+  sources = libs.map( lib => argv.build ? `angular/${lib}-builds` : `@angular/${lib}`);
+
+  gutil.log(`Installing Angular npm packages from ${argv.build ? 'BUILD' : 'RELEASE'}`);
+
+  var spawnInfo = spawnExt('rm', ['-rf', 'node_modules/@angular'], { cwd: EXAMPLES_PATH});
+  return spawnInfo.promise
+    .then(() =>  {
+      spawnInfo = spawnExt('npm', ['install', ...sources], {cwd: EXAMPLES_PATH});
+      return spawnInfo.promise
+    });
+}
+
 // deletes boilerplate files that were added by copyExampleBoilerplate
 // from locations where an example app is found
 gulp.task('_delete-example-boilerplate', deleteExampleBoilerPlate);
@@ -602,7 +630,7 @@ gulp.task('link-checker', function(done) {
     '*/dart/latest/api/*',
     // Somehow the link checker sees ng1 {{...}} in the resource page; ignore it
     'resources/%7B%7Bresource.url%7D%7D',
-    // API docs have links directly into GitHub repo sources; these can 
+    // API docs have links directly into GitHub repo sources; these can
     // quickly become invalid, so ignore them for now:
     '*/angular/tree/*'
   ];
@@ -786,7 +814,7 @@ function linkChecker(options) {
   var outputFile = path.join(process.cwd(), 'link-checker-results.txt');
   var header = 'Link checker results for: ' + siteUrl +
                '\nStarted: ' + (new Date()).toLocaleString() +
-               '\nExcluded links (blc file globs): ' + blcOptions.excludedKeywords + 
+               '\nExcluded links (blc file globs): ' + blcOptions.excludedKeywords +
                '\nExcluded links (custom --exclude-bad regex): ' + excludeBad.toString() + '\n\n';
   gutil.log(header);
   fs.writeFileSync(outputFile, header);


### PR DESCRIPTION
Use build packages: gulp install-example-angular --build
Restore release packages: gulp install-example-angular
Documented the command in the README