### PR TITLE
docs(lifecycle-hooks): Remove statements of router-deprecated hooks

### DIFF
--- a/public/docs/ts/latest/guide/lifecycle-hooks.jade
+++ b/public/docs/ts/latest/guide/lifecycle-hooks.jade
@@ -186,8 +186,6 @@ a(id="other-lifecycles")
   ## Other lifecycle hooks
   
   Other Angular sub-systems may have their own lifecycle hooks apart from the component hooks we've listed. 
-  The router, for instance, also has it's own [router lifecycle hooks](router.html#router-lifecycle-hooks)
-  that allow us to tap into specific moments in route navigation.
   
   A parallel can be drawn between `ngOnInit` and `routerOnActivate`. 
   Both are prefixed so as to avoid collision, and both run right when a component is 'booting' up.


### PR DESCRIPTION
The lifecycle-hooks provided by router-deprecated has already been removed in the router, the router now uses guards rather than lifecycle-hooks to achieve the same work.