### PR TITLE
docs(architecture): rename missing library

### DIFF
--- a/public/docs/ts/latest/guide/architecture.jade
+++ b/public/docs/ts/latest/guide/architecture.jade
@@ -120,7 +120,7 @@ block angular-library-modules
   `!{_at_angular}/core` is the primary Angular library from which we get most of what we need.
   <br clear="all">
 
-  There are other important Angular libraries too, such as `!{_at_angular}/common`, `!{_at_angular}/router`, and `!{_at_angular}/animate`.
+  There are other important Angular libraries too, such as `!{_at_angular}/common`, `!{_at_angular}/router`, and `!{_at_angular}/http`.
   We import what we need from an Angular !{_library_module}.
 
 block angular-imports


### PR DESCRIPTION
@angular/animate doesn't exist, so let's use http so we don't change the sentence.

Fixes #1970 