### PR TITLE
chore(site): support site build w/o recompiling API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ _.*
 **/resources/zips
 public/docs/xref-*.*
 _zip-output
-www
+www*
 npm-debug*.log*
 *.plnkr.html
 plnkr.html

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -890,6 +890,7 @@ function harpCompile() {
   spawnInfo.promise.then(function(x) {
     gutil.log("NODE_ENV: " + process.env.NODE_ENV);
     showHideExampleNodeModules('show');
+    showHideApiDir('show');
     if (x !== 0) {
       deferred.reject(x)
     } else {
@@ -899,9 +900,8 @@ function harpCompile() {
   }).catch(function(e) {
     gutil.log("NODE_ENV: " + process.env.NODE_ENV);
     showHideExampleNodeModules('show');
-    deferred.reject(e);
-  }).finally(() => {
     showHideApiDir('show');
+    deferred.reject(e);
   });
   return deferred.promise;
 }
@@ -1148,11 +1148,10 @@ function watchAndSync(options, cb) {
 
 // returns a promise;
 function askDeploy() {
-
   prompt.start();
   var schema = {
     name: 'shouldDeploy',
-    description: 'Deploy to Firebase? (y/n): ',
+    description: 'Deploy to Firebase? (y/n)',
     type: 'string',
     pattern: /Y|N|y|n/,
     message: "Respond with either a 'y' or 'n'",


### PR DESCRIPTION
If the site has already been built once, then rebuild the site without re-harp-compiling the API docs use:
```
gulp check-deploy --lang=''
```
Otherwise specify the languages whose API docs are to be rebuilt; as usual, omitting the `--lang` flag is equivalent to `--lang=all` which is equivalent to `--lang=‘ts|js|dart’`.

Other changes to gulp tasks:
- Renamed `serve` to `harp-serve`.
- Removed `check-serve`. Use `harp-compile` followed by `serve-www’ instead.
- `harp-compile` now also defaults to `--lang=all`.