### PR TITLE
docs(glossary): Fix ECMAScript description

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -322,8 +322,8 @@ include _util-fns
     The [official JavaScript language specification](https://en.wikipedia.org/wiki/ECMAScript).
 
     The latest approved version of JavaScript is
-    [ECMAScript 2015](http://www.ecma-international.org/ecma-262/6.0/)
-    (AKA "ES2015" or "ES6") and many Angular 2 developers will write their applications
+    [ECMAScript 2016](http://www.ecma-international.org/ecma-262/7.0/)
+    (AKA "ES2016" or "ES7") and many Angular 2 developers will write their applications
     either in this version of the language or a dialect that strives to be
     compatible with it such as [TypeScript](#typesScript).
 


### PR DESCRIPTION
ES2016(ES7) has already been officially published.