### PR TITLE
output an audit file to keep track of documentation progress on API

### DIFF
--- a/tools/api-builder/angular.io-package/index.js
+++ b/tools/api-builder/angular.io-package/index.js
@@ -135,6 +135,12 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
     pathTemplate: 'api-list.json',
     outputPathTemplate: '${path}'
   });
+  
+  computePathsProcessor.pathTemplates.push({
+    docTypes: ['api-list-data'],
+    pathTemplate: 'api-list-audit.json',
+    outputPathTemplate: '${path}'
+  });
 
   computePathsProcessor.pathTemplates.push({
     docTypes: ['cheatsheet-data'],

--- a/tools/api-builder/angular.io-package/templates/api-list-audit.template.html
+++ b/tools/api-builder/angular.io-package/templates/api-list-audit.template.html
@@ -1,0 +1,15 @@
+[{% for module, items in doc.data %}
+  {% for item in items %}
+    {
+      "title": "{$ item.title $}",
+      "path": "{$ item.exportDoc.path $}",
+      "docType": "{$ item.docType $}",
+      "stability": "{$ item.stability $}",
+      "secure": "{$ item.security $}",
+      "howToUse": "{$ item.howToUse $}",
+      "whatItDoes": {% if item.whatItDoes %}"Exists"{% else %}"Not Done"{% endif %},
+      "barrel" : "{$ module | replace("/index", "") $}"
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+  {% endfor %}
+]


### PR DESCRIPTION
#### Changes
* The command `gulp build-api-doc` will output a file called `ts/.../api-list-audit.json` and `js/.../api-list-audit.json`. Why? @naomiblack wants the API reference outputted in the format of `api-list-audit.template.html` so that she can keep track of progress documenting the Angular 2 APIs.
* Creating the file produces no visible side-effects on angular.io, besides the new files created after the build is made.