### PR TITLE
docs(ngmodule): remove module.id

### DIFF
--- a/public/docs/_examples/ngmodule/ts/app/contact/contact.component.3.ts
+++ b/public/docs/_examples/ngmodule/ts/app/contact/contact.component.3.ts
@@ -5,10 +5,9 @@ import { Contact, ContactService } from './contact.service';
 import { UserService }    from '../user.service';
 
 @Component({
-  moduleId: module.id,
   selector: 'app-contact',
-  templateUrl: 'contact.component.html',
-  styleUrls: ['contact.component.css']
+  templateUrl: 'app/contact/contact.component.html',
+  styleUrls: ['app/contact/contact.component.css']
 })
 export class ContactComponent implements OnInit {
   contact:  Contact;

--- a/public/docs/_examples/ngmodule/ts/app/contact/contact.component.ts
+++ b/public/docs/_examples/ngmodule/ts/app/contact/contact.component.ts
@@ -6,10 +6,9 @@ import { Contact, ContactService } from './contact.service';
 import { UserService }    from '../shared/user.service';
 
 @Component({
-  moduleId: module.id,
   selector: 'app-contact',
-  templateUrl: 'contact.component.html',
-  styleUrls: ['contact.component.css']
+  templateUrl: 'app/contact/contact.component.html',
+  styleUrls: ['app/contact/contact.component.css']
 })
 export class ContactComponent implements OnInit {
   contact:  Contact;

--- a/public/docs/_examples/ngmodule/ts/app/shared/title.component.ts
+++ b/public/docs/_examples/ngmodule/ts/app/shared/title.component.ts
@@ -3,9 +3,8 @@ import { Component, Input } from '@angular/core';
 import { UserService }      from './user.service';
 
 @Component({
-  moduleId: module.id,
   selector: 'app-title',
-  templateUrl: 'title.component.html',
+  templateUrl: 'app/shared/title.component.html',
 })
 export class TitleComponent {
   @Input() subtitle = '';

--- a/public/docs/_examples/ngmodule/ts/app/title.component.ts
+++ b/public/docs/_examples/ngmodule/ts/app/title.component.ts
@@ -7,9 +7,8 @@ import { UserService } from './user.service';
 // #docregion v1
 
 @Component({
-  moduleId: module.id,
   selector: 'app-title',
-  templateUrl: 'title.component.html',
+  templateUrl: 'app/title.component.html',
 })
 export class TitleComponent {
   @Input() subtitle = '';


### PR DESCRIPTION
The reasoning behind this is because `module.id` is not a well known property and since the chapter is called "Module" as well, people are thinking that `NgModule` and `module.id` are related and not really seeing a connection nor explanation. 