### PR TITLE
Fixed Url of "Should I add providers to the root AppModule or the root AppComponent?"

### DIFF
--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -283,7 +283,7 @@ block ctor-syntax
 
 .l-sub-section
   :marked
-    Read also **Should I add providers to the root AppModule or the root AppComponent?** at the [NgModule](ngmodule.html#q-root-component-or-module) chapter.
+    Read also **Should I add providers to the root AppModule or the root AppComponent?** at the [NgModule FAQ](../cookbook/ngmodule-faq.html#!#q-root-component-or-module) chapter.
 
 :marked
   ### Preparing the HeroListComponent for injection


### PR DESCRIPTION
Fixed url "Should I add providers to the root AppModule or the root AppComponent?" to proper link : NgModule to NgModule-FAQ