### PR TITLE
chore(travis): include dart doc generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,26 @@ env:
     - DISPLAY=:99.0
     - CHROME_BIN=chromium-browser
     - LATEST_RELEASE=2.0.0-rc.4
+    - TASK_FLAGS="--dgeni-log=warn"
+    # - TASK_FLAGS=""
   matrix:
     - TASK=lint
     - TASK="run-e2e-tests --fast" SCRIPT=examples-install.sh
     - TASK="run-e2e-tests --fast" SCRIPT=examples-install-preview.sh
-    - TASK=build-compile SCRIPT=deploy-install.sh
-    - TASK=build-compile SCRIPT=deploy-install-preview.sh
+    - TASK=build-compile SCRIPT=deploy-install.sh WAIT="travis_wait 50"
+    - TASK=build-compile SCRIPT=deploy-install-preview.sh WAIT="travis_wait 50"
 matrix:
   fast_finish: true
   allow_failures:
-    - env: "TASK=\"run-e2e-tests --fast\" SCRIPT=examples-install-preview.sh"
-    - env: "TASK=build-compile SCRIPT=deploy-install-preview.sh"
+    - env: TASK="run-e2e-tests --fast" SCRIPT=examples-install-preview.sh
+    - env: TASK=build-compile SCRIPT=deploy-install-preview.sh WAIT="travis_wait 50"
 before_install:
-  - npm install -g gulp --no-optional
+  - source ./scripts/env-set.sh
+  - ./scripts/before-install.sh
 install:
   - npm install --no-optional
-  - if [[ $SCRIPT ]]; then ./scripts/$SCRIPT; fi
+  - if [[ -n "$SCRIPT" ]]; then echo "EXTRA INSTALL $SCRIPT"; ./scripts/$SCRIPT; fi
 before_script:
   - sh -e /etc/init.d/xvfb start
 script:
