### PR TITLE
chore(ng2/dart): update from beta.1x to beta.18

### DIFF
--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/component-styles/dart/pubspec.yaml
+++ b/public/docs/_examples/component-styles/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/displaying-data/dart/pubspec.yaml
+++ b/public/docs/_examples/displaying-data/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/pipes/dart/lib/exponential_strength_pipe.dart
+++ b/public/docs/_examples/pipes/dart/lib/exponential_strength_pipe.dart
@@ -13,13 +13,5 @@ import 'package:angular2/angular2.dart';
  */
 @Pipe(name: 'exponentialStrength')
 class ExponentialStrengthPipe extends PipeTransform {
-  num transform(dynamic _value, [List<dynamic> args]) {
-    var exponent = args.isEmpty
-        ? 1
-        : args.first is num
-            ? args.first
-            : num.parse(args.first.toString(), (_) => 1);
-    var value = _value is num ? _value : num.parse(_value.toString(), (_) => 0);
-    return math.pow(value, exponent);
-  }
+  num transform(num value, num exponent) => math.pow(value, exponent);
 }

--- a/public/docs/_examples/pipes/dart/lib/fetch_json_pipe.dart
+++ b/public/docs/_examples/pipes/dart/lib/fetch_json_pipe.dart
@@ -11,7 +11,7 @@ class FetchJsonPipe extends PipeTransform {
   dynamic _fetchedJson;
   String _prevUrl;
 
-  dynamic transform(dynamic url, [List<dynamic> args]) {
+  dynamic transform(String url) {
     if (url != _prevUrl) {
       _prevUrl = url;
       _fetchedJson = null;

--- a/public/docs/_examples/pipes/dart/lib/flying_heroes_component.html
+++ b/public/docs/_examples/pipes/dart/lib/flying_heroes_component.html
@@ -20,7 +20,7 @@ New hero:
 <h4>Heroes who fly (piped)</h4>
 <div id="flyers">
 <!-- #docregion template-flying-heroes -->
-  <div *ngFor="#hero of (heroes | flyingHeroes)">
+  <div *ngFor="let hero of (heroes | flyingHeroes)">
     {{hero.name}}
   </div>
 <!-- #enddocregion template-flying-heroes -->
@@ -30,7 +30,7 @@ New hero:
 <div id="all">
 <!-- #docregion template-1 -->
 <!-- #docregion template-all-heroes -->
-  <div *ngFor="#hero of heroes">
+  <div *ngFor="let hero of heroes">
     {{hero.name}}
   </div>
 <!-- #enddocregion template-all-heroes -->

--- a/public/docs/_examples/pipes/dart/lib/flying_heroes_pipe.dart
+++ b/public/docs/_examples/pipes/dart/lib/flying_heroes_pipe.dart
@@ -6,7 +6,7 @@ import 'heroes.dart';
 @Pipe(name: 'flyingHeroes')
 class FlyingHeroesPipe extends PipeTransform {
   // #docregion filter
-  List<Hero> transform(dynamic value, [List<dynamic> args]) =>
+  List<Hero> transform(List<Hero> value) =>
       value.where((hero) => hero.canFly).toList();
   // #enddocregion filter
 }

--- a/public/docs/_examples/pipes/dart/lib/hero_list_component.dart
+++ b/public/docs/_examples/pipes/dart/lib/hero_list_component.dart
@@ -9,7 +9,7 @@ import 'fetch_json_pipe.dart';
     template: '''
       <h4>Heroes from JSON File</h4>
 
-      <div *ngFor="#hero of ('heroes.json' | fetch) ">
+      <div *ngFor="let hero of ('heroes.json' | fetch) ">
         {{hero['name']}}
       </div>
 

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.15
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/quickstart/dart/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/server-communication/dart/pubspec.yaml
+++ b/public/docs/_examples/server-communication/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
   http: ^0.11.3+3

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-1/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-1/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-2/dart-snippets/app_component_snippets_pt2.dart
+++ b/public/docs/_examples/toh-2/dart-snippets/app_component_snippets_pt2.dart
@@ -1,5 +1,5 @@
 // #docregion ng-for
-<li *ngFor="#hero of heroes">
+<li *ngFor="let hero of heroes">
   <span class="badge">{{hero.id}}</span> {{hero.name}}
 </li>
 // #enddocregion ng-for
@@ -7,14 +7,14 @@
 // #docregion heroes-styled
 <h2>My Heroes</h2>
 <ul class="heroes">
-  <li *ngFor="#hero of heroes">
+  <li *ngFor="let hero of heroes">
     <span class="badge">{{hero.id}}</span> {{hero.name}}
   </li>
 </ul>
 // #enddocregion heroes-styled
 
 // #docregion selectedHero-click
-<li *ngFor="#hero of heroes" (click)="onSelect(hero)">
+<li *ngFor="let hero of heroes" (click)="onSelect(hero)">
   <span class="badge">{{hero.id}}</span> {{hero.name}}
 </li>
 // #enddocregion selectedHero-click
@@ -53,7 +53,7 @@ final List<Hero> heroes = mockHeroes;
 // #enddocregion heroes-template-1
 
 // #docregion heroes-ngfor-1
-<li *ngFor="#hero of heroes">
+<li *ngFor="let hero of heroes">
 // #enddocregion heroes-ngfor-1
 
 // #docregion class-selected-1
@@ -61,7 +61,7 @@ final List<Hero> heroes = mockHeroes;
 // #enddocregion class-selected-1
 
 // #docregion class-selected-2
-<li *ngFor="#hero of heroes"
+<li *ngFor="let hero of heroes"
   [class.selected]="hero == selectedHero"
   (click)="onSelect(hero)">
   <span class="badge">{{hero.id}}</span> {{hero.name}}

--- a/public/docs/_examples/toh-2/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-2/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-3/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-3/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-4/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-4/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-5/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-5/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-6/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-6/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.13.0 <2.0.0'
   # #docregion additions
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   # #enddocregion additions
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/dart/latest/_data.json
+++ b/public/docs/dart/latest/_data.json
@@ -3,7 +3,7 @@
     "icon": "home",
     "title": "Angular Docs",
     "menuTitle": "Docs Home",
-    "banner": "Welcome to <b>angular.io/dart</b>! The current Angular 2 Dart release is <b>beta.17</b>. Consult the <a href='https://github.com/angular/angular/blob/master/CHANGELOG.md' target='_blank'>Change Log</a> about recent enhancements, fixes, and breaking changes."
+    "banner": "Welcome to <b>angular.io/dart</b>! The current Angular 2 Dart release is <b>beta.18</b>. Consult the <a href='https://github.com/angular/angular/blob/master/CHANGELOG.md' target='_blank'>Change Log</a> about recent enhancements, fixes, and breaking changes."
   },
 
   "quickstart": {

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -31,7 +31,7 @@ block package-and-config-files
     packages as dependencies, as well as the `angular2` transformer.
     It can also specify other packages and transformers for the app to use,
     such as [dart_to_js_script_rewriter](https://pub.dartlang.org/packages/dart_to_js_script_rewriter).
-    Angular 2 is still changing, so provide an exact version: **2.0.0-beta.17**.
+    Angular 2 is still changing, so provide an exact version: **2.0.0-beta.18**.
 
     [pubspec]: https://www.dartlang.org/tools/pub/pubspec.html
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.18
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:


### PR DESCRIPTION
Update made to all `pubspec.yaml` files and to relevant prose.
Note that pipes was back a beta.15; the rest were at beta.17.

Updates to pipe example source code:
- Pipe `transform()` method parameters
- `ngFor` microsyntax, from `#` to `let`

Suites passed:
- public/docs/_examples/architecture/dart
- public/docs/_examples/attribute-directives/dart
- public/docs/_examples/dependency-injection/dart
- public/docs/_examples/displaying-data/dart
- public/docs/_examples/forms/dart
- public/docs/_examples/lifecycle-hooks/dart
- public/docs/_examples/quickstart/dart
- public/docs/_examples/server-communication/dart
- public/docs/_examples/template-syntax/dart
- public/docs/_examples/toh-1/dart
- public/docs/_examples/toh-2/dart
- public/docs/_examples/toh-3/dart
- public/docs/_examples/toh-4/dart
- public/docs/_examples/toh-5/dart
- public/docs/_examples/user-input/dart
Suites failed:
- public/docs/_examples/pipes/dart

One test if failing for pipes. An issue will be filed for that.

cc @kwalrath 