### PR TITLE
docs(dart): remove unnecessary directives import

### DIFF
--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -12,7 +12,6 @@ transformers:
 - angular2:
     platform_directives:
     - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    - 'package:angular2/common.dart#FORM_DIRECTIVES'
     platform_pipes:
     - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -12,7 +12,6 @@ transformers:
 - angular2:
     platform_directives:
     - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    - 'package:angular2/common.dart#FORM_DIRECTIVES'
     platform_pipes:
     - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart


### PR DESCRIPTION
`FORM_DIRECTIVES` no longer has to be imported as it is part of the `COMMON_DIRECTIVES` import.
