### PR TITLE
docs(webpack): update testing for RC5

### DIFF
--- a/public/docs/_examples/webpack/ts/config/karma-test-shim.js
+++ b/public/docs/_examples/webpack/ts/config/karma-test-shim.js
@@ -5,10 +5,10 @@ require('core-js/es6');
 require('reflect-metadata');
 
 require('zone.js/dist/zone');
-require('zone.js/dist/long-stack-trace-zone');
-require('zone.js/dist/jasmine-patch');
 require('zone.js/dist/async-test');
 require('zone.js/dist/fake-async-test');
+require('zone.js/dist/sync-test');
+require('zone.js/dist/proxy-zone');
 
 var appContext = require.context('../src', true, /\.spec\.ts/);
 
@@ -17,7 +17,4 @@ appContext.keys().forEach(appContext);
 var testing = require('@angular/core/testing');
 var browser = require('@angular/platform-browser-dynamic/testing');
 
-testing.setBaseTestProviders(
-  browser.TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
-  browser.TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS
-);
+testing.TestBed.initTestEnvironment(browser.BrowserDynamicTestingModule, browser.platformBrowserDynamicTesting());

--- a/public/docs/_examples/webpack/ts/config/webpack.test.js
+++ b/public/docs/_examples/webpack/ts/config/webpack.test.js
@@ -1,4 +1,6 @@
 // #docregion
+var helpers = require('./helpers');
+
 module.exports = {
   devtool: 'inline-source-map',
 
@@ -23,7 +25,13 @@ module.exports = {
       },
       {
         test: /\.css$/,
+        exclude: helpers.root('src', 'app'),
         loader: 'null'
+      },
+      {
+        test: /\.css$/,
+        include: helpers.root('src', 'app'),
+        loader: 'raw'
       }
     ]
   }

--- a/public/docs/_examples/webpack/ts/src/app/app.component.spec.ts
+++ b/public/docs/_examples/webpack/ts/src/app/app.component.spec.ts
@@ -1,21 +1,16 @@
 // #docregion
-import {
-  addProviders,
-  inject,
-} from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { AppComponent } from './app.component';
 
 describe('App', () => {
   beforeEach(() => {
-    addProviders([
-      AppComponent
-    ]);
+    TestBed.configureTestingModule({ declarations: [AppComponent]});
   });
 
-  it ('should work', inject([AppComponent], (app: AppComponent) => {
-    // Add real test here
-    expect(2).toBe(2);
-  }));
+  it ('should work', () => {
+    let fixture = TestBed.createComponent(AppComponent);
+    expect(fixture.componentInstance instanceof AppComponent).toBe(true, 'should create AppComponent');
+  });
 });
 // #enddocregion

--- a/public/docs/ts/latest/guide/webpack.jade
+++ b/public/docs/ts/latest/guide/webpack.jade
@@ -360,8 +360,8 @@ a(id="test-configuration")
   
   We don't need much configuration to run unit tests. 
   We don't need the loaders and plugins that we declared for our development and production builds.
-  We probably don't need to load and process `css` files for unit tests and doing so would slow us down;
-  we'll use the `null` loader for all CSS.
+  We probably don't need to load and process the application-wide styles files for unit tests and doing so would slow us down;
+  we'll use the `null` loader for those CSS.
   
   We could merge our test configuration into the `webpack.common` configuration and override the parts we don't want or need.
   But it might be simpler to start over with a completely fresh configuration.


### PR DESCRIPTION
This updates the webpack unit test to use TestBed along with updates to the karma-shim.

Also I realized while doing it that I cannot disable **all** css on testing, so I modified the test config to just disable the application-wide styles which is what we should do.