### PR TITLE
chore(build): fix so --fast can be used with check-deploy etc

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -441,7 +441,7 @@ gulp.task('add-example-boilerplate', function(done) {
 // copies boilerplate files to locations
 // where an example app is found
 gulp.task('_copy-example-boilerplate', function (done) {
-  if (!argv.fast) buildStyles(copyExampleBoilerplate, done);
+  return argv.fast ? done() : buildStyles(copyExampleBoilerplate, done);
 });
 
 //Builds Angular 2 Docs CSS file from Bootstrap npm LESS source


### PR DESCRIPTION
Using `--fast` with most targets would just stop after doing `_copy-example-boilerplate`. This fixes the issue.

cc @kwalrath @Foxandxss 