### PR TITLE
docs(quickstart): remove compiler-cli from dependencies

### DIFF
--- a/public/docs/_examples/quickstart/ts/package.1.json
+++ b/public/docs/_examples/quickstart/ts/package.1.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@angular/common": "2.0.0-rc.7",
     "@angular/compiler": "2.0.0-rc.7",
-    "@angular/compiler-cli": "0.6.1",
     "@angular/core": "2.0.0-rc.7",
     "@angular/forms": "2.0.0-rc.7",
     "@angular/http": "2.0.0-rc.7",


### PR DESCRIPTION
This seems to confuse people and we are actually not using it.

I know we are going to use it in the future for AoT but we can either bring it back when TS 2 is here (so new users don't get a lot of warnings) or just add the instructions to add it on the AoT cookbook.