### PR TITLE
docs(toh): add return types

### DIFF
--- a/public/docs/_examples/toh-2/ts/app/app.component.ts
+++ b/public/docs/_examples/toh-2/ts/app/app.component.ts
@@ -102,6 +102,8 @@ export class AppComponent {
   // #enddocregion selected-hero
 
   // #docregion on-select
-  onSelect(hero: Hero) { this.selectedHero = hero; }
+  onSelect(hero: Hero): void {
+    this.selectedHero = hero;
+  }
   // #enddocregion on-select
 }

--- a/public/docs/_examples/toh-3/ts/app/app.component.ts
+++ b/public/docs/_examples/toh-3/ts/app/app.component.ts
@@ -89,5 +89,7 @@ export class AppComponent {
   heroes = HEROES;
   selectedHero: Hero;
 
-  onSelect(hero: Hero) { this.selectedHero = hero; }
+  onSelect(hero: Hero): void {
+    this.selectedHero = hero;
+  }
 }

--- a/public/docs/_examples/toh-4/ts/app/app.component.1.ts
+++ b/public/docs/_examples/toh-4/ts/app/app.component.1.ts
@@ -7,7 +7,7 @@ import { Component } from '@angular/core';
 
 import { Hero } from './hero';
 // #docregion hero-service-import
-import { HeroService } from './hero.service.1';
+import { HeroService } from './hero.service.2';
 // #enddocregion hero-service-import
 
 // Testable but never shown
