### PR TITLE
chore(travis): anchor Dart SDK version to 1.18.1

### DIFF
--- a/scripts/install-dart-sdk.sh
+++ b/scripts/install-dart-sdk.sh
@@ -13,7 +13,8 @@ if  [[ -z "$(type -t dart)" ]]; then
     # https://storage.googleapis.com/dart-archive/channels/stable/release/latest/dartium/dartium-macos-x64-release.zip
 
     DART_ARCHIVE=https://storage.googleapis.com/dart-archive/channels
-    VERS=stable/release/latest
+    # VERS=stable/release/latest
+    VERS=stable/release/1.18.1
 
     mkUrl() {
         local dir=$1


### PR DESCRIPTION
Because dartdoc from 1.19.0 has issues; see https://github.com/dart-lang/dartdoc/issues/1233.

cc @wardbell @kwalrath 