-  - gulp $TASK
+  - $WAIT gulp $TASK $TASK_FLAGS

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,13 +116,14 @@ var _exampleConfigFilename = 'example-config.json';
 //
 var lang, langs, buildDartApiDocs = false;
 function configLangs(langOption) {
-  // TODO(chalin): temporary dependence on process.env.TRAVIS until #1910 lands.
-  const buildAllDocs = argv['_'] && argv['_'].indexOf('check-deploy' ) >= 0;
-  const langDefault = (!buildAllDocs || process.env.TRAVIS) ? '(ts|js)' : 'all';
+  const fullSiteBuildTasks = ['build-compile', 'check-serve', 'check-deploy'];
+  const buildAllDocs = argv['_'] && 
+    fullSiteBuildTasks.some((task) => argv['_'].indexOf(task) >= 0);
+  const langDefault = buildAllDocs ? 'all' : '(ts|js)';
   lang = (langOption || langDefault).toLowerCase();
   if (lang === 'all') lang = '(ts|js|dart)';
   langs = lang.match(/\w+/g); // the languages in `lang` as an array
-  gutil.log('Build docs for: ' + lang);
+  gutil.log('Building docs for: ' + lang);
   if (langs.indexOf('dart') >= 0) {
     buildDartApiDocs = true;
     // For Dart, be proactive about checking for the repo

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,17 @@
+name: angular2_io
+description: Angular 2 for Dart Website
+version: 0.0.1
+environment:
+  sdk: '>=1.13.0 <2.0.0'
+dependencies:
+  angular2: 2.0.0-beta.17
+  browser: ^0.10.0
+  dart_to_js_script_rewriter: ^1.0.1
+transformers:
+- angular2:
+    platform_directives:
+    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
+    platform_pipes:
+    - 'package:angular2/common.dart#COMMON_PIPES'
+    entry_points: web/main.dart
+- dart_to_js_script_rewriter

--- a/scripts/before-install.sh
+++ b/scripts/before-install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+./scripts/env-info-and-check.sh
+
+if [[ 0 ]]; then
+    # Doesn't seem to be necessary. Disabling.
+    travis_fold start install.globals
+    set -x
+    npm install -g gulp --no-optional
+    set +x
+    travis_fold end install.globals
+fi

--- a/scripts/deploy-install.sh
+++ b/scripts/deploy-install.sh
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
 
-set -ex -o pipefail
+set -e -o pipefail
 
-(cd ../ && git clone https://github.com/angular/angular.git --branch $LATEST_RELEASE)
+[[ -z "$NGIO_ENV_DEFS" ]] && . ./scripts/env-set.sh
+
+if [[ -e "$NG2_REPO" ]]; then
+    echo Angular2 repo is already present at: $NG2_REPO
+else
+    travis_fold start install.ng2
+    echo GETTING Angular2 from GitHub ...
+    set -x
+    git clone https://github.com/angular/angular.git --branch $LATEST_RELEASE $NG2_REPO
+    set +x
+    travis_fold end install.ng2
+fi
+
+if [[ -e "$NG2DART_REPO" ]]; then
+    echo Angular2 Dart repo is already present at: $NG2DART_REPO
+elif [[ -n "$TRAVIS" ]]; then
+    ./scripts/install-ng2dart.sh
+# else
+#    echo WARNING: no Angular2 Dart repo found at: $NG2DART_REPO
+fi
+
+echo INSTALLED repos:
+ls -ld ../a*

--- a/scripts/env-info-and-check.sh
+++ b/scripts/env-info-and-check.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+travis_fold start env_info
+echo ENVIRONMENT INFO
+travis_fold start env_info.path
+echo Path:
+echo $PATH | tr : '\n'
+echo
+travis_fold end env_info.path
+travis_fold start env_info.home
+echo Home: $HOME
+ls ~ -la
+echo 
+travis_fold end env_info.home
+travis_fold start env_info.pwd
+echo Pwd: `pwd`
+ls -la
+echo
+travis_fold end env_info.pwd
+if [[ 0 ]]; then
+    # Not needed anymore, but keeping it at least for the first commit for archival purposes.
+    travis_fold start env_info.bash_profile
+    echo Bash profile ------------------------------------------------------------
+    cat ~/.bash_profile
+    travis_fold end env_info.bash_profile
+    travis_fold start env_info.bashrc
+    echo Bashrc ------------------------------------------------------------------
+    cat ~/.bashrc
+    echo -------------------------------------------------------------------------
+    travis_fold end env_info.bashrc
+    travis_fold start env_info.build
+    echo build.sh ----------------------------------------------------------------
+    cat ~/build.sh
+    echo -------------------------------------------------------------------------
+    travis_fold end env_info.build
+fi
+travis_fold end env_info
+
+echo ENVIRONMENT CONFIG CHECK:
+if [[ -z "$NGIO_ENV_DEFS" ]]; then
+    echo Environment variables are not being set. Aborting.
+    exit 1;
+else
+    echo Environment variables successfully set.
+fi

--- a/scripts/env-set.sh
+++ b/scripts/env-set.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+if [[ -z "$NGIO_ENV_DEFS" ]]; then
+    export ANSI_YELLOW="\033[33;1m"
+    export ANSI_RESET="\033[0m"
+    echo -e "${ANSI_YELLOW}Setting environment variables from scripts/env.sh${ANSI_RESET}"
+
+    export NGIO_ENV_DEFS=1
+
+    export NG2_REPO=../angular
+    export NG2DART_REPO=$NG2_REPO-dart
+
+    if [ ! $(type -t travis_fold) ]; then
+        # In case this is being run locally. Turn travis_fold into a noop.
+        travis_fold () { return; }
+        # Alternative definition:
+        # travis_fold () { echo -en "travis_fold:${1}:${2}"; }
+    fi
+    export -f travis_fold
+
+    case "$(uname -a)" in
+        Darwin\ *) _OS_NAME=macos ;;
+        Linux\ *) _OS_NAME=linux ;;
+        *) _OS_NAME=linux ;;
+    esac
+    export _OS_NAME
+
+    export TMP=$HOME/tmp
+    export PKG=$TMP/pkg
+
+    export DART_SDK="$PKG/dart-sdk"
+    if [[ ! $PATH =~ */dart-sdk/* ]]; then
+        echo Updating PATH
+        export PATH="$DART_SDK/bin:$PATH"
+        export PATH="$HOME/.pub-cache/bin:$PATH"
+    fi
+fi

--- a/scripts/env-set.sh
+++ b/scripts/env-set.sh
@@ -25,12 +25,14 @@ if [[ -z "$NGIO_ENV_DEFS" ]]; then
     esac
     export _OS_NAME
 
-    export TMP=$HOME/tmp
-    export PKG=$TMP/pkg
+    : ${TMP:=$HOME/tmp}
+    : ${PKG:=$TMP/pkg}
+    export TMP
+    export PKG
 
-    export DART_SDK="$PKG/dart-sdk"
-    if [[ ! $PATH =~ */dart-sdk/* ]]; then
-        echo Updating PATH
+    if [[ -z "$(type -t dart)" && ! $PATH =~ */dart-sdk/* ]]; then
+        export DART_SDK="$PKG/dart-sdk"
+        # echo Updating PATH to include access to Dart bin.
         export PATH="$DART_SDK/bin:$PATH"
         export PATH="$HOME/.pub-cache/bin:$PATH"
     fi

--- a/scripts/install-dart-sdk.sh
+++ b/scripts/install-dart-sdk.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+[[ -z "$NGIO_ENV_DEFS" ]] && . ./scripts/env-set.sh
+
+if  [[ -z "$(type -t dart)" ]]; then
+    travis_fold start install.dart
+    # curl https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-x64-release.zip > $TMP/dartsdk.zip
+    
+    DART_ARCHIVE=https://storage.googleapis.com/dart-archive/channels
+    ARCH=x64
+    VERS=stable/release/latest/sdk
+    OS_ZIP=dartsdk-$_OS_NAME-$ARCH-release.zip
+    URL=$DART_ARCHIVE/$VERS/$OS_ZIP
+
+    echo "Installing Dart SDK from:"
+    echo "  $URL"
+
+    [[ ! -d "$TMP" ]] && mkdir "$TMP"
+    [[ ! -d "$PKG" ]] && mkdir "$PKG"
+
+    curl $URL > "$TMP/$OS_ZIP" 2> /dev/null
+
+    if [[ "1000" -lt "$(wc -c $TMP/$OS_ZIP | awk '{print $1}')" ]]; then
+        unzip "$TMP/$OS_ZIP" -d "$PKG" > /dev/null
+        rm -f "$TMP/$OS_ZIP"
+        # PATH is set in ./scripts/env-set.sh
+        dart --version
+    else
+        echo FAILED to download Dart SDK. Check URL.
+    fi
+    travis_fold end install.dart
+else
+    echo Dart SDK appears to be installed: `type dart`
+    # PATH is set in ./scripts/env-set.sh
+    dart --version
+fi

--- a/scripts/install-ng2dart.sh
+++ b/scripts/install-ng2dart.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+[[ -z "$NGIO_ENV_DEFS" ]] && . ./scripts/env-set.sh
+
+./scripts/install-dart-sdk.sh
+
+travis_fold start install.ng2dart
+if  [[ -z "$(type -t dart)" ]]; then
+    echo "No Dart SDK: aborting install of Angular2/Dart"
+    exit 1;
+elif [[ -e "$NG2DART_REPO" ]]; then
+    echo Angular2/Dart found at: $NG2DART_REPO
+else
+    echo GETTING Angular2/Dart from pub package ...
+    set -x
+    # Get ng2dart via pub on ng.io pubspec.yaml
+    pub upgrade > /dev/null
+
+    NG2DART_PUB=`find ~/.pub-cache/ -type d -name "angular2*" | xargs ls -dtr | tail -1`
+
+    cp -r $NG2DART_PUB $NG2DART_REPO
+fi
+
+# Run pub on ng2dart
+(cd $NG2DART_REPO && pub get)
+set +x
+travis_fold end install.ng2dart

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ npm install --no-optional
 echo "Patching ..."
 source ./scripts/patch.sh
 
-if [ "$TRAVIS" != "true" ]; then
+if [ -z "$TRAVIS" ]; then
     echo "Rebuilding node-sass, just in case ..."
     npm rebuild node-sass;
 fi


### PR DESCRIPTION
- Installs Dart SDK
- Installs ng2/dart sources from the pub package site.
- Re-enables doc build on Travis (which runs `pub` and `dartdoc` over ng2/dart).

**Note**: `npm install -g gulp --no-optional` has been removed since it does not appear to be needed.

Implements most of #1907.