### PR TITLE
green = do

### DIFF
--- a/public/resources/css/module/_style-guide.scss
+++ b/public/resources/css/module/_style-guide.scss
@@ -12,11 +12,11 @@
 }
 
 .s-rule.do {
-  border-left-color: #1976D2;
+  border-left-color: #237317;
 }
 
 .s-rule.consider {
-  border-left-color: rgba(35, 115, 23, 0.64);
+  border-left-color: #1976D2;
 }
 
 .s-rule.avoid {


### PR DESCRIPTION
blue = consider
red = avoid
light gray = why

Addressing the point raised here ... https://github.com/angular/angular.io/issues/1958

Docs team discussed and agree that Green is best for Do, and Red for avoid. We'll keep the neutral blue for consider.

we decided not to use shades of colors as some folks (like me) have difficulty discerning shades.

cc @wardbell @Foxandxss 