### PR TITLE
docs(ngmodule): replace `export default` with explicit export

### DIFF
--- a/public/docs/_examples/ngmodule/ts/app/app.routing.3.ts
+++ b/public/docs/_examples/ngmodule/ts/app/app.routing.3.ts
@@ -1,11 +1,10 @@
-import { ModuleWithProviders } from '@angular/core';
-import { Routes,
-         RouterModule } from '@angular/router';
+import { ModuleWithProviders }  from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'contact', pathMatch: 'full'},
-  { path: 'crisis', loadChildren: 'app/crisis/crisis.module' },
-  { path: 'heroes', loadChildren: 'app/hero/hero.module.3' }
+  { path: 'crisis', loadChildren: 'app/crisis/crisis.module#CrisisModule' },
+  { path: 'heroes', loadChildren: 'app/hero/hero.module.3#HeroModule' }
 ];
 
 export const routing: ModuleWithProviders = RouterModule.forRoot(routes);

--- a/public/docs/_examples/ngmodule/ts/app/app.routing.ts
+++ b/public/docs/_examples/ngmodule/ts/app/app.routing.ts
@@ -1,13 +1,12 @@
 // #docregion
-import { ModuleWithProviders } from '@angular/core';
-import { Routes,
-         RouterModule } from '@angular/router';
+import { ModuleWithProviders }  from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'contact', pathMatch: 'full'},
 // #docregion lazy-routes
-  { path: 'crisis', loadChildren: 'app/crisis/crisis.module' },
-  { path: 'heroes', loadChildren: 'app/hero/hero.module' }
+  { path: 'crisis', loadChildren: 'app/crisis/crisis.module#CrisisModule' },
+  { path: 'heroes', loadChildren: 'app/hero/hero.module#HeroModule' }
 // #enddocregion lazy-routes
 ];
 

--- a/public/docs/_examples/ngmodule/ts/app/crisis/crisis.module.ts
+++ b/public/docs/_examples/ngmodule/ts/app/crisis/crisis.module.ts
@@ -11,6 +11,4 @@ import { routing }       from './crisis.routing';
   declarations: [ CrisisDetailComponent, CrisisListComponent ],
   providers:    [ CrisisService ]
 })
-// #docregion export-default
-export default class CrisisModule {}
-// #enddocregion export-default
+export class CrisisModule {}

--- a/public/docs/_examples/ngmodule/ts/app/hero/hero.module.3.ts
+++ b/public/docs/_examples/ngmodule/ts/app/hero/hero.module.3.ts
@@ -21,5 +21,5 @@ import { HeroService }         from './hero.service';
     HighlightDirective
   ]
 })
-export default class HeroModule { }
+export class HeroModule { }
 // #enddocregion class

--- a/public/docs/_examples/ngmodule/ts/app/hero/hero.module.ts
+++ b/public/docs/_examples/ngmodule/ts/app/hero/hero.module.ts
@@ -18,4 +18,4 @@ import { HeroService } from './hero.service';
     HeroComponent, HeroDetailComponent, HeroListComponent,
   ]
 })
-export default class HeroModule { }
+export class HeroModule { }

--- a/public/docs/ts/latest/guide/ngmodule.jade
+++ b/public/docs/ts/latest/guide/ngmodule.jade
@@ -684,19 +684,9 @@ a#lazy-load
 +makeExample('ngmodule/ts/app/app.routing.ts', 'lazy-routes')(format='.')
 .l-sub-section
   :marked
-    Note that the lazy loaded module location is a _string_, not a _type_. 
-
-    To reference the _type_ we'd have to use a JavaScript import statement to get the module symbol, 
-    which loads the module immediately, defeating our intent to load the module later.
-
-    A string, on the other hand, is just a string. It has no side-effects.
-:marked
-  The module location strings in this app identify module _files_, not module _classes_.
-  That works because each module class is marked as the default export in its file.
-+makeExample('ngmodule/ts/app/crisis/crisis.module.ts', 'export-default', '/app/crisis/crisis.module.ts (export default)')(format='.')
-:marked
-    _Remember to use_ `export default`_ for the lazy loaded module class.
-    Continue to use `export` for all other classes.
+    A lazy loaded module location is a _string_, not a _type_. 
+    In this app, the string identifies both the module _file_ and the module _class_,
+    the latter separated from the former by a `#`.
 
 :marked
   ### RouterModule.forRoot


### PR DESCRIPTION
Because AoT won't support `export default` for RC6.