### PR TITLE
docs(template-syntax): post-RC5 Dart resync

### DIFF
--- a/public/docs/_examples/template-syntax/dart/lib/app_component.dart
+++ b/public/docs/_examples/template-syntax/dart/lib/app_component.dart
@@ -176,7 +176,12 @@ class AppComponent implements OnInit, AfterViewInit {
   // #enddocregion NgStyle
 
   String title = 'Template Syntax';
+  // #docregion evil-title
+  String evilTitle = 'Template <script>alert("evil never sleeps")</script>Syntax';
+  // #enddocregion evil-title
+
   String toeChoice;
+
   String toeChooser(Element picker) {
     List<Element> choices = picker.children;
     for (var i = 0; i < choices.length; i++) {

--- a/public/docs/_examples/template-syntax/dart/lib/app_component.html
+++ b/public/docs/_examples/template-syntax/dart/lib/app_component.html
@@ -197,12 +197,17 @@ button</button>
 <!-- #enddocregion property-binding-7 -->
 
 <!-- #docregion property-binding-vs-interpolation -->
-Interpolated: <img src="{{heroImageUrl}}"><br>
-Property bound: <img [src]="heroImageUrl">
+<p><img src="{{heroImageUrl}}"> is the <i>interpolated</i> image.</p>
+<p><img [src]="heroImageUrl"> is the <i>property bound</i> image.</p>
 
-<div>The interpolated title is {{title}}</div>
-<div [innerHTML]="'The [innerHTML] title is '+title"></div>
+<p><span>"{{title}}" is the <i>interpolated</i> title.</span></p>
+<p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>
 <!-- #enddocregion property-binding-vs-interpolation -->
+
+<!-- #docregion property-binding-vs-interpolation-sanitization -->
+<p><span>"{{evilTitle}}" is the <i>interpolated</i> evil title.</span></p>
+<p>"<span [innerHTML]="evilTitle"></span>" is the <i>property bound</i> evil title.</p>
+<!-- #enddocregion property-binding-vs-interpolation-sanitization -->
 
 <a class="to-toc" href="#toc">top</a>
 

--- a/public/docs/ts/_cache/guide/template-syntax.jade
+++ b/public/docs/ts/_cache/guide/template-syntax.jade
@@ -858,8 +858,20 @@ block style-property-name-dart-diff
   header [()] = banana in a box
   :marked
     To remember that the parentheses go inside the brackets, visualize a *banana in a box*.
+
+.callout.is-important
+  header FormsModule is Required to use ngModel
+  :marked
+    Before we can use `ngModel` two-way data binding, we need to import the `FormsModule`
+    package in our Angular module. We add it to the `NgModule` decorator's `imports` array. This array contains the list
+    of external modules used by our application.
+    <br>Learn more about the `FormsModule` and `ngModel` in the
+    [Forms](../guide/forms.html#ngModel) chapter.
+
++makeExample('template-syntax/ts/app/app.module.1.ts', '', 'app.module.ts (FormsModule import)')
+
 :marked
-  Alternatively, we can use the canonical prefix form:
+  Alternatively to using `[(ngModel)]`, we can use the canonical prefix form:
 +makeExample('template-syntax/ts/app/app.component.html', 'NgModel-2')(format=".")
 :marked
   There’s a story behind this construction, a story that builds on the property and event binding techniques we learned previously.

--- a/public/docs/ts/_cache/guide/template-syntax.jade
+++ b/public/docs/ts/_cache/guide/template-syntax.jade
@@ -859,16 +859,17 @@ block style-property-name-dart-diff
   :marked
     To remember that the parentheses go inside the brackets, visualize a *banana in a box*.
 
-.callout.is-important
-  header FormsModule is Required to use ngModel
-  :marked
-    Before we can use `ngModel` two-way data binding, we need to import the `FormsModule`
-    package in our Angular module. We add it to the `NgModule` decorator's `imports` array. This array contains the list
-    of external modules used by our application.
-    <br>Learn more about the `FormsModule` and `ngModel` in the
-    [Forms](../guide/forms.html#ngModel) chapter.
++ifDocsFor('ts|js')
+  .callout.is-important
+    header FormsModule is Required to use ngModel
+    :marked
+      Before we can use `ngModel` two-way data binding, we need to import the `FormsModule`
+      package in our Angular module. We add it to the `NgModule` decorator's `imports` array. This array contains the list
+      of external modules used by our application.
+      <br>Learn more about the `FormsModule` and `ngModel` in the
+      [Forms](../guide/forms.html#ngModel) chapter.
 
-+makeExample('template-syntax/ts/app/app.module.1.ts', '', 'app.module.ts (FormsModule import)')
+  +makeExample('template-syntax/ts/app/app.module.1.ts', '', 'app.module.ts (FormsModule import)')
 
 :marked
   Alternatively to using `[(ngModel)]`, we can use the canonical prefix form:

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -859,16 +859,17 @@ block style-property-name-dart-diff
   :marked
     To remember that the parentheses go inside the brackets, visualize a *banana in a box*.
 
-.callout.is-important
-  header FormsModule is Required to use ngModel
-  :marked
-    Before we can use `ngModel` two-way data binding, we need to import the `FormsModule`
-    package in our Angular module. We add it to the `NgModule` decorator's `imports` array. This array contains the list
-    of external modules used by our application.
-    <br>Learn more about the `FormsModule` and `ngModel` in the
-    [Forms](../guide/forms.html#ngModel) chapter.
++ifDocsFor('ts|js')
+  .callout.is-important
+    header FormsModule is Required to use ngModel
+    :marked
+      Before we can use `ngModel` two-way data binding, we need to import the `FormsModule`
+      package in our Angular module. We add it to the `NgModule` decorator's `imports` array. This array contains the list
+      of external modules used by our application.
+      <br>Learn more about the `FormsModule` and `ngModel` in the
+      [Forms](../guide/forms.html#ngModel) chapter.
 
-+makeExample('template-syntax/ts/app/app.module.1.ts', '', 'app.module.ts (FormsModule import)')
+  +makeExample('template-syntax/ts/app/app.module.1.ts', '', 'app.module.ts (FormsModule import)')
 
 :marked
   Alternatively to using `[(ngModel)]`, we can use the canonical prefix form:


### PR DESCRIPTION
- Single line change to TS prose ([ignore whitespace diffs](https://github.com/angular/angular.io/pull/2121/files?w=1)).
- Dart-side code changes are to match a May 2016 TS-side commit: https://github.com/angular/angular.io/commit/ae2d8f27306c940bc127560649eb7fda8c10f291.
- Contributes to #2077.

Suites passed:
 - public/docs/_examples/template-syntax/dart
 - public/docs/_examples/template-syntax/ts
