### PR TITLE
removed duplicated word (before)

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -1206,7 +1206,7 @@ h2#guards Route Guards
 
   2. [CanDeactivate](../api/router/index/CanDeactivate-interface.html) to mediate navigation *away* from the current route.
 
-  3. [Resolve](../api/router/index/Resolve-interface.html) to perform route data retrieval before *before* route activation.
+  3. [Resolve](../api/router/index/Resolve-interface.html) to perform route data retrieval *before* route activation.
 
 .l-sub-section
   :marked


### PR DESCRIPTION
Just a simple typo, the word before appeared twice (one in italic)