### PR TITLE
docs(dependency-injection): Clarify how TypeScript generates decorator metadata

### DIFF
--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -432,7 +432,8 @@ block injectable-not-always-needed-in-ts
     :marked
       Injectors use a class's constructor metadata to determine dependent types as
       identified by the constructor's parameter types.
-      TypeScript generates such metadata for any class with a decorator, and any decorator will do.
+      TypeScript generates such metadata for any class with a decorator (if 
+      `emitDecoratorMetadata` compiler option is set to true), and any decorator will do.
       But of course, it is more meaningful to mark a class using the appropriate
       <a href="#{injMetaUrl}">InjectableMetadata</a> #{_decorator}.
 


### PR DESCRIPTION
I think it's important to mention the compiler option. After reading the note I wanted to see how this magic works and what it looks like in a compiled javascript and tried to make a simple test in TypeScript playground. I got nothing and it took some time to figure out that a compiler option is involved in this.