### PR TITLE
webpack-guide: fix ordering of resolve-extensions.

### DIFF
--- a/public/docs/_examples/webpack/ts/config/webpack.common.js
+++ b/public/docs/_examples/webpack/ts/config/webpack.common.js
@@ -15,7 +15,7 @@ module.exports = {
 
   // #docregion resolve
   resolve: {
-    extensions: ['', '.js', '.ts']
+    extensions: ['', '.ts', '.js']
   },
   // #enddocregion resolve
 


### PR DESCRIPTION
the .ts extension has to be before the .js extension for the angular2-template-loader to work.
