### PR TITLE
docs(pipes): add a section about the Intl API

### DIFF
--- a/public/docs/ts/latest/guide/pipes.jade
+++ b/public/docs/ts/latest/guide/pipes.jade
@@ -39,6 +39,14 @@ block includes
   [pipe operator](./template-syntax.html#pipe) ( | ) to the [Date pipe](../api/common/index/DatePipe-class.html)
   function on the right. All pipes work this way.
 
+.l-sub-section
+  :marked
+    The `Date` and `Currency` pipes needs the **ECMAScript Internationalization API**.
+    Safari and other older browsers doesn't support it. We can add support with a polyfill.
+
+  code-example(language="html").
+    &lt;script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en"&gt;&lt;/script&gt;
+
 .l-main-section
 :marked
   ## Built-in pipes
@@ -48,7 +56,7 @@ block includes
 
 .l-sub-section
   :marked
-    Learn more about these and many other built-in pipes in the  the [API Reference](../api/#!?apiFilter=pipe);
+    Learn more about these and many other built-in pipes in the the [API Reference](../api/#!?apiFilter=pipe);
     filter for entries that include the word "pipe".
 
     Angular 2 doesn't have a `FilterPipe` or an `OrderByPipe` for reasons explained in an [appendix below](#no-filter-pipe).


### PR DESCRIPTION
Adds a warning to tell Safari users to use a polyfill for the `Date` and `Currency` pipes.

Fixes #1989
Closes #1572