### PR TITLE
chore: fix linting

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/app.component.1.ts
+++ b/public/docs/_examples/toh-5/ts/app/app.component.1.ts
@@ -1,4 +1,3 @@
-/* tslint:disable no-unused-variables */
 // #docplaster
 // #docregion
 import { Component }       from '@angular/core';
@@ -6,9 +5,6 @@ import { Component }       from '@angular/core';
 import { HeroService }     from './hero.service';
 import { HeroesComponent } from './heroes.component';
 // #enddocregion
-
-// For testing only
-import { ROUTER_DIRECTIVES } from '@angular/router';
 
 // #docregion
 @Component({


### PR DESCRIPTION
For some reason there is a breaking change in TsLint that broke our build. Even with the rule disable, it would still fail.

The reality is that we don't need that `For testing only` line, is outside regions and e2e pass with normality.

I will debug the tslint issue on my own and report it.