### PR TITLE
fix(footer): Footer logo is overflowing

### DIFF
--- a/public/resources/css/module/_footer.scss
+++ b/public/resources/css/module/_footer.scss
@@ -27,9 +27,10 @@
   }
 
   .logo-inverse-large {
-    background: url('/resources/images/logos/inverse/shield/shield-large.png') 0px 0px no-repeat;
+    background: url('/resources/images/logos/inverse/shield/shield-large.png') 0px 0px / contain no-repeat;
     height: 200px;
     width: 200px;
+    max-width: 100%;
 
     @media handheld and (max-width: $phone-breakpoint),
     screen and (max-device-width: $phone-breakpoint),


### PR DESCRIPTION
Footer logo was overflowing at ~960px wide viewport. Added `background-size: contain` (shorthand), and `max-width: 100%` to contain wrapper, and background image within grid.