### PR TITLE
docs(ngmodule): fix broken link

### DIFF
--- a/public/docs/ts/latest/guide/ngmodule.jade
+++ b/public/docs/ts/latest/guide/ngmodule.jade
@@ -548,7 +548,7 @@ a#feature-modules
     The `ContactModule` must import `FormsModule` explicitly so that
     `ContactComponent` can data bind with `ngModel`.
 :marked
-  We also replaced `BrowserModule` by `CommonModule` for reasons we explain [soon](#root-vs-feature-module).
+  We also replaced `BrowserModule` by `CommonModule` for reasons we explain at the [faq](#q-what-to-import).
 
   We _declare_ the contact component, directive, and pipe in the module `declarations`.
 


### PR DESCRIPTION
The link was pointing to nowhere.

I am not completely sure if the prose mentions this reasons, but the FAQ does it really nicely.

Fixes #2166