### PR TITLE
docs(server-communication): Fetch API does not belong to ECMAScript

### DIFF
--- a/public/docs/ts/latest/guide/server-communication.jade
+++ b/public/docs/ts/latest/guide/server-communication.jade
@@ -265,7 +265,7 @@ block parse-json
   .l-sub-section
     :marked
       This is not Angular's own design. 
-      The Angular HTTP client follows the ES2015 specification for the
+      The Angular HTTP client follows the Fetch specification for the
       [response object](https://fetch.spec.whatwg.org/#response-class) returned by the `Fetch` function.
       That spec defines a `json()` method that parses the response body into a JavaScript object.
 


### PR DESCRIPTION
Fetch API is a Web API, has its own specification. ECMAScript is the specification of the JavaScript language, nothing to do with Web API.