### PR TITLE
chore: remove global variable at plunker-builder

### DIFF
--- a/tools/plunker-builder/plunkerBuilder.js
+++ b/tools/plunker-builder/plunkerBuilder.js
@@ -224,8 +224,7 @@ function encodeBase64(file) {
 }
 
 function createPlunkerHtml(postData) {
-  useNewWindow = false;
-  var baseHtml = createBasePlunkerHtml(useNewWindow);
+  var baseHtml = createBasePlunkerHtml(false);
   var doc = jsdom.jsdom(baseHtml);
   var form = doc.querySelector('form');
   _.forEach(postData, function(value, key) {


### PR DESCRIPTION
that `useNewWindow` is a global variable but the reality is that we don't need it.