### PR TITLE
chore(cheatsheet): fix double banner issue

### DIFF
--- a/public/docs/dart/latest/_data.json
+++ b/public/docs/dart/latest/_data.json
@@ -38,7 +38,7 @@
 
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax.",
+    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "reference": false
   },
 

--- a/public/docs/dart/latest/cheatsheet.jade
+++ b/public/docs/dart/latest/cheatsheet.jade
@@ -1,9 +1,4 @@
 - var base = current.path[4] ? '.' : './guide';
-.banner.grid-fluid
-  .alert.is-important
-    :marked
-      This cheat sheet is provisional and subject to change.
 
-article(class="l-content-small grid-fluid docs-content")
-  .cheatsheet
-    ngio-cheatsheet(src= base + '/cheatsheet.json')
+.l-content-small.grid-fluid.docs-content.cheatsheet
+  ngio-cheatsheet(src= base + '/cheatsheet.json')

--- a/public/docs/dart/latest/guide/_data.json
+++ b/public/docs/dart/latest/guide/_data.json
@@ -59,7 +59,7 @@
 
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax.",
+    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "nextable": true,
     "basics": true
   },

--- a/public/docs/dart/latest/guide/cheatsheet.jade
+++ b/public/docs/dart/latest/guide/cheatsheet.jade
@@ -1,1 +1,1 @@
-!= partial("../cheatsheet")
+extends ../cheatsheet

--- a/public/docs/js/latest/_data.json
+++ b/public/docs/js/latest/_data.json
@@ -38,7 +38,7 @@
 
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax.",
+    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "reference": false
   },
 

--- a/public/docs/js/latest/cheatsheet.jade
+++ b/public/docs/js/latest/cheatsheet.jade
@@ -1,5 +1,4 @@
 - var base = current.path[4] ? '.' : './guide';
 
-article(class="l-content-small grid-fluid docs-content")
-  .cheatsheet
-    ngio-cheatsheet(src= base + '/cheatsheet.json')
+.l-content-small.grid-fluid.docs-content.cheatsheet
+  ngio-cheatsheet(src= base + '/cheatsheet.json')

--- a/public/docs/js/latest/guide/_data.json
+++ b/public/docs/js/latest/guide/_data.json
@@ -52,7 +52,7 @@
 
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax.",
+    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "nextable": true,
     "basics": true
   },

--- a/public/docs/js/latest/guide/cheatsheet.jade
+++ b/public/docs/js/latest/guide/cheatsheet.jade
@@ -1,1 +1,1 @@
-!= partial("../cheatsheet")
+extends ../cheatsheet

--- a/public/docs/ts/latest/_data.json
+++ b/public/docs/ts/latest/_data.json
@@ -45,7 +45,7 @@
 
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax.",
+    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "reference": false
   },
 

--- a/public/docs/ts/latest/cheatsheet.jade
+++ b/public/docs/ts/latest/cheatsheet.jade
@@ -1,7 +1,4 @@
 - var base = current.path[4] ? '.' : './guide';
-.banner
-  p.text-body This cheat sheet is provisional and may change. Angular 2 is currently in Release Candidate.
 
-article(class="l-content-small grid-fluid docs-content")
-  .cheatsheet
-    ngio-cheatsheet(src= base + '/cheatsheet.json')
+.l-content-small.grid-fluid.docs-content.cheatsheet
+  ngio-cheatsheet(src= base + '/cheatsheet.json')

--- a/public/docs/ts/latest/guide/_data.json
+++ b/public/docs/ts/latest/guide/_data.json
@@ -60,7 +60,7 @@
 
   "cheatsheet": {
     "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax.",
+    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "nextable": true,
     "basics": true
   },


### PR DESCRIPTION
Each page is designed to have a single banner; adjust the cheatsheet to follow this convention. Also eliminate the article nested within the `l-conent` div.

Propagated changes/cleanup to JS and Dart.

@kwalrath, cc @ericjim 