### PR TITLE
chore(dart): api doc builder enhancements

### DIFF
--- a/tools/api-builder/dart-package/test.js
+++ b/tools/api-builder/dart-package/test.js
@@ -14,7 +14,7 @@ const apiDocPath = path.join(DOCS_PATH, 'dart/latest/api');
 
 dartPkg.config(function (dartPkgConfigInfo) {
     dartPkgConfigInfo.ngIoDartApiDocPath = apiDocPath;
-    dartPkgConfigInfo.ngDartDocPath = path.join(ANGULAR_IO_PROJECT_PATH, '../ngdart/doc/api');
+    dartPkgConfigInfo.ngDartDocPath = path.join(ANGULAR_IO_PROJECT_PATH, '../angular-dart/docs/api');
 });
 
 const dgeni = new Dgeni([dartPkg]);


### PR DESCRIPTION
- #2049, support ng.io doc relative links and code-regions
- Change dartdoc output folder to `docs/api` (from `doc/api`).