### PR TITLE
docs(glossary/dart): recover content

### DIFF
--- a/public/docs/dart/latest/glossary.jade
+++ b/public/docs/dart/latest/glossary.jade
@@ -1,45 +1,35 @@
 include _util-fns
-// From ts/glossary.jade, the folder ts/latest/_fragments is generated which contains a bunch of partial files.
-// These partials comprise the glossary,a subset of these partials should be used to generate the glossary for
-// __dart__ under BASICS.
-!=partial('../../ts/latest/_fragments/glossary-intro')
-!=partial('../../ts/latest/_fragments/glossary-a-2')
-!=partial('../../ts/latest/_fragments/glossary-b-c')
-!=partial('../../ts/latest/_fragments/glossary-d1')
-!=partial('../../ts/latest/_fragments/glossary-d2')
-!=partial('../../ts/latest/_fragments/glossary-e1')
-!=partial('../../ts/latest/_fragments/glossary-e2')
-!=partial('../../ts/latest/_fragments/glossary-f-l')
-!=partial('../../ts/latest/_fragments/glossary-m1')
-//!=partial('../../ts/latest/_fragments/glossary-m2') not needed in dart
-!=partial('../../ts/latest/_fragments/glossary-n-s-1')
+
+block var-def
+  - var fragPath='../../ts/latest/_fragments/';
+
+!=partial(fragPath + 'glossary-intro')
+!=partial(fragPath + 'glossary-a1')
+!=partial(fragPath + 'glossary-a-2')
+!=partial(fragPath + 'glossary-b-c')
+!=partial(fragPath + 'glossary-d1')
+!=partial(fragPath + 'glossary-d2')
+!=partial(fragPath + 'glossary-e1')
+!=partial(fragPath + 'glossary-e2')
+!=partial(fragPath + 'glossary-f-l')
+!=partial(fragPath + 'glossary-m1')
+//partial(fragPath + 'glossary-m2') not needed in dart
+!=partial(fragPath + 'glossary-n-s-1')
 
 :marked
   ## snake_case
+
 .l-sub-section
   :marked
-    The practice of writing compound words or phrases such that each word is separated by an underscore (`_`). 
+    The practice of writing compound words or phrases such that each word is separated by an
+    underscore (`_`).
     
-    Library and file names are often spelled in snake_case. Examples include: `angular2_tour_of_heroes` and `app_component.dart`.
+    Library and file names are often spelled in snake_case. Examples include:
+    `angular2_tour_of_heroes` and `app_component.dart`.
     
     This form is also known as **underscore case**.
 
-!=partial('../../ts/latest/_fragments/glossary-n-s-2')
-!=partial('../../ts/latest/_fragments/glossary-t1')
-//!=partial('../../ts/latest/_fragments/glossary-t2') notneeded in dart
-!=partial('../../ts/latest/_fragments/glossary-u-z')
-
-// NOTE: (ericjim): I am almost certain these lines are doing nothing,
-// so instead I use `!=partial` to include the glossary fragments.
-//+includeShared('{ts}', 'intro')
-//+includeShared('{ts}', 'a2')
-//+includeShared('{ts}', 'b-c')
-//+includeShared('{ts}', 'd1')
-//+includeShared('{ts}', 'd2')
-//+includeShared('{ts}', 'e1')
-//+includeShared('{ts}', 'e2')
-//+includeShared('{ts}', 'f-l')
-//+includeShared('{ts}', 'm1')
-//+includeShared('{ts}', 'n-s')
-//+includeShared('{ts}', 't1')
-//+includeShared('{ts}', 'u-z')
+!=partial(fragPath + 'glossary-n-s-2')
+!=partial(fragPath + 'glossary-t1')
+//partial(fragPath + 'glossary-t2') notneeded in dart
+!=partial(fragPath + 'glossary-u-z')

--- a/public/docs/dart/latest/guide/_data.json
+++ b/public/docs/dart/latest/guide/_data.json
@@ -39,7 +39,6 @@
   "forms-deprecated": {
     "title": "Forms",
     "intro": "A form creates a cohesive, effective, and compelling data entry experience. An Angular form coordinates a set of data-bound user controls, tracks changes, validates input, and presents errors.",
-    "nextable": true,
     "basics": true,
     "hide": true
   },

--- a/public/docs/dart/latest/guide/forms-deprecated.jade
+++ b/public/docs/dart/latest/guide/forms-deprecated.jade
@@ -1,5 +1,4 @@
 include ../_util-fns
 
 :marked
-  There is no deprecated forms library in Angular Dart.
-  The forms guide is [here](forms.html).
+  This page has no Dart equivalent. Instead, see the [forms guide](forms.html).

--- a/public/docs/dart/latest/guide/glossary.jade
+++ b/public/docs/dart/latest/guide/glossary.jade
@@ -1,1 +1,4 @@
-include ../glossary
+extends ../glossary
+
+block var-def
+  - var fragPath='../../../ts/latest/_fragments/';

--- a/public/docs/dart/latest/guide/router-deprecated.jade
+++ b/public/docs/dart/latest/guide/router-deprecated.jade
@@ -1,5 +1,4 @@
 include ../_util-fns
 
 :marked
-  There is no deprecated router library in Angular Dart.
-  The router guide is [here](router.html).
+  This page has no Dart equivalent. Instead, see the [router guide](router.html).


### PR DESCRIPTION
- Fixes #1918.
- Also fixes wording in `dart/latest/guide/*-deprecated.jade` files as suggested by @kwalrath.
- Follow-up glossary work will be done under #2036.