### PR TITLE
docs-styles(build): Operationalize doc styles build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ plnkr.html
 public/docs/*/latest/guide/cheatsheet.json
 protractor-results.txt
 link-checker-results.txt
+*a2docs.css

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -195,7 +195,7 @@ function runE2e() {
         return spawnInfo.promise;
       })
       .then(function() {
-        copyExampleBoilerplate();
+        buildStyles(copyExampleBoilerplate, _.noop);
         gutil.log('runE2e: update webdriver');
         spawnInfo = spawnExt('npm', ['run', 'webdriver:update'], {cwd: EXAMPLES_PROTRACTOR_PATH});
         return spawnInfo.promise;
@@ -419,7 +419,7 @@ gulp.task('help', taskListing.withFilters(function(taskName) {
 }));
 
 // requires admin access because it adds symlinks
-gulp.task('add-example-boilerplate', function() {
+gulp.task('add-example-boilerplate', function(done) {
   var realPath = path.join(EXAMPLES_PATH, '/node_modules');
   var nodeModulesPaths = excludeDartPaths(getNodeModulesPaths(EXAMPLES_PATH));
 
@@ -435,24 +435,24 @@ gulp.task('add-example-boilerplate', function() {
     fsUtils.addSymlink(realPath, linkPath);
   });
 
-  return buildStyles(copyExampleBoilerplate);
+  return buildStyles(copyExampleBoilerplate, done);
 });
 
 
 // copies boilerplate files to locations
 // where an example app is found
-gulp.task('_copy-example-boilerplate', function () {
-  if (!argv.fast) return buildStyles(copyExampleBoilerplate);
+gulp.task('_copy-example-boilerplate', function (done) {
+  if (!argv.fast) buildStyles(copyExampleBoilerplate, done);
 });
 
 //Builds Angular 2 Docs CSS file from Bootstrap npm LESS source
 //and copies the result to the _examples folder to be included as
 //part of the example boilerplate.
-function buildStyles(cb){
-  return gulp.src(path.join(STYLES_SOURCE_PATH, _styleLessName))
+function buildStyles(cb, done){
+  gulp.src(path.join(STYLES_SOURCE_PATH, _styleLessName))
     .pipe(less())
-    .pipe(gulp.dest(EXAMPLES_PATH)).on('finish', function(){
-      return cb();
+    .pipe(gulp.dest(EXAMPLES_PATH)).on('end', function(){
+      cb().then(function() { done(); });
     });
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -473,10 +473,8 @@ function copyExampleBoilerplate() {
 
   // Make boilerplate files read-only to avoid that they be edited by mistake.
   var destFileMode = '444';
-        gutil.log('*** example files copied')
   return copyFiles(sourceFiles, examplePaths, destFileMode)
     .then(function() {
-      gutil.log('*** example files copied')
       return copyFiles(dartWebSourceFiles, dartExampleWebPaths, destFileMode);
     })
     // copy certain files from _examples/_protractor dir to each subdir that contains an e2e-spec file.
@@ -598,7 +596,6 @@ gulp.task('build-dart-api-docs', ['_shred-api-examples', 'dartdoc'], function() 
 });
 
 gulp.task('build-plunkers', ['_copy-example-boilerplate'], function() {
-  gutil.log('**** Building Plunkers')
   return plunkerBuilder.buildPlunkers(EXAMPLES_PATH, LIVE_EXAMPLES_PATH, { errFn: gutil.log });
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,8 +87,8 @@ var _excludeMatchers = _excludePatterns.map(function(excludePattern){
 });
 
 var _exampleBoilerplateFiles = [
-  'a2docs.css',
   '.editorconfig',
+  'a2docs.css',
   'karma.conf.js',
   'karma-test-shim.js',
   'package.json',
@@ -100,7 +100,7 @@ var _exampleBoilerplateFiles = [
   'wallaby.js'
  ];
 
-var _exampleDartWebBoilerPlateFiles = ['styles.css'];
+var _exampleDartWebBoilerPlateFiles = ['a2docs.css', 'styles.css'];
 
 var _exampleProtractorBoilerplateFiles = [
   'tsconfig.json'
@@ -121,7 +121,7 @@ var _styleLessName = 'a2docs.less';
 var lang, langs, buildDartApiDocs = false;
 function configLangs(langOption) {
   const fullSiteBuildTasks = ['build-compile', 'check-serve', 'check-deploy'];
-  const buildAllDocs = argv['_'] && 
+  const buildAllDocs = argv['_'] &&
     fullSiteBuildTasks.some((task) => argv['_'].indexOf(task) >= 0);
   const langDefault = buildAllDocs ? 'all' : '(ts|js)';
   lang = (langOption || langDefault).toLowerCase();
@@ -442,18 +442,18 @@ gulp.task('add-example-boilerplate', function() {
 // copies boilerplate files to locations
 // where an example app is found
 gulp.task('_copy-example-boilerplate', function () {
-  if (!argv.fast) buildStyles(copyExampleBoilerplate);
+  if (!argv.fast) return buildStyles(copyExampleBoilerplate);
 });
 
 //Builds Angular 2 Docs CSS file from Bootstrap npm LESS source
 //and copies the result to the _examples folder to be included as
 //part of the example boilerplate.
 function buildStyles(cb){
-  gulp.src(path.join(STYLES_SOURCE_PATH, _styleLessName))
+  return gulp.src(path.join(STYLES_SOURCE_PATH, _styleLessName))
     .pipe(less())
     .pipe(gulp.dest(EXAMPLES_PATH)).on('finish', function(){
       return cb();
-  });
+    });
 }
 
 // copies boilerplate files to locations
@@ -473,8 +473,10 @@ function copyExampleBoilerplate() {
 
   // Make boilerplate files read-only to avoid that they be edited by mistake.
   var destFileMode = '444';
+        gutil.log('*** example files copied')
   return copyFiles(sourceFiles, examplePaths, destFileMode)
     .then(function() {
+      gutil.log('*** example files copied')
       return copyFiles(dartWebSourceFiles, dartExampleWebPaths, destFileMode);
     })
     // copy certain files from _examples/_protractor dir to each subdir that contains an e2e-spec file.
@@ -596,6 +598,7 @@ gulp.task('build-dart-api-docs', ['_shred-api-examples', 'dartdoc'], function() 
 });
 
 gulp.task('build-plunkers', ['_copy-example-boilerplate'], function() {
+  gutil.log('**** Building Plunkers')
   return plunkerBuilder.buildPlunkers(EXAMPLES_PATH, LIVE_EXAMPLES_PATH, { errFn: gutil.log });
 });
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "archiver": "^1.0.0",
     "assert-plus": "^1.0.0",
+    "bootstrap": "3.3.6",
     "broken-link-checker": "0.7.1",
     "browser-sync": "^2.9.3",
     "canonical-path": "0.0.2",
@@ -43,6 +44,7 @@
     "gulp": "^3.5.6",
     "gulp-env": "0.4.0",
     "gulp-sass": "^2.3.2",
+    "gulp-less": "^3.1.0",
     "gulp-task-listing": "^1.0.1",
     "gulp-tslint": "^5.0.0",
     "gulp-util": "^3.0.6",

--- a/tools/styles-builder/less/a2docs.less
+++ b/tools/styles-builder/less/a2docs.less
@@ -1,0 +1,29 @@
+//Import angular 2 docs colors and mixins
+@import './colors/docs-material-palette.colors.less';
+@import './mixins/docs.mixins.less';
+//Import Bootstrap scaffolding and variables
+@import '../../../node_modules/bootstrap/less/scaffolding.less';
+@import '../../../node_modules/bootstrap/less/variables.less';
+//Override Bootstrap variables with custom values for angular 2 docs
+@import './overrides/bootstrap.overrides.less';
+//Import Bootstrap layout systems
+@import '../../../node_modules/bootstrap/less/mixins.less';
+@import '../../../node_modules/bootstrap/less/grid.less';
+@import '../../../node_modules/bootstrap/less/utilities.less';
+@import '../../../node_modules/bootstrap/less/responsive-utilities.less';
+//Import only Bootstrap elements to support angular 2 docs styles
+@import '../../../node_modules/bootstrap/less/type.less';
+@import '../../../node_modules/bootstrap/less/forms.less';
+@import '../../../node_modules/bootstrap/less/buttons.less';
+@import '../../../node_modules/bootstrap/less/button-groups.less';
+@import '../../../node_modules/bootstrap/less/input-groups.less';
+@import '../../../node_modules/bootstrap/less/tables.less';
+@import '../../../node_modules/bootstrap/less/glyphicons.less';
+@import '../../../node_modules/bootstrap/less/alerts.less';
+@import '../../../node_modules/bootstrap/less/close.less';
+//Import opacity overrides
+@import './overrides/docs.opacity.overrides.less';
+//Import styles overrides and angular 2 doc styles layouts
+@import './overrides/docs.overrides.less';
+//Import accessibility tweaks
+@import './overrides/docs.a11y.overrides.less';

--- a/tools/styles-builder/less/colors/docs-material-palette.colors.less
+++ b/tools/styles-builder/less/colors/docs-material-palette.colors.less
@@ -1,0 +1,10 @@
+//Style guide colors
+@material-header: #455A64;
+@material-header-darker: #37474F;
+@material-header-dark: #263238;
+@material-200: #EEEEEE;
+@material-700: #616161;
+@material-800: #424242;
+@material-900: #212121;
+@black: #000000;
+@white: #FFFFFF;

--- a/tools/styles-builder/less/mixins/docs.mixins.less
+++ b/tools/styles-builder/less/mixins/docs.mixins.less
@@ -1,0 +1,44 @@
+.opacity(){
+  opacity: 0.87;
+}
+
+.top-header-text(){
+  font-size: 50px;
+  font-weight: bold;
+}
+
+.header-text(){
+  font-size: 30px;
+  font-weight: bold;
+}
+
+.sub-header-text(){
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 40px;
+}
+
+.paragraph-text(){
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 28px;
+}
+
+.label-text(){
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 28px;
+}
+
+.button-text(){
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 28px;
+}
+
+.input-text(){
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 28px;
+  margin-top: 15px;
+}

--- a/tools/styles-builder/less/overrides/bootstrap.overrides.less
+++ b/tools/styles-builder/less/overrides/bootstrap.overrides.less
@@ -1,0 +1,21 @@
+//Main Bootstrap color overrides
+@gray-base: @black;
+@gray-darker: @black;
+@gray-dark: @material-900;
+@gray: @material-800;
+@gray-light: @material-700;
+@gray-lighter: @material-200;
+
+//Font override
+@font-family-sans-serif: "Roboto", Helvetica, Sans-Serif;
+
+//Glyphicons font path
+@icon-font-path: "./node_modules/bootstrap/fonts/";
+
+//Class overrides
+@input-color: @gray-dark;
+@text-color: @gray-dark;
+@btn-primary-color: @gray-lighter;
+@btn-primary-bg: @material-header-dark;
+@btn-default-color: @white;
+@btn-default-bg: @material-header-darker;

--- a/tools/styles-builder/less/overrides/docs.a11y.overrides.less
+++ b/tools/styles-builder/less/overrides/docs.a11y.overrides.less
@@ -1,0 +1,55 @@
+//Accessibility tweaks
+@danger-text: #632827;
+@state-danger-text: @danger-text;
+
+input {
+  &::-webkit-input-placeholder {
+    color: @gray-light !important;
+  }
+
+  &::-moz-placeholder {
+    color: @gray-light !important;
+  }
+}
+
+label {
+  input, textarea, select {
+    font-weight: normal;
+  }
+}
+
+button.btn.disabled,
+button.btn[disabled] {
+  color: @white;
+  background-color: @black;
+}
+
+.btn.btn-primary:not(.disabled):not([disabled]) {
+  &:hover,
+  &:focus{
+    color: @black;
+    background-color: @gray-lighter;
+  }
+}
+
+.btn.btn-default:not(.disabled):not([disabled]) {
+  &:hover,
+  &:focus{
+    color: @black;
+    background-color: @gray-lighter;
+  }
+}
+
+button.btn.disabled, button.btn[disabled] {
+  &:hover,
+  &:focus{
+    color: @white;
+    background-color: @black;
+  }
+}
+
+.close,
+.close:hover,
+.close:focus{
+  opacity: 1;
+}

--- a/tools/styles-builder/less/overrides/docs.opacity.overrides.less
+++ b/tools/styles-builder/less/overrides/docs.opacity.overrides.less
@@ -1,0 +1,35 @@
+//Opacity tweaks
+
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+  .opacity();
+}
+
+label {
+
+  input {
+    opacity: 1;
+  }
+
+  .opacity();
+}
+
+
+input {
+  .opacity();
+}
+
+.label-default {
+  .opacity();
+}
+
+legend {
+  .opacity();
+}
+
+button {
+  .opacity();
+}
+
+span, p, dl {
+  .opacity();
+}

--- a/tools/styles-builder/less/overrides/docs.overrides.less
+++ b/tools/styles-builder/less/overrides/docs.overrides.less
@@ -1,0 +1,75 @@
+//Design tweaks
+h1 {
+  color: @material-header;
+  .top-header-text();
+}
+
+h2 {
+  color: @material-header;
+  .header-text();
+}
+
+h3, legend {
+  .sub-header-text();
+}
+
+label, .label-default {
+  .label-text();
+}
+
+input, textarea, select {
+  color: @gray-dark;
+  .input-text();
+}
+
+span, p, dl, .doc-text {
+  .paragraph-text();
+}
+
+button.btn {
+  .button-text();
+}
+
+.dl-horizontal dt {
+  text-align: left;
+}
+
+.input-group-btn {
+  padding-top: 15px;
+
+  button.btn {
+    padding-top: 2px;
+    padding-bottom: 3px;
+  }
+
+}
+
+.shadow-1 {
+  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.37);
+}
+
+.showcase {
+  margin-bottom: 20px;
+}
+
+.showcase .showcase-header {
+  background: #E0E0E0;
+  padding: 32px;
+}
+
+.showcase .showcase-content {
+  padding: 32px;
+}
+
+.main-header {
+  margin-bottom: 40px;
+}
+
+a *{
+  color:inherit;
+
+  &:hover  {
+    color: inherit;
+  }
+
+}


### PR DESCRIPTION
Automated process to build a `CSS` file for the Angular 2 documentation examples. 

The process is driven by using the `LESS` source from *Bootstrap CSS*. By overriding the `LESS` variables and including other style overrides in the `LESS` build a single stylesheet is created that provides the Design approved example styles.

It is integrated in the `gulp` **add-example-boilerplate** and the **_copy-example-boilerplate** tasks.

Remaining steps (_after merging to master_):
* [ ] Get @naomiblack approval of the styles-in-action
* [ ] New PR to rename `a2docs.css` to `sample.css` which will propagate the style change to all doc samples.