### PR TITLE
chore(install): reintroduce single install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This project generates a lot of untracked files, if you wish to reset it to a mi
 
 Also, there is a script available for Linux, OSX and Windows Gitbash users that will setup the project using the steps shown in this section:
 
-- `npm install --no-optional && ./scripts/examples-install.sh`
+- `./scripts/install.sh`
 
 ### Run with current build instead of release packages
 Can switch the `@angular` packages in `~/public/docs/_examples/node_modules` to the current build packages with

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+cd `dirname $0`/..
+
+if [[ "$(node --version)" < "v5" ]]; then
+    echo "ERROR: bad version of node detected. If you have nvm installed, type:"
+    echo "  nvm use"
+    echo "Aborting installation."
+    exit 1;
+else
+    echo "Node version: $(node --version)"
+fi
+
+echo "Installing main packages ..."
+npm install --no-optional
+
+echo "Patching ..."
+source ./scripts/patch.sh
+
+if [ "$TRAVIS" != "true" ]; then
+    echo "Rebuilding node-sass, just in case ..."
+    npm rebuild node-sass;
+fi
+
+echo "Installing packages for examples ..."
+source ./scripts/examples-install.sh
+set +x
+
+echo "Installation done"


### PR DESCRIPTION
Our installation process can change rapidly. I think it helps if we have a single script to run that we ensure is up-to-date for all.

This PR reintroduces a single install script, which, in particular:
- **Checks for the proper version of node** (some of us develop with node
v4 on other sites, and it is too easy to forget to switch to v5 for
angular.io).
- Applies the **patch** (that is necessary to support harp compilation of
Dart API pages).