### PR TITLE
chore(dart-doc-sync): data files for component-styles and lifecycle-hooks

### DIFF
--- a/public/docs/_examples/component-styles/dart/.docsync.json
+++ b/public/docs/_examples/component-styles/dart/.docsync.json
@@ -1,0 +1,4 @@
+{
+  "title": "Component Styles",
+  "docPart": "guide"
+}

--- a/public/docs/_examples/lifecycle-hooks/dart/.docsync.json
+++ b/public/docs/_examples/lifecycle-hooks/dart/.docsync.json
@@ -1,0 +1,4 @@
+{
+  "title": "Lifecycle Hooks",
+  "docPart": "guide"
+}


### PR DESCRIPTION
Note that component-styles and lifecycle-hooks examples have been sync’d for a while, though they were missing `.docsync.json` files.

cc @kwalrath 