### PR TITLE
(NgModule Guide) Change property name to align with other examples.

### DIFF
--- a/public/docs/_examples/ngmodule/ts/app/user.service.ts
+++ b/public/docs/_examples/ngmodule/ts/app/user.service.ts
@@ -4,5 +4,5 @@ import { Injectable } from '@angular/core';
 @Injectable()
 /** Dummy version of an authenticated user service */
 export class UserService {
-  userName = 'Sam Spade';
+  user = 'Sam Spade';
 }


### PR DESCRIPTION
Changed property "userName" to "user" because in other files it is needed the property "user". Fixes #2094 