### PR TITLE
UWaterloo Amandaegraham edit

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -41,7 +41,7 @@ block includes
 .l-main-section
 :marked
   ## HTML
-  HTML is the language of the Angular template. Our [QuickStart](../quickstart.html) application had a template that was pure HTML:
+  HTML is the language of the Angular template. Our [QuickStart](../quickstart.html) application has a template that is pure HTML:
 
 code-example(language="html" escape="html").
   <h1>My First Angular 2 App</h1>
@@ -51,7 +51,7 @@ code-example(language="html" escape="html").
 
   Some legal HTML doesn’t make much sense in a template. The `<html>`, `<body>`, and `<base>` elements have no useful role in our repertoire. Pretty much everything else is fair game.
 
-  We can extend the HTML vocabulary of our templates with components and directives that appear as new elements and attributes. And we are about to learn how to get and set DOM values dynamically through data binding.
+  We can extend the HTML vocabulary of our templates with components and directives that appear as new elements and attributes. In the following sections we are going to learn how to get and set DOM (Document Object Model) values dynamically through data binding.
 
   Let’s turn to the first form of data binding &mdash; interpolation &mdash; to see how much richer template HTML can be.
 

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -66,8 +66,8 @@ code-example(language="html" escape="html").
 +makeExample('template-syntax/ts/app/app.component.html', 'title+image')(format=".")
 :marked
   The material between the braces is often the name of a component property. Angular replaces that name with the
-  string value of the corresponding component property. In this example, Angular evaluates the `title` and `heroImageUrl` properties
-  and "fills in the blanks", displaying first a bold application title and then a heroic image.
+  string value of the corresponding component property. In the example above, Angular evaluates the `title` and `heroImageUrl` properties
+  and "fills in the blanks", first displaying a bold application title and then a heroic image.
 
   More generally, the material between the braces is a **template expression** that Angular first **evaluates**
   and then **converts to a string**. The following interpolation illustrates the point by adding the two numbers within braces:
@@ -76,13 +76,13 @@ code-example(language="html" escape="html").
   The expression can invoke methods of the host component, as we do here with `getVal()`:
 +makeExample('template-syntax/ts/app/app.component.html', 'sum-2')(format=".")
 :marked
-  Angular evaluates all expressions in double curly braces, converts the expression results to strings, and concatenates them with neighboring literal strings. Finally,
+  Angular evaluates all expressions in double curly braces, converts the expression results to strings, and links them with neighboring literal strings. Finally,
   it assigns this composite interpolated result to an **element or directive property**.
 
-  We appear to be inserting the result between element tags and assigning to attributes.
+  We appear to be inserting the result between element tags and assigning it to attributes.
   It's convenient to think so, and we rarely suffer for this mistake.
-  But it is not literally true. Interpolation is a special syntax that Angular converts into a
-  [property binding](#property-binding), as we'll explain below.
+  Though this is not exactly true. Interpolation is a special syntax that Angular converts into a
+  [property binding](#property-binding), and is explained below.
 
   But first, let's take a closer look at template expressions and statements.
 

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -1401,11 +1401,11 @@ h3#aliasing-io Aliasing input/output properties
 :marked
   <a id="pipe"></a>
   ### The pipe operator ( | )
+  Pipes are simple functions that accept an input value and return a transformed value.
   The result of an expression might require some transformation before we’re ready to use it in a binding.  For example, we might want to display a number as a currency, force text to uppercase, or filter a list and sort it.
 
-  Angular [pipes](./pipes.html) are a good choice for small transformations such as these.
-  Pipes are simple functions that accept an input value and return a transformed value.
-  They're easy to apply within template expressions, using the **pipe operator (`|`)**:
+  Angular [pipes](./pipes.html) are a good choice for small transformations such as those listed above.
+  Pipe operators are easy to apply within template expressions, using the **pipe operator (`|`)**:
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-1')(format=".")
 :marked
   The pipe operator passes the result of an expression on the left to a pipe function on the right.
@@ -1413,7 +1413,7 @@ h3#aliasing-io Aliasing input/output properties
   We can chain expressions through multiple pipes:
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-2')(format=".")
 :marked
-  And we can also [apply parameters](./pipes.html#parameterizing-a-pipe) to a pipe:
+  We can also [apply parameters](./pipes.html#parameterizing-a-pipe) to a pipe:
 +makeExample('template-syntax/ts/app/app.component.html', 'pipes-3')(format=".")
 
 block json-pipe
@@ -1421,7 +1421,7 @@ block json-pipe
     The `json` pipe is particularly helpful for debugging our bindings:
   +makeExample('template-syntax/ts/app/app.component.html', 'pipes-json')(format=".")
   :marked
-    The generated output would look something like this
+    The generated output would look something like this:
   code-example(language="json").
     { "firstName": "Hercules", "lastName": "Son of Zeus",
       "birthdate": "1970-02-25T08:00:00.000Z",
@@ -1433,7 +1433,7 @@ block json-pipe
   ### The safe navigation operator ( ?. ) and null property paths
 
   The Angular **safe navigation operator (`?.`)** is a fluent and convenient way to guard against null and undefined values in property paths.
-  Here it is, protecting against a view render failure if the `currentHero` is null.
+  Here it is used to protect against against a view render failure if the `currentHero` is null:
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-2')(format=".")
 
 block dart-safe-nav-op
@@ -1446,10 +1446,10 @@ block dart-safe-nav-op
 +makeExample('template-syntax/ts/app/app.component.html', 'safe-1')(format=".")
 :marked
   The view still renders but the displayed value is blank; we see only "The title is" with nothing after it.
-  That is reasonable behavior. At least the app doesn't crash.
+  That is reasonable a behavior. At least the app doesn't crash.
 
-  Suppose the template expression involves a property path, as in this next example
-  where we’re displaying the `firstName` of a null hero.
+  Suppose the template expression involves a property path, as seen in this next example
+  where we’re displaying the `firstName` of a null hero:
 
 code-example(language="html").
   The null hero's name is {{nullHero.firstName}}


### PR DESCRIPTION
Edited HTML, Interpolation and Template Expression Operator sections 

Changes: 
- Changed tense from past to present 
- Reworded sentences 
- Added acronym descriptions 
- Changed concatenates to links 
- Rewrote sentences to not start with 'and'
- Changed pip operator order to have introduction 
- Added ':' before example descriptions 
