### PR TITLE
chore(dartdoc): don't cross link to sources

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -613,7 +613,8 @@ gulp.task('dartdoc', ['pub upgrade'], function() {
   const tmpPath = topLevelLibFilePath + '.disabled';
   renameIfExistsSync(topLevelLibFilePath, tmpPath);
   gutil.log(`Hiding top-level angular2 library: ${topLevelLibFilePath}`);
-  const dartdoc = spawnExt('dartdoc', ['--output', 'docs/api', '--add-crossdart'], { cwd: ngRepoPath});
+  // Remove dartdoc '--add-crossdart' flag while we are fixing links to API pages.
+  const dartdoc = spawnExt('dartdoc', ['--output', 'docs/api'], { cwd: ngRepoPath});
   return dartdoc.promise.finally(() => {
       gutil.log(`Restoring top-level angular2 library: ${topLevelLibFilePath}`);
       renameIfExistsSync(tmpPath, topLevelLibFilePath);


### PR DESCRIPTION
Remove dartdoc `—add-crossdart` flag.

cc @kwalrath