### PR TITLE
docs(toh-5): Fix lack of declaring in a sample code

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/app.module.1.ts
+++ b/public/docs/_examples/toh-5/ts/app/app.module.1.ts
@@ -7,6 +7,8 @@ import { AppComponent }   from './app.component';
 
 import { HeroesComponent }  from './heroes.component';
 
+import { HeroDetailComponent } from './hero-detail.component';
+
 import { HeroService }  from './hero.service';
 
 @NgModule({
@@ -16,7 +18,8 @@ import { HeroService }  from './hero.service';
   ],
   declarations: [
     AppComponent,
-    HeroesComponent
+    HeroesComponent,
+    HeroDetailComponent
   ],
   providers: [
     HeroService


### PR DESCRIPTION
Fixes https://github.com/angular/angular.io/issues/2096.

`HeroDetailComponent` was missing in a sample code ( `app/app.module.ts (v1)` ), so the app didn't work.