### PR TITLE
Change command line for node version

### DIFF
--- a/public/docs/ts/latest/guide/npm-packages.jade
+++ b/public/docs/ts/latest/guide/npm-packages.jade
@@ -11,7 +11,7 @@ include ../_util-fns
     Get it now</a> if it's not already installed on your machine.
  
     **Verify that you are running at least node `v4.x.x` and npm `3.x.x`**
-    by running `node -v` and `npm -v` in a terminal/console window.
+    by running `node -p process.versions.v8` and `npm -v` in a terminal/console window.
     Older versions produce errors.
 
     We recommend [nvm](https://github.com/creationix/nvm) for managing multiple versions of node and npm.


### PR DESCRIPTION
`node -v` retrieves the version of node cli, not of nodejs engine.