### PR TITLE
chore: swap reflect on webpack to core-js

### DIFF
--- a/public/docs/_examples/webpack/ts/src/polyfills.ts
+++ b/public/docs/_examples/webpack/ts/src/polyfills.ts
@@ -1,6 +1,6 @@
 // #docregion
 import 'core-js/es6';
-import 'reflect-metadata';
+import 'core-js/es7/reflect';
 require('zone.js/dist/zone');
 
 if (process.env.ENV === 'production') {


### PR DESCRIPTION
New reflect-metadata 0.1.4 broke webpack.

On the one hand, there is a dozen of warnings with this line:

`const nodeCrypto = isNode && function () { try { return (void 0, require)("crypto"); } catch (e) { } }();`

Also, reflect is stuck on an old Typescript and that fires hundred of errors (which broke our build).

So I am recommending that we swap `reflect-metadata` for the one inside `core-js` which works perfect.

On the other hand I am investigating the warnings to see if they can be fix on webpack or reflect-metadata.