### PR TITLE
docs(ngmodule): Fix typo of unneeded underscore

### DIFF
--- a/public/docs/ts/latest/guide/ngmodule.jade
+++ b/public/docs/ts/latest/guide/ngmodule.jade
@@ -1506,7 +1506,7 @@ a#q-bootstrap_vs_entry_component
   It's an entry component that Angular loads into the DOM during the bootstrap (application launch) process.
   Other entry components are loaded by dynamically by other means such as with the router.
 
-  The `@NgModule.bootstrap` property tells the compiler _both_ that this is an entry_component _and_
+  The `@NgModule.bootstrap` property tells the compiler _both_ that this is an entry component _and_
   that it should generate code to bootstrap the application with this component.
 
   There is no need to list a component in both the `bootstrap` and `entryComponent` lists 


### PR DESCRIPTION
Change the underscore to space since it's normal English statement here.