### PR TITLE
chore: remove testing libs from systemjs.config

### DIFF
--- a/public/docs/_examples/quickstart/ts/systemjs.config.1.js
+++ b/public/docs/_examples/quickstart/ts/systemjs.config.1.js
@@ -24,16 +24,6 @@
       '@angular/router': 'npm:@angular/router/bundles/router.umd.js',
       '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
 
-      // angular testing umd bundles
-      '@angular/core/testing': 'npm:@angular/core/bundles/core-testing.umd.js',
-      '@angular/common/testing': 'npm:@angular/common/bundles/common-testing.umd.js',
-      '@angular/compiler/testing': 'npm:@angular/compiler/bundles/compiler-testing.umd.js',
-      '@angular/platform-browser/testing': 'npm:@angular/platform-browser/bundles/platform-browser-testing.umd.js',
-      '@angular/platform-browser-dynamic/testing': 'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
-      '@angular/http/testing': 'npm:@angular/http/bundles/http-testing.umd.js',
-      '@angular/router/testing': 'npm:@angular/router/bundles/router-testing.umd.js',
-      '@angular/forms/testing': 'npm:@angular/forms/bundles/forms-testing.umd.js',
-
       // other libraries
       'rxjs':                       'npm:rxjs',
       'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',

--- a/public/docs/_examples/systemjs.config.js
+++ b/public/docs/_examples/systemjs.config.js
@@ -23,16 +23,6 @@
       '@angular/router': 'npm:@angular/router/bundles/router.umd.js',
       '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
 
-      // angular testing umd bundles
-      '@angular/core/testing': 'npm:@angular/core/bundles/core-testing.umd.js',
-      '@angular/common/testing': 'npm:@angular/common/bundles/common-testing.umd.js',
-      '@angular/compiler/testing': 'npm:@angular/compiler/bundles/compiler-testing.umd.js',
-      '@angular/platform-browser/testing': 'npm:@angular/platform-browser/bundles/platform-browser-testing.umd.js',
-      '@angular/platform-browser-dynamic/testing': 'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
-      '@angular/http/testing': 'npm:@angular/http/bundles/http-testing.umd.js',
-      '@angular/router/testing': 'npm:@angular/router/bundles/router-testing.umd.js',
-      '@angular/forms/testing': 'npm:@angular/forms/bundles/forms-testing.umd.js',
-
       // other libraries
       'rxjs':                       'npm:rxjs',
       'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',

--- a/public/docs/_examples/systemjs.config.plunker.build.js
+++ b/public/docs/_examples/systemjs.config.plunker.build.js
@@ -38,7 +38,7 @@
       '@angular/router': 'ng:router-builds/master/bundles/router.umd.js',
       '@angular/forms': 'ng:forms-builds/master/bundles/forms.umd.js',
 
-      // angular testing umd bundles
+      // angular testing umd bundles (overwrite the shim mappings)
       '@angular/core/testing': 'ng:core-builds/master/bundles/core-testing.umd.js',
       '@angular/common/testing': 'ng:common-builds/master/bundles/common-testing.umd.js',
       '@angular/compiler/testing': 'ng:compiler-builds/master/bundles/compiler-testing.umd.js',

--- a/public/docs/_examples/systemjs.config.plunker.js
+++ b/public/docs/_examples/systemjs.config.plunker.js
@@ -35,16 +35,6 @@
       '@angular/router': 'npm:@angular/router/bundles/router.umd.js',
       '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
 
-      // angular testing umd bundles
-      '@angular/core/testing': 'npm:@angular/core/bundles/core-testing.umd.js',
-      '@angular/common/testing': 'npm:@angular/common/bundles/common-testing.umd.js',
-      '@angular/compiler/testing': 'npm:@angular/compiler/bundles/compiler-testing.umd.js',
-      '@angular/platform-browser/testing': 'npm:@angular/platform-browser/bundles/platform-browser-testing.umd.js',
-      '@angular/platform-browser-dynamic/testing': 'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
-      '@angular/http/testing': 'npm:@angular/http/bundles/http-testing.umd.js',
-      '@angular/router/testing': 'npm:@angular/router/bundles/router-testing.umd.js',
-      '@angular/forms/testing': 'npm:@angular/forms/bundles/forms-testing.umd.js',
-
       // other libraries
       'rxjs':                       'npm:rxjs',
       'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',


### PR DESCRIPTION
They belong in the testing shim files