### PR TITLE
chore: fix live-example for multiple plunkers

### DIFF
--- a/public/resources/js/directives/live-example.js
+++ b/public/resources/js/directives/live-example.js
@@ -32,15 +32,19 @@ angularIO.directive('liveExample', ['$location', function ($location) {
     compile: function (tElement, attrs) {
       var text = tElement.text() || 'live example';
       var ex = attrs.name || NgIoUtil.getExampleName($location);
-      var plnkr = attrs.plnkr || '';
+      var plnkr = '';
       var href, template;
+
+      if (attrs.plnkr) {
+        plnkr = attrs.plnkr + '.';
+      }
 
       var isForDart = attrs.lang === 'dart' || NgIoUtil.isDoc($location, 'dart');
       var isForJs = attrs.lang === 'js' || NgIoUtil.isDoc($location, 'js');
       var exLang = isForDart ? 'dart' : isForJs ? 'js' : 'ts';
       var href = isForDart
         ? 'http://angular-examples.github.io/' + ex
-        : '/resources/live-examples/' + ex + '/' + exLang + '/plnkr.html';
+        : '/resources/live-examples/' + ex + '/' + exLang + '/' + plnkr + 'plnkr.html';
 
       // Link to live example.
       var template = a(text, { href: href, target: '_blank' });


### PR DESCRIPTION
It wasn't giving you the "named" plunkers.