### PR TITLE
chore(cheatsheet): use Jade to generate mirror page

### DIFF
--- a/public/docs/ts/latest/guide/cheatsheet.jade
+++ b/public/docs/ts/latest/guide/cheatsheet.jade
@@ -1,1 +1,1 @@
-!= partial("../cheatsheet")
+extends ../cheatsheet


### PR DESCRIPTION
The page `docs/ts/latest/guide/cheatsheet.html` is a mirror of `docs/ts/latest/cheatsheet.html`. Use Jade instead of Harp to create the mirror.

cc @kwalrath - note that this has no visible effect on the generated page.