### PR TITLE
fix(quickstart): remove accidental space

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -40,7 +40,7 @@ figure.image-display
 :marked
   **Try it out**. Here's a link to a <live-example></live-example>.
 
-  You can also <a href="https://github .com/angular/quickstart/blob/master/README.md" target="_blank">
+  You can also <a href="https://github.com/angular/quickstart/blob/master/README.md" target="_blank">
   clone the entire QuickStart application</a> from GitHub.
 
 h2 Build this application!


### PR DESCRIPTION
- Remove accidental space causing URL to be rendered incorrectly

This fixes https://github.com/angular/angular/issues/11267