### PR TITLE
docs(router): Minor content update for Heroes tutorial

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/app.component.3.ts
+++ b/public/docs/_examples/toh-5/ts/app/app.component.3.ts
@@ -11,10 +11,8 @@ import { HeroService } from './hero.service';
   template: `
     <h1>{{title}}</h1>
     <nav>
-      // #docregion router-link-active
-      <a [routerLink]="['/dashboard']" routerLinkActive="active">Dashboard</a>
-      <a [routerLink]="['/heroes']" routerLinkActive="active">Heroes</a>
-      // #enddocregion router-link-active
+      <a [routerLink]="['/dashboard']">Dashboard</a>
+      <a [routerLink]="['/heroes']">Heroes</a>
     </nav>
     <router-outlet></router-outlet>
   `,

--- a/public/docs/_examples/toh-5/ts/app/app.component.ts
+++ b/public/docs/_examples/toh-5/ts/app/app.component.ts
@@ -11,8 +11,10 @@ import { HeroService } from './hero.service';
   template: `
     <h1>{{title}}</h1>
     <nav>
+      // #docregion router-link-active
       <a [routerLink]="['/dashboard']" routerLinkActive="active">Dashboard</a>
       <a [routerLink]="['/heroes']" routerLinkActive="active">Heroes</a>
+      // #enddocregion router-link-active
     </nav>
     <router-outlet></router-outlet>
   `,

--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -265,7 +265,7 @@ code-example(language="bash").
 :marked
   Finally, add a dashboard navigation link to the template, just above the *Heroes* link.
 
-+makeExample('toh-5/ts/app/app.component.ts','template', 'app/app.component.ts (template)')(format=".")
++makeExample('toh-5/ts/app/app.component.3.ts','template', 'app/app.component.ts (template)')(format=".")
 .l-sub-section
   :marked
     We nestled the two links within `<nav>` tags.
@@ -626,7 +626,7 @@ figure.image-display
     The Angular Router provides a `routerLinkActive` directive we can use to
     add a class to the HTML navigation element whose route matches the active route.
     All we have to do is define the style for it. Sweet!
-+makeExample('toh-5/ts/app/app.component.3.ts', 'router-link-active', 'app/app.component.ts (active router links)')(format=".")
++makeExample('toh-5/ts/app/app.component.ts', 'router-link-active', 'app/app.component.ts (active router links)')(format=".")
 :marked
   Set the `AppComponent`’s `styleUrls` property to this CSS file.
 +makeExample('toh-5/ts/app/app.component.ts','style-urls', 'app/app.component.ts (styleUrls)')(format=".")

--- a/tools/api-builder/links-package/inline-tag-defs/linkDocs.js
+++ b/tools/api-builder/links-package/inline-tag-defs/linkDocs.js
@@ -45,7 +45,7 @@ module.exports = function linkDocsInlineTagDef(parseArgString, createDocMessage,
         var vers = _self.vers;
         var prevUri = uri;
         uri = path.join(lang, vers, uri);
-        log.info('Ajusted linkDocs chapter-relative uri (' + doc.fileInfo.baseName + '): ' + prevUri + ' -> ' + uri);
+        log.info('Adjusted linkDocs chapter-relative uri (' + doc.fileInfo.baseName + '): ' + prevUri + ' -> ' + uri);
       }
 
       var isValid = false;

--- a/tools/doc-shredder/processors/shredMapProcessor.js
+++ b/tools/doc-shredder/processors/shredMapProcessor.js
@@ -43,7 +43,7 @@ module.exports = function shredMapProcessor(log, createDocMessage) {
             mixinPath = appProjDirName + '/' + lang + '/' + mixinPath;
             fragInfo = makeFragInfo(options.fragmentsDir, fullExamplePath, fragItem, mixinPath);
             if (fragInfo.exists) {
-              log.info('Ajusted example path (' + doc.fileInfo.baseName + '): ' + appProjRelPath + ' -> ' + mixinPath);
+              log.info('Adjusted example path (' + doc.fileInfo.baseName + '): ' + appProjRelPath + ' -> ' + mixinPath);
             } else {
                 fragInfo = savedFragInfo;
             }


### PR DESCRIPTION
Delete routerLinkActive from one of the earlier code examples as it is not relevant to what the user is trying to achieve at that point in the tutorial

When I was running through the tutorial, it said "Finally, add a dashboard navigation link to the template, just above the Heroes link.", but the code sample showed the routerLinkActive attribute added as well to the code. I was wondering "what's that for? why are both links being set as active?". I only realised what it was for later on in the tutorial in the section that describes the directive. It's not relevant to adding a new navigation link and can detract from the flow of the tutorial so it's better it only gets added in the bit that actually discusses it.