### PR TITLE
docs(quickstart): remove instruction

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -190,6 +190,12 @@ block install-packages
 
     Every Angular application has at least one module: the _root module_, named `AppModule` here.
 
+    **Create #{_an} #{_appDir} subfolder** off the project root directory:
+
+  code-example.
+    mkdir #{_appDir}
+
+  :marked
     Create the file `app/app.module.ts` with the following content:
 
   +makeExample('app/app.module.1.ts')(format='.')
@@ -221,15 +227,10 @@ h1#root-component Step !{step++}: Create a component and add it to your applicat
   Components are the basic building blocks of Angular applications. A component controls a portion
   of the screen&mdash;a *view*&mdash;through its associated template
 
-  **Create #{_an} #{_appDir} subfolder** off the project root directory:
-
-code-example.
-  mkdir #{_appDir}
-
 a#app-component
 p.
   #[b Create the component file]
-  #[code #[+adjExPath('app/app.component.ts')]] (in this newly created directory) with the following content:
+  #[code #[+adjExPath('app/app.component.ts')]] with the following content:
 
 +makeExample('app/app.component.ts')
 


### PR DESCRIPTION
Quickstart tells you to create a `app/app.module.ts` and then later it instructs you on creating the `app` folder (as reported in #2260).

I believe that we don't need the instruction on creating that folder since we are giving clear instructions in where those new files should belong.

Fixes #2260 