### PR TITLE
docs(ngmodule): Fix typo

### DIFF
--- a/public/docs/ts/latest/guide/ngmodule.jade
+++ b/public/docs/ts/latest/guide/ngmodule.jade
@@ -1392,7 +1392,7 @@ a#q-root-component-or-module
   ### Should I add providers to the root _AppModule_ or the root _AppComponent_?
 
   Most apps launch with an initial set of service providers. 
-  Should we register those providers on the root `AppModule` (`@NgModel.providers`) or
+  Should we register those providers on the root `AppModule` (`@NgModule.providers`) or
   the root `AppComponent` (`@Component.providers`)?
 
   **_List such providers in the root_ `AppModule` _unless you have a compelling reason to do otherwise_**.
@@ -1490,7 +1490,7 @@ a#q-entry-component-defined
   We must tell it about them ... by adding them to the `entryComponents` list.
   
   Angular automatically adds two kinds of components to the module's `entryComponents`:
-  1. the component in the `@NgModel.bootstrap` list
+  1. the component in the `@NgModule.bootstrap` list
   1. components referenced in router configuration
 
   We don't have to mention these components explicitly although it does not harm to do so.


### PR DESCRIPTION
Another two `@NgModel` typos.