### PR TITLE
doc-gen: ignore new private module

### DIFF
--- a/public/docs/dart/latest/tutorial/toh-pt3.jade
+++ b/public/docs/dart/latest/tutorial/toh-pt3.jade
@@ -62,7 +62,7 @@ code-example(language="bash").
 
     All of our component names end in "Component".  All of our component file names end in "_component".
 
-    We spell our filenames in lower **underscore case** 
+    We spell our filenames in lower **underscore case**
     (AKA **[snake_case](../guide/glossary.html#!#snake_case)**) so we don't worry about
     case sensitivity on the server or in source control.
 
@@ -164,7 +164,7 @@ code-example(format=".").
 :marked
  The two components won't coordinate until we bind the `selectedHero` property of the `AppComponent`
  to the `HeroDetailComponent` element's `hero` property  like this:
-code-example(format=".")
+code-example(format=".").
   &lt;my-hero-detail [hero]="selectedHero">&lt;/my-hero-detail>
 :marked
   The `AppComponent`’s template should now look like this

--- a/public/docs/ts/latest/cookbook/set-document-title.jade
+++ b/public/docs/ts/latest/cookbook/set-document-title.jade
@@ -9,21 +9,21 @@ a(id='top')
 .l-sub-section
   img(src='/resources/images/devguide/plunker-separate-window-button.png' alt="pop out the window" align="right" style="margin-right:-20px")
   :marked
-    To see the browser Title bar changes, 
+    To see the browser Title bar changes,
     pop out the preview window by clicking the blue 'X' button in the upper right corner.
 :marked
   ## The problem with *&lt;title&gt;*
-  
+
   The obvious approach is to bind a property of the component to the HTML `<title>` like this:
-code-example(format='')
+code-example(format='').
   &lt;title&gt;{{This_Does_Not_Work}}&lt;/title&gt;
 :marked
-  Sorry but that won't work. 
+  Sorry but that won't work.
   The root component of our application is an element contained within the `<body>` tag.
   The HTML `<title>` is in the document `<head>`, outside the body, making it inaccessible to Angular data binding.
 
-  We could grab the browser `document` object and set the title manually. 
-  That's dirty and undermines our chances of running the app outside of a browser someday. 
+  We could grab the browser `document` object and set the title manually.
+  That's dirty and undermines our chances of running the app outside of a browser someday.
 .l-sub-section
   :marked
     Running your app outside a browser means that you can take advantage of server-side
@@ -40,16 +40,16 @@ code-example(format='')
   * `getTitle() : string` &mdash; Gets the title of the current HTML document.
   * `setTitle( newTitle : string )` &mdash; Sets the title of the current HTML document.
 
-  While this class is part of the Browser platform package, it is *not part of the default Browser 
-  platform providers* that Angular loads automatically. 
+  While this class is part of the Browser platform package, it is *not part of the default Browser
+  platform providers* that Angular loads automatically.
   This means as we bootstrap our application using the Browser platform `boostrap()`
   function, we'll also have to include `Title` service explicitly as one of the bootstrap providers:
 
 +makeExample( "cb-set-document-title/ts/app/main.ts", "bootstrap-title", "app/main.ts (provide Title service)" )(format='.')
 :marked
   Once we've explicitly provided the `Title` service we can then inject the `Title` service into any of our
-  custom application components and services. 
-  
+  custom application components and services.
+
   Let's inject the `Title` service into the root `AppComponent` and expose a bindable `setTitle` method that calls it:
 
 +makeExample( "cb-set-document-title/ts/app/app.component.ts", "class", "app/app.component.ts (class)" )(format='.')
@@ -61,31 +61,31 @@ figure.image-display
 :marked
   Here's the complete solution
 
-+makeTabs( 
++makeTabs(
   `cb-set-document-title/ts/app/main.ts,
-   cb-set-document-title/ts/app/app.component.ts`, 
-  '', 
+   cb-set-document-title/ts/app/app.component.ts`,
+  '',
   'app/main.ts, app/app.component.ts' )
 
 //
-  Todo: tie this back to the router so we can see how to use this Title service to (re)set the title 
+  Todo: tie this back to the router so we can see how to use this Title service to (re)set the title
   that appears in the window navigation history and shows up in the back/forward buttons
   during routing.
-  
+
   See https://github.com/angular/angular/issues/7630#issuecomment-198328802
-  
+
 .l-main-section
 :marked
   ## Why we provide the *Title* service in *bootstrap*
-  
+
   We generally recommended providing application-wide services in the root application component, `AppComponent`.
-  
-  Here we recommend registering the title service during bootstrapping, 
+
+  Here we recommend registering the title service during bootstrapping,
   a location we reserve for configuring the runtime Angular environment.
-  
+
   That's exactly what we're doing.
-  The `Title` service is part of the Angular *browser platform*. 
-  If we bootstrap our application into a different platform, 
+  The `Title` service is part of the Angular *browser platform*.
+  If we bootstrap our application into a different platform,
   we'll have to provide a different `Title` service that understands the concept of a "document title" for that specific platform.
   Ideally the application itself neither knows nor cares about the runtime environment.
 :marked

--- a/tools/api-builder/angular.io-package/index.js
+++ b/tools/api-builder/angular.io-package/index.js
@@ -54,6 +54,7 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
     '___platform_browser_private_types__',
     '___platform_browser_dynamic_private__',
     '___platform_browser_dynamic_private_types__',
+    '___core_private_testing_types__',
     '___compiler_private__',
     '__core_private__',
     '___core_private__'
@@ -135,7 +136,7 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
     pathTemplate: 'api-list.json',
     outputPathTemplate: '${path}'
   });
-  
+
   computePathsProcessor.pathTemplates.push({
     docTypes: ['api-list-data'],
     pathTemplate: 'api-list-audit.json',


### PR DESCRIPTION
@naomiblack & @IgorMinar I think this should solve the problem. Shall we change the processor so that it takes a regexp instead so that we don't have to keep adding these?

Closes #2024