### PR TITLE
docs(api): fix cross-language dropdown menu

### DIFF
--- a/public/_includes/_hero.jade
+++ b/public/_includes/_hero.jade
@@ -35,5 +35,8 @@ header(class="hero background-sky", style=fixHeroCss ? "height:auto" : "")
 
   else if current.path[3] == 'api' && current.path[1] == 'dart'
     block breadcrumbs
+    //- Show cross-language menu for top-level API page (but not entry pages)
+    if ! public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]
+      != partial("_version-dropdown")
   else if current.path[0] == "docs"
     != partial("_version-dropdown")

--- a/public/_includes/_version-dropdown.jade
+++ b/public/_includes/_version-dropdown.jade
@@ -5,7 +5,7 @@
 - var version = ''
 - var page = ''
 
-<!-- Replace _ underscores with . dots -->
+//- Replace _ underscores with . dots
 if current.path[2]
   - var version = current.path[2].replace(/\_+/gm, ".")
 
@@ -33,7 +33,7 @@ else if current.path[3]
   else
     - var page = current.path[3] + '.html'
 
-<!-- VERSION TREE CREATOR MIXIN -->
+//- VERSION TREE CREATOR MIXIN
 mixin tree(directory, urlPrefix, name, latest)
   ul
     for val, semvar in directory
@@ -42,7 +42,7 @@ mixin tree(directory, urlPrefix, name, latest)
         li <a href="#{urlPrefix}/#{semvar}/#{page}" md-button>#{name} #{libVersion}</a>
 
 
-<!-- BUTTON TITLE GENERATION  -->
+//- BUTTON TITLE GENERATION
 if language == 'ts'
   if version == "latest"
     - var title = 'Angular 2 for TypeScript'
@@ -72,4 +72,6 @@ nav.dropdown
   div(class="dropdown-menu" ng-class="appCtrl.showMenu ? 'is-visible' : ''")
     mixin tree(public.docs.ts, "/docs/ts", "Angular 2 for TypeScript")
     mixin tree(public.docs.js, "/docs/js", "Angular 2 for JavaScript")
-    mixin tree(public.docs.dart, "/docs/dart", "Angular 2 for Dart")
+    //- Disable cross-language link for API entry pages (but keep for top API search page):
+    if ! (current.path[3] === 'api' && public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]])
+      mixin tree(public.docs.dart, "/docs/dart", "Angular 2 for Dart")


### PR DESCRIPTION
- Re-enable dropdown on main API page.
- Remove Dart choice from TS & JS API entry pages dropdown.

Contributes to #2173.