### PR TITLE
docs(ngModule): fix a potential confusion

### DIFF
--- a/public/docs/ts/latest/guide/ngmodule.jade
+++ b/public/docs/ts/latest/guide/ngmodule.jade
@@ -803,7 +803,7 @@ a#shared-module
   * It imports the `CommonModule` because its component needs common directives.
   * It declares and exports the utility pipe, directive, and component classes as expected.
   * It re-exports the `CommonModule`
-  * It re-exports the `FormsModule` which it didn't even import.
+  * It re-exports the `FormsModule` which it didn't even add to the `imports`.
   * There's a strange, static class method call `forRoot` that we should talk about.
 
   But first a few words about module `exports`.


### PR DESCRIPTION
I know it's petty stuff, but technically it does `import` the `FormsModule`.
It just doesn't add it to the imports array.

So to minimize the potential confusion about the overloaded "import" thing, I suggest the following change to the sentence