### PR TITLE
docs(*): fix broken links in glossary and router chapter

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -357,17 +357,17 @@ block includes
   ## ES2015
 .l-sub-section
   :marked
-    Short hand for "[ECMAScript 2015](#ecmascript=2015)".
+    Short hand for [ECMAScript](#ecmascript) 2015.
 :marked
   ## ES6
 .l-sub-section
   :marked
-    Short hand for "[ECMAScript 2015](#ecmascript=2015)".
+    Short hand for [ECMAScript](#ecmascript) 2015.
 :marked
   ## ES5
 .l-sub-section
   :marked
-    Short hand for "ECMAScript 5", the version of JavaScript run by most modern browsers.
+    Short hand for [ECMAScript](#ecmascript) 5, the version of JavaScript run by most modern browsers.
     See [ECMAScript](#ecmascript).
 
 a#F
@@ -732,7 +732,7 @@ a#snake-case
   ## TypeScript
 .l-sub-section
   :marked
-    A version of JavaScript that supports most [ECMAScript 2015](#ecmascript=2015)
+    A version of JavaScript that supports most [ECMAScript](#ecmascript) 2015
     language features and many features that may arrive in future versions
     of JavaScript such as [Decorators](#decorator).
 

--- a/public/docs/ts/latest/guide/router-deprecated.jade
+++ b/public/docs/ts/latest/guide/router-deprecated.jade
@@ -1380,9 +1380,8 @@ code-example(format="." language="bash").
   We too can call that `ngOnInit` method in our tests if we wish ... after taking control of the injected
   `HeroService` and (perhaps) mocking it.
 
-<a name="browser-url-styles"></a>
-<a id="location-strategy"></a>
-.l-main-section
+a#browser-url-styles
+.l-main-section#location-strategy
 :marked
   ## Appendix: *LocationStrategy* and browser URL styles
 

--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -1941,9 +1941,8 @@ a#fragment
   We too can call that `ngOnInit` method in our tests if we wish ... after taking control of the injected
   `HeroService` and (perhaps) mocking it.
 
-<a name="browser-url-styles"></a>
-<a id="location-strategy"></a>
-.l-main-section
+a#browser-url-styles
+.l-main-section#location-strategy
 :marked
   ## Appendix: *LocationStrategy* and browser URL styles
 


### PR DESCRIPTION
- Glossary: `#ecmascript=2015` is not a valid fragment.
- Router: `<a name=“…”>` needed to be `<a id=“…”>`.

@kwalrath 
cc @ericjim 