### PR TITLE
chore: update next-item for hidden

### DIFF
--- a/public/_includes/_next-item.jade
+++ b/public/_includes/_next-item.jade
@@ -6,7 +6,7 @@ for page, slug in data
 
   // CHECK IF CURRENT PAGE IS SET, THEN SET NEXT PAGE
   if currentPage
-    if !nextPage && page.nextable
+    if !nextPage && page.nextable && !page.hide
       .l-sub-section
         h3 Next Step
         a(href="/docs/#{current.path[1]}/#{current.path[2]}/#{current.path[3]}/#{slug}.html") #{page.title}


### PR DESCRIPTION
Now, if you go to "Forms", the next page will be ... "Forms" (but in this case the deprecated one). Since we don't want a hidden guide to be nextable, this fixes it.