### PR TITLE
docs(quickstart): adjust recent change for Dart

### DIFF
--- a/public/docs/ts/_cache/quickstart.jade
+++ b/public/docs/ts/_cache/quickstart.jade
@@ -361,7 +361,7 @@ block create-main
     1. Angular's browser `!{_platformBrowserDynamicVsBootStrap}` function
     1. The application !{_moduleVsRootComp}, `!{_AppModuleVsAppComp}`.
 
-    Then we call `!{_pBD_bootstrapModule}` with `AppComponent`.
+    Then we call `!{_pBD_bootstrapModule}` with `AppModule`.
 
     ### Bootstrapping is platform-specific
 

--- a/public/docs/ts/_cache/quickstart.jade
+++ b/public/docs/ts/_cache/quickstart.jade
@@ -361,7 +361,7 @@ block create-main
     1. Angular's browser `!{_platformBrowserDynamicVsBootStrap}` function
     1. The application !{_moduleVsRootComp}, `!{_AppModuleVsAppComp}`.
 
-    Then we call `!{_pBD_bootstrapModule}` with `AppModule`.
+    Then we call `!{_pBD_bootstrapModule}` with `!{_AppModuleVsAppComp}`.
 
     ### Bootstrapping is platform-specific
 

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -361,7 +361,7 @@ block create-main
     1. Angular's browser `!{_platformBrowserDynamicVsBootStrap}` function
     1. The application !{_moduleVsRootComp}, `!{_AppModuleVsAppComp}`.
 
-    Then we call `!{_pBD_bootstrapModule}` with `AppModule`.
+    Then we call `!{_pBD_bootstrapModule}` with `!{_AppModuleVsAppComp}`.
 
     ### Bootstrapping is platform-specific
 


### PR DESCRIPTION
Tweak prose so that `AppModule` shows up as `AppComponent` in Dart.

cc @kwalrath 