### PR TITLE
chore: add tslint to example package.json

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -73,6 +73,7 @@
     "style-loader": "^0.13.1",
     "ts-loader": "^0.8.2",
     "ts-node": "^0.7.3",
+    "tslint": "^3.13.0",
     "typescript": "^1.8.10",
     "typings": "^1.0.4",
     "webpack": "^1.13.0",


### PR DESCRIPTION
Not sure how it disappeared.