### PR TITLE
update conference links - add ng-europe; remove AngularConnect

### DIFF
--- a/public/_includes/_hero-home.jade
+++ b/public/_includes/_hero-home.jade
@@ -8,6 +8,6 @@ header(class="background-sky")
   .banner.banner-floaty
     .banner-ng-annoucement
       div(class="banner-text" align="center")
-        p Join us for AngularConnect in London, UK this September!
+        p Join us for ng-europe in Paris, France this October!
       div(class="banner-button")
-        a(href="http://angularconnect.com/?utm_source=angular&utm_medium=banner&utm_campaign=angular-banner" target="_blank" class="button md-button") Register now
+        a(href="https://ngeurope.org/?utm_source=angular&utm_medium=banner&utm_campaign=angular-banner" target="_blank" class="button md-button") Register now


### PR DESCRIPTION
This links the top banner to ng-europe instead of AngularConnect. Now that AngularConnect is sold out, I think it would be really helpful to link to ng-europe until the conf. Let me know if this could work. Thanks!

How it looks like right now:

![oldbannerangulario](https://cloud.githubusercontent.com/assets/1428412/18409878/450f90e0-7753-11e6-81cc-38b9230b2b93.png)

How it looks like with the ng-europe update:

![image](https://cloud.githubusercontent.com/assets/1428412/18409889/9c3a9ce8-7753-11e6-811d-bd197ebd8e3c.png)



