### PR TITLE
docs(glossary): add ECMAScript2015 section back

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -358,7 +358,13 @@ a#aot
     to ES5 JavaScript.
 
     Angular 2 developers may choose to write in ES5 directly.
-
+:marked
+  ## ECMAScript 2015
+.l-sub-section
+  :marked
+    The latest released version of JavaScript,
+    [ECMAScript 2015](http://www.ecma-international.org/ecma-262/6.0/)
+    (AKA "ES2015" or "ES6")
 :marked
   ## ES2015
 .l-sub-section


### PR DESCRIPTION
it was removed, but it's the explanation of the shorthand of ES2015