### PR TITLE
docs(server-communication): Fix typo in example

### DIFF
--- a/public/docs/_examples/server-communication/ts/app/wiki/wikipedia.service.1.ts
+++ b/public/docs/_examples/server-communication/ts/app/wiki/wikipedia.service.1.ts
@@ -18,7 +18,7 @@ export class WikipediaService {
 
     return this.jsonp
                .get(wikiUrl + queryString)
-               .map(request => <string[]> request.json()[1]);
+               .map(response => <string[]> response.json()[1]);
     // #enddocregion query-string
   }
 }

--- a/public/docs/_examples/server-communication/ts/app/wiki/wikipedia.service.ts
+++ b/public/docs/_examples/server-communication/ts/app/wiki/wikipedia.service.ts
@@ -22,7 +22,7 @@ export class WikipediaService {
     // TODO: Add error handling
     return this.jsonp
                .get(wikiUrl, { search: params })
-               .map(request => <string[]> request.json()[1]);
+               .map(response => <string[]> response.json()[1]);
     // #enddocregion call-jsonp
   }
 }


### PR DESCRIPTION
Clearly we're transforming the response, not the request.