### PR TITLE
docs(ngmodule): Fix typo of italic in backquote

### DIFF
--- a/public/docs/ts/latest/guide/ngmodule.jade
+++ b/public/docs/ts/latest/guide/ngmodule.jade
@@ -1519,7 +1519,7 @@ a#q-when-entry-components
 :marked
   ### When do I add components to _entryComponents_?
   
-  Most application developers won't need to add components to the `_entryComponents_`.
+  Most application developers won't need to add components to the `entryComponents`.
 
   Angular adds certain components to _entry components_ automatically.
   Components listed in `@NgModule.bootstrap` are added automatically.


### PR DESCRIPTION
The underscore would turn to real underscore character within backquote and resulting in `_entryComponents_`.