### PR TITLE
change arrow style function to regular function

### DIFF
--- a/public/resources/js/directives/api-list.js
+++ b/public/resources/js/directives/api-list.js
@@ -39,8 +39,9 @@ angularIO.directive('apiList', function () {
         { cssClass: 'const', title: 'Const', matches: ['var', 'let', 'const'] }
       ];
 
-      if (isForDart) $ctrl.apiTypes = $ctrl.apiTypes.filter((t) => 
-        !t.cssClass.match(/^(stable|directive|decorator|interface|enum)$/));
+      if (isForDart) $ctrl.apiTypes = $ctrl.apiTypes.filter(function (t) {
+        return !t.cssClass.match(/^(stable|directive|decorator|interface|enum)$/);
+      });
 
       $ctrl.apiFilter = getApiFilterFromLocation();
       $ctrl.apiType = getApiTypeFromLocation();


### PR DESCRIPTION
#### Changes:
* Change arrow function to regular function. Safari does not support arrow functions yet, and as a result, it was giving a syntax error on the API reference page.

#### Closes:
* https://github.com/angular/angular.io/issues/1981

@naomiblack who uses Safari? 😄 