### PR TITLE
example(toh-4,5): getHeroesSlowly() to return getHeroes()

### DIFF
--- a/public/docs/_examples/toh-4/dart/lib/hero_service.dart
+++ b/public/docs/_examples/toh-4/dart/lib/hero_service.dart
@@ -17,7 +17,7 @@ class HeroService {
   // See the "Take it slow" appendix
   // #docregion get-heroes-slowly
   Future<List<Hero>> getHeroesSlowly() {
-    return new Future.delayed(const Duration(seconds: 2), () => mockHeroes);
+    return new Future.delayed(const Duration(seconds: 2), getHeroes);
   }
   // #enddocregion get-heroes-slowly
   // #docregion

--- a/public/docs/_examples/toh-4/dart/lib/hero_service_1.dart
+++ b/public/docs/_examples/toh-4/dart/lib/hero_service_1.dart
@@ -13,7 +13,7 @@ class HeroService {
   // #enddocregion getHeroes-stub, empty-class, final
   /*
   // #docregion getHeroes-stub
-  List<Hero> getHeroes() {}
+  List<Hero> getHeroes() {} // stub
   // #enddocregion getHeroes-stub
   */
   // #docregion final

--- a/public/docs/_examples/toh-4/ts/app/hero.service.1.ts
+++ b/public/docs/_examples/toh-4/ts/app/hero.service.1.ts
@@ -13,8 +13,7 @@ export class HeroService {
   // #enddocregion empty-class, getHeroes-stub, full
   /*
   // #docregion getHeroes-stub
-  getHeroes(): void {
-  }
+  getHeroes(): void {} // stub
   // #enddocregion getHeroes-stub
   */
   // #docregion full

--- a/public/docs/_examples/toh-4/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-4/ts/app/hero.service.ts
@@ -18,8 +18,8 @@ export class HeroService {
   // #docregion get-heroes-slowly
   getHeroesSlowly(): Promise<Hero[]> {
     return new Promise<Hero[]>(resolve =>
-      setTimeout(() => resolve(HEROES), 2000) // 2 seconds
-    );
+      setTimeout(resolve, 2000)) // delay 2 seconds
+      .then(() => this.getHeroes());
   }
   // #enddocregion get-heroes-slowly
   // #docregion

--- a/public/docs/_examples/toh-5/dart/lib/hero_service.dart
+++ b/public/docs/_examples/toh-5/dart/lib/hero_service.dart
@@ -10,10 +10,9 @@ import 'mock_heroes.dart';
 class HeroService {
   Future<List<Hero>> getHeroes() async => mockHeroes;
 
-  // See the "Take it slow" appendix
   Future<List<Hero>> getHeroesSlowly() {
     return new Future<List<Hero>>.delayed(
-        const Duration(seconds: 2), () => mockHeroes);
+        const Duration(seconds: 2), getHeroes);
   }
 
   // #docregion getHero

--- a/public/docs/_examples/toh-5/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-5/ts/app/hero.service.ts
@@ -10,11 +10,10 @@ export class HeroService {
     return Promise.resolve(HEROES);
   }
 
-  // See the "Take it slow" appendix
   getHeroesSlowly(): Promise<Hero[]> {
     return new Promise<Hero[]>(resolve =>
-      setTimeout(() => resolve(HEROES), 2000) // 2 seconds
-    );
+      setTimeout(resolve, 2000)) // delay 2 seconds
+      .then(() => this.getHeroes());
   }
 
   // #docregion getHero


### PR DESCRIPTION
Have `getHeroesSlowly()` delay and then return the value of `getHeroes()`. This makes it easier for user’s performing the tutorial to keep this slower method as they evolve toh-5 into toh-6.

@kwalrath @Foxandxss @filipesilva : note that I've partitioned the files. There is a TS commit and a Dart commit, each ready to be reviewed.