### PR TITLE
examples(tutorial): misc fixes to issues from failed e2e

### DIFF
--- a/public/docs/_examples/toh-1/ts/index.html
+++ b/public/docs/_examples/toh-1/ts/index.html
@@ -17,6 +17,7 @@
     <script>
       System.import('app').catch(function(err){ console.error(err); });
     </script>
+  </head>
 
   <body>
     <my-app>Loading...</my-app>

--- a/public/docs/_examples/toh-2/ts/index.html
+++ b/public/docs/_examples/toh-2/ts/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Angular 2 Tour of Heros</title>
+    <title>Angular 2 Tour of Heroes</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">

--- a/public/docs/_examples/toh-4/dart/web/index.html
+++ b/public/docs/_examples/toh-4/dart/web/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title>Angular 2 Tour of Heroes</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="styles.css">
+
     <script defer src="main.dart" type="application/dart"></script>
     <script defer src="packages/browser/dart.js"></script>
   </head>

--- a/public/docs/_examples/toh-4/ts/app/app.component.1.ts
+++ b/public/docs/_examples/toh-4/ts/app/app.component.1.ts
@@ -34,9 +34,11 @@ export class AppComponent implements OnInit {
   // #enddocregion heroes-prop
   selectedHero: Hero;
 
+  /*
   // #docregion new-service
   heroService = new HeroService(); // don't do this
   // #enddocregion new-service
+  */
   // #docregion ctor
   constructor(private heroService: HeroService) { }
   // #enddocregion ctor


### PR DESCRIPTION
Misc fixes to problems with the tutorial examples, as detected by the new e2e tests. Now the toh-4 index.html is identical to those of the previous parts.

Fixes #1609.
Supersedes #1785.