### PR TITLE
Correct some small errors in tutorial examples

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/heroes.component.1.ts
+++ b/public/docs/_examples/toh-5/ts/app/heroes.component.1.ts
@@ -1,0 +1,96 @@
+// #docplaster
+// #docregion
+import { Component, OnInit } from '@angular/core';
+
+import { Hero } from './hero';
+// #docregion hero-service-import
+import { HeroService } from './hero.service';
+// #enddocregion hero-service-import
+
+@Component({
+  selector: 'my-app',
+  // #docregion template
+  template: `
+    <h2>My Heroes</h2>
+    <ul class="heroes">
+      <li *ngFor="let hero of heroes"
+        [class.selected]="hero === selectedHero"
+        (click)="onSelect(hero)">
+        <span class="badge">{{hero.id}}</span> {{hero.name}}
+      </li>
+    </ul>
+    <my-hero-detail [hero]="selectedHero"></my-hero-detail>
+  `,
+  // #enddocregion template
+  styles: [`
+    .selected {
+      background-color: #CFD8DC !important;
+      color: white;
+    }
+    .heroes {
+      margin: 0 0 2em 0;
+      list-style-type: none;
+      padding: 0;
+      width: 15em;
+    }
+    .heroes li {
+      cursor: pointer;
+      position: relative;
+      left: 0;
+      background-color: #EEE;
+      margin: .5em;
+      padding: .3em 0;
+      height: 1.6em;
+      border-radius: 4px;
+    }
+    .heroes li.selected:hover {
+      background-color: #BBD8DC !important;
+      color: white;
+    }
+    .heroes li:hover {
+      color: #607D8B;
+      background-color: #DDD;
+      left: .1em;
+    }
+    .heroes .text {
+      position: relative;
+      top: -3px;
+    }
+    .heroes .badge {
+      display: inline-block;
+      font-size: small;
+      color: white;
+      padding: 0.8em 0.7em 0 0.7em;
+      background-color: #607D8B;
+      line-height: 1em;
+      position: relative;
+      left: -1px;
+      top: -4px;
+      height: 1.8em;
+      margin-right: .8em;
+      border-radius: 4px 0 0 4px;
+    }
+  `],
+  providers: [HeroService]
+})
+export class AppComponent implements OnInit {
+  title = 'Tour of Heroes';
+  heroes: Hero[];
+  selectedHero: Hero;
+
+  constructor(private heroService: HeroService) { }
+
+// #docregion get-heroes
+  getHeroes(): void {
+    this.heroService.getHeroes().then(heroes => this.heroes = heroes);
+  }
+// #enddocregion get-heroes
+
+  ngOnInit(): void {
+    this.getHeroes();
+  }
+
+  onSelect(hero: Hero): void {
+    this.selectedHero = hero;
+  }
+}

--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -662,7 +662,7 @@ block extract-id
   That component's current template exhibits a "master/detail" style with the list of heroes
   at the top and details of the selected hero below.
 
-+makeExample('toh-4/ts/app/app.component.ts','template', 'app/heroes.component.ts (current template)')(format=".")
++makeExample('toh-5/ts/app/heroes.component.1.ts','template', 'app/heroes.component.ts (current template)')(format=".")
 
 :marked
   Delete the last line of the template with the `<my-hero-detail>` tags.

--- a/public/docs/ts/latest/tutorial/toh-pt6.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt6.jade
@@ -294,6 +294,10 @@ block get-heroes-details
   When the given name is non-blank, the handler delegates creation of the
   named hero to the hero service, and then adds the new hero to our !{_array}.
 
+  Finally, we implement the create method in the HeroService class.
+
++makeExcerpt('app/hero.service.ts', 'create')
+
   Go ahead, refresh the browser and create some new heroes!
 
 .l-main-section


### PR DESCRIPTION
Addresses: https://github.com/angular/angular.io/issues/2231

And also a small issue where an `<h1>` tag is being included in a template where it was previously deleted.

At https://angular.io/docs/ts/latest/tutorial/toh-pt5.html:

Near the top, user sees:

<img width="625" alt="screen shot 2016-09-02 at 6 08 15 pm" src="https://cloud.githubusercontent.com/assets/3976692/18219529/4212d40e-7138-11e6-8371-8415d16dceab.png">

Since the user has moved the `<h1>` tag to another template, we should not see it here, below:

<img width="871" alt="screen shot 2016-09-02 at 6 07 37 pm" src="https://cloud.githubusercontent.com/assets/3976692/18219522/2ef2a962-7138-11e6-9f93-f574194057c9.png">

Thanks in advance for your consideration of these tweaks.