@@ -41,7 +41,7 @@ export class AppComponent implements OnInit {
   constructor(private heroService: HeroService) { }
   // #enddocregion ctor
   // #docregion getHeroes
-  getHeroes() {
+  getHeroes(): void {
     // #docregion get-heroes
     this.heroes = this.heroService.getHeroes();
     // #enddocregion get-heroes
@@ -50,7 +50,7 @@ export class AppComponent implements OnInit {
 
   // #docregion ng-on-init
   // #docregion on-init
-  ngOnInit() {
+  ngOnInit(): void {
     // #enddocregion on-init
     this.getHeroes();
     // #docregion on-init
@@ -58,6 +58,8 @@ export class AppComponent implements OnInit {
   // #enddocregion on-init
   // #enddocregion ng-on-init
 
-  onSelect(hero: Hero) { this.selectedHero = hero; }
+  onSelect(hero: Hero): void {
+    this.selectedHero = hero;
+  }
   // #docregion on-init
 }

--- a/public/docs/_examples/toh-4/ts/app/app.component.ts
+++ b/public/docs/_examples/toh-4/ts/app/app.component.ts
@@ -82,14 +82,16 @@ export class AppComponent implements OnInit {
   constructor(private heroService: HeroService) { }
 
 // #docregion get-heroes
-  getHeroes() {
+  getHeroes(): void {
     this.heroService.getHeroes().then(heroes => this.heroes = heroes);
   }
 // #enddocregion get-heroes
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.getHeroes();
   }
 
-  onSelect(hero: Hero) { this.selectedHero = hero; }
+  onSelect(hero: Hero): void {
+    this.selectedHero = hero;
+  }
 }

--- a/public/docs/_examples/toh-4/ts/app/hero.service.1.ts
+++ b/public/docs/_examples/toh-4/ts/app/hero.service.1.ts
@@ -10,10 +10,7 @@ import { HEROES } from './mock-heroes';
 @Injectable()
 export class HeroService {
   // #enddocregion empty-class
-  getHeroes() {
-    // #enddocregion getHeroes-stub
-    return HEROES;
-    // #docregion getHeroes-stub
+  getHeroes(): void {
   }
   // #docregion empty-class
 }

--- a/public/docs/_examples/toh-4/ts/app/hero.service.1.ts
+++ b/public/docs/_examples/toh-4/ts/app/hero.service.1.ts
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion
-// #docregion empty-class
+// #docregion empty-class, full
 import { Injectable } from '@angular/core';
 
 // #enddocregion empty-class
@@ -9,8 +9,16 @@ import { HEROES } from './mock-heroes';
 // #docregion empty-class, getHeroes-stub
 @Injectable()
 export class HeroService {
-  // #enddocregion empty-class
+  // #enddocregion empty-class, getHeroes-stub, full
+  /*
+  // #docregion getHeroes-stub
   getHeroes(): void {
   }
-  // #docregion empty-class
+  // #enddocregion getHeroes-stub
+  */
+  // #docregion full
+  getHeroes(): Hero[] {
+    return HEROES;
+  }
+  // #docregion empty-class, getHeroes-stub
 }

--- a/public/docs/_examples/toh-4/ts/app/hero.service.2.ts
+++ b/public/docs/_examples/toh-4/ts/app/hero.service.2.ts
@@ -1,0 +1,13 @@
+// #docregion
+import { Injectable } from '@angular/core';
+
+import { Hero } from './hero';
+import { HEROES } from './mock-heroes';
+
+@Injectable()
+export class HeroService {
+
+  getHeroes(): Hero[] {
+    return HEROES;
+  }
+}

--- a/public/docs/_examples/toh-4/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-4/ts/app/hero.service.ts
@@ -9,14 +9,14 @@ import { HEROES } from './mock-heroes';
 @Injectable()
 export class HeroService {
   // #docregion get-heroes
-  getHeroes() {
+  getHeroes(): Promise<Hero[]> {
     return Promise.resolve(HEROES);
   }
   // #enddocregion get-heroes, just-get-heroes
   // #enddocregion
   // See the "Take it slow" appendix
   // #docregion get-heroes-slowly
-  getHeroesSlowly() {
+  getHeroesSlowly(): Promise<Hero[]> {
     return new Promise<Hero[]>(resolve =>
       setTimeout(() => resolve(HEROES), 2000) // 2 seconds
     );

--- a/public/docs/_examples/toh-5/ts/app/dashboard.component.2.ts
+++ b/public/docs/_examples/toh-5/ts/app/dashboard.component.2.ts
@@ -17,10 +17,10 @@ export class DashboardComponent implements OnInit {
 
   constructor(private heroService: HeroService) { }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.heroService.getHeroes()
       .then(heroes => this.heroes = heroes.slice(1, 5));
   }
 
-  gotoDetail() { /* not implemented yet */}
+  gotoDetail(): void { /* not implemented yet */}
 }

--- a/public/docs/_examples/toh-5/ts/app/dashboard.component.ts
+++ b/public/docs/_examples/toh-5/ts/app/dashboard.component.ts
@@ -29,13 +29,13 @@ export class DashboardComponent implements OnInit {
   }
   // #enddocregion ctor
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.heroService.getHeroes()
       .then(heroes => this.heroes = heroes.slice(1, 5));
   }
 
   // #docregion goto-detail
-  gotoDetail(hero: Hero) {
+  gotoDetail(hero: Hero): void {
     let link = ['/detail', hero.id];
     this.router.navigate(link);
   }

--- a/public/docs/_examples/toh-5/ts/app/hero-detail.component.ts
+++ b/public/docs/_examples/toh-5/ts/app/hero-detail.component.ts
@@ -35,7 +35,7 @@ export class HeroDetailComponent implements OnInit {
   // #enddocregion ctor
 
   // #docregion ng-oninit
-  ngOnInit() {
+  ngOnInit(): void {
     // #docregion get-id
     this.route.params.forEach((params: Params) => {
       let id = +params['id'];
@@ -47,7 +47,7 @@ export class HeroDetailComponent implements OnInit {
   // #enddocregion ng-oninit
 
   // #docregion go-back
-  goBack() {
+  goBack(): void {
     window.history.back();
   }
 // #enddocregion go-back

--- a/public/docs/_examples/toh-5/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-5/ts/app/hero.service.ts
@@ -6,19 +6,19 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class HeroService {
-  getHeroes() {
+  getHeroes(): Promise<Hero[]> {
     return Promise.resolve(HEROES);
   }
 
   // See the "Take it slow" appendix
-  getHeroesSlowly() {
+  getHeroesSlowly(): Promise<Hero[]> {
     return new Promise<Hero[]>(resolve =>
       setTimeout(() => resolve(HEROES), 2000) // 2 seconds
     );
   }
 
   // #docregion get-hero
-  getHero(id: number) {
+  getHero(id: number): Promise<Hero> {
     return this.getHeroes()
                .then(heroes => heroes.find(hero => hero.id === id));
   }

--- a/public/docs/_examples/toh-5/ts/app/heroes.component.ts
+++ b/public/docs/_examples/toh-5/ts/app/heroes.component.ts
@@ -25,17 +25,19 @@ export class HeroesComponent implements OnInit {
     private router: Router,
     private heroService: HeroService) { }
 
-  getHeroes() {
+  getHeroes(): void {
     this.heroService.getHeroes().then(heroes => this.heroes = heroes);
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.getHeroes();
   }
 
-  onSelect(hero: Hero) { this.selectedHero = hero; }
+  onSelect(hero: Hero): void {
+    this.selectedHero = hero;
+  }
 
-  gotoDetail() {
+  gotoDetail(): void {
     this.router.navigate(['/detail', this.selectedHero.id]);
   }
   // #docregion heroes-component-renaming

--- a/public/docs/_examples/toh-6/ts/app/dashboard.component.ts
+++ b/public/docs/_examples/toh-6/ts/app/dashboard.component.ts
@@ -19,12 +19,12 @@ export class DashboardComponent implements OnInit {
     private heroService: HeroService) {
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.heroService.getHeroes()
       .then(heroes => this.heroes = heroes.slice(1, 5));
   }
 
-  gotoDetail(hero: Hero) {
+  gotoDetail(hero: Hero): void {
     let link = ['/detail', hero.id];
     this.router.navigate(link);
   }

--- a/public/docs/_examples/toh-6/ts/app/hero-detail.component.ts
+++ b/public/docs/_examples/toh-6/ts/app/hero-detail.component.ts
@@ -27,7 +27,7 @@ export class HeroDetailComponent implements OnInit {
   }
 
   // #docregion ngOnInit
-  ngOnInit() {
+  ngOnInit(): void {
     this.route.params.forEach((params: Params) => {
       if (params['id'] !== undefined) {
         let id = +params['id'];
@@ -43,7 +43,7 @@ export class HeroDetailComponent implements OnInit {
   // #enddocregion ngOnInit
 
   // #docregion save
-  save() {
+  save(): void {
     this.heroService
         .save(this.hero)
         .then(hero => {
@@ -54,7 +54,7 @@ export class HeroDetailComponent implements OnInit {
   }
   // #enddocregion save
   // #docregion goBack
-  goBack(savedHero: Hero = null) {
+  goBack(savedHero: Hero = null): void {
     this.close.emit(savedHero);
     if (this.navigated) { window.history.back(); }
   }

--- a/public/docs/_examples/toh-6/ts/app/hero-search.component.ts
+++ b/public/docs/_examples/toh-6/ts/app/hero-search.component.ts
@@ -28,11 +28,13 @@ export class HeroSearchComponent implements OnInit {
   // #docregion searchTerms
 
   // Push a search term into the observable stream.
-  search(term: string) { this.searchTerms.next(term); }
+  search(term: string): void {
+    this.searchTerms.next(term);
+  }
   // #enddocregion searchTerms
   // #docregion search
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.heroes = this.searchTerms
       .debounceTime(300)        // wait for 300ms pause in events
       .distinctUntilChanged()   // ignore if next search term is same as previous
@@ -49,7 +51,7 @@ export class HeroSearchComponent implements OnInit {
   }
   // #enddocregion search
 
-  gotoDetail(hero: Hero) {
+  gotoDetail(hero: Hero): void {
     let link = ['/detail', hero.id];
     this.router.navigate(link);
   }

--- a/public/docs/_examples/toh-6/ts/app/hero-search.service.ts
+++ b/public/docs/_examples/toh-6/ts/app/hero-search.service.ts
@@ -1,6 +1,7 @@
 // #docregion
 import { Injectable }     from '@angular/core';
 import { Http, Response } from '@angular/http';
+import { Observable } from 'rxjs';
 
 import { Hero }           from './hero';
 
@@ -9,7 +10,7 @@ export class HeroSearchService {
 
   constructor(private http: Http) {}
 
-  search(term: string) {
+  search(term: string): Observable<Hero[]> {
     return this.http
                .get(`app/heroes/?name=${term}`)
                .map((r: Response) => r.json().data as Hero[]);

--- a/public/docs/_examples/toh-6/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-6/ts/app/hero.service.ts
@@ -1,7 +1,7 @@
 // #docplaster
 // #docregion
 import { Injectable }    from '@angular/core';
-import { Headers, Http } from '@angular/http';
+import { Headers, Http, Response } from '@angular/http';
 
 // #docregion rxjs
 import 'rxjs/add/operator/toPromise';
@@ -17,7 +17,7 @@ export class HeroService {
 
   constructor(private http: Http) { }
 
-  getHeroes() {
+  getHeroes(): Promise<Hero[]> {
     return this.http.get(this.heroesUrl)
     // #docregion to-promise
                .toPromise()
@@ -31,7 +31,7 @@ export class HeroService {
   }
   // #enddocregion getHeroes
 
-  getHero(id: number) {
+  getHero(id: number): Promise<Hero> {
     return this.getHeroes()
                .then(heroes => heroes.find(hero => hero.id === id));
   }
@@ -46,7 +46,7 @@ export class HeroService {
   // #enddocregion save
 
   // #docregion delete
-  delete(hero: Hero) {
+  delete(hero: Hero): Promise<Response> {
     let headers = new Headers();
     headers.append('Content-Type', 'application/json');
 
@@ -75,7 +75,7 @@ export class HeroService {
 
   // #docregion put
   // Update existing Hero
-  private put(hero: Hero) {
+  private put(hero: Hero): Promise<Hero> {
     let headers = new Headers();
     headers.append('Content-Type', 'application/json');
 
@@ -90,7 +90,7 @@ export class HeroService {
   // #enddocregion put
 
   // #docregion handleError
-  private handleError(error: any) {
+  private handleError(error: any): Promise<any> {
     console.error('An error occurred', error);
     return Promise.reject(error.message || error);
   }

--- a/public/docs/_examples/toh-6/ts/app/heroes.component.ts
+++ b/public/docs/_examples/toh-6/ts/app/heroes.component.ts
@@ -24,7 +24,7 @@ export class HeroesComponent implements OnInit {
     private router: Router,
     private heroService: HeroService) { }
 
-  getHeroes() {
+  getHeroes(): void {
     this.heroService
         .getHeroes()
         .then(heroes => this.heroes = heroes)
@@ -32,19 +32,19 @@ export class HeroesComponent implements OnInit {
   }
 
   // #docregion addHero
-  addHero() {
+  addHero(): void {
     this.addingHero = true;
     this.selectedHero = null;
   }
 
-  close(savedHero: Hero) {
+  close(savedHero: Hero): void {
     this.addingHero = false;
     if (savedHero) { this.getHeroes(); }
   }
   // #enddocregion addHero
 
   // #docregion deleteHero
-  deleteHero(hero: Hero, event: any) {
+  deleteHero(hero: Hero, event: any): void {
     event.stopPropagation();
     this.heroService
         .delete(hero)
@@ -56,16 +56,16 @@ export class HeroesComponent implements OnInit {
   }
   // #enddocregion deleteHero
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.getHeroes();
   }
 
-  onSelect(hero: Hero) {
+  onSelect(hero: Hero): void {
     this.selectedHero = hero;
     this.addingHero = false;
   }
 
-  gotoDetail() {
+  gotoDetail(): void {
     this.router.navigate(['/detail', this.selectedHero.id]);
   }
 }

--- a/public/docs/ts/latest/tutorial/toh-pt4.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt4.jade
@@ -129,7 +129,7 @@ code-example(language="bash").
   ### Return Mocked Heroes
   Back in the `HeroService`  we import the mock `HEROES` and return it from the `getHeroes` method.
   Our `HeroService` looks like this:
-+makeExample('toh-4/ts/app/hero.service.1.ts', null, 'app/hero.service.ts')(format=".")
++makeExample('toh-4/ts/app/hero.service.2.ts', null, 'app/hero.service.ts')(format=".")
 :marked
   ### Use the Hero Service
   We're ready to use the `HeroService` in other components starting with our `AppComponent`.

--- a/public/docs/ts/latest/tutorial/toh-pt4.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt4.jade
@@ -129,7 +129,7 @@ code-example(language="bash").
   ### Return Mocked Heroes
   Back in the `HeroService`  we import the mock `HEROES` and return it from the `getHeroes` method.
   Our `HeroService` looks like this:
-+makeExample('toh-4/ts/app/hero.service.2.ts', null, 'app/hero.service.ts')(format=".")
++makeExample('toh-4/ts/app/hero.service.1.ts', 'full', 'app/hero.service.ts')(format=".")
 :marked
   ### Use the Hero Service
   We're ready to use the `HeroService` in other components starting with our `AppComponent`.


### PR DESCRIPTION
So this PR adds return types for ToH. Since we print the code on the screen (as snippets in our guide), it is nice to have those return types on the signature so the readers can see what a method returns.