### PR TITLE
docs(NgModule): fix typo

### DIFF
--- a/public/docs/ts/latest/guide/ngmodule.jade
+++ b/public/docs/ts/latest/guide/ngmodule.jade
@@ -660,7 +660,7 @@ a#lazy-load
     Note that the module location is a _string_, not a _type_. 
 
     To reference the _type_ we'd have to import the module,
-    which loads the module loads immediately,
+    which loads the module immediately,
     defeating our intent to load the module later. 
     A string, on the other hand, is just a string. 
     It has no side-effects.


### PR DESCRIPTION
Changed

> To reference the _type_ we'd have to import the module, which loads the module **loads** immediately

to

> To reference the _type_ we'd have to import the module, which loads the module immediately