### PR TITLE
hide notes if none are found

### DIFF
--- a/tools/api-builder/angular.io-package/templates/layout/_how-to-use.html
+++ b/tools/api-builder/angular.io-package/templates/layout/_how-to-use.html
@@ -1,10 +1,8 @@
+{%- if doc.howToUse %}
 div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") How to use
   div(flex="80" flex-xs="100")
     :marked
-    {%- if doc.howToUse %}
 {$ doc.howToUse | indentForMarkdown(6) $}
-    {% else %}
-      *Not yet documented*
-    {% endif %}
+{% endif %}

--- a/tools/api-builder/angular.io-package/templates/layout/_what-it-does.html
+++ b/tools/api-builder/angular.io-package/templates/layout/_what-it-does.html
@@ -1,10 +1,8 @@
+{%- if doc.whatItDoes %}
 div(layout="row" layout-xs="column" class="row-margin ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") What it does
   div(flex="80" flex-xs="100")
     :marked
-    {%- if doc.whatItDoes %}
 {$ doc.whatItDoes | indentForMarkdown(6) $}
-    {% else %}
-      *Not yet documented*
-    {% endif %}
+{% endif %}


### PR DESCRIPTION
#### Changes
* Hide "How To Use" and "What It Does" whenever no notes are found.

#### Closes
* https://github.com/angular/angular.io/issues/1963

@naomiblack 