### PR TITLE
fix(build-compile): allow skipping langs in a fresh build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1044,8 +1044,10 @@ function restoreApiHtml() {
     const relApiDir = path.join('docs', lang, vers, 'api');
     const wwwApiSubdir = path.join('www', relApiDir);
     const backupApiSubdir = path.join('www-backup', relApiDir);
-    gutil.log(`cp ${backupApiSubdir} ${wwwApiSubdir}`)
-    fs.copySync(backupApiSubdir, wwwApiSubdir);
+    if (fs.existsSync(backupApiSubdir) || argv.forceSkipApi !== true) {
+      gutil.log(`cp ${backupApiSubdir} ${wwwApiSubdir}`)
+      fs.copySync(backupApiSubdir, wwwApiSubdir);
+    }
   });
 }
 


### PR DESCRIPTION
Currently, running ` gulp build-compile --dgeni-log=error --lang=''` with no previously full (all langs) build will result in these errors:

```
[17:52:57] Error: ENOENT: no such file or directory, stat 'D:\work\angular.io\www-backup\docs\ts\latest\api'
[17:52:57] Error: ENOENT: no such file or directory, stat 'D:\work\angular.io\www-backup\docs\js\latest\api'
[17:52:57] Error: ENOENT: no such file or directory, stat 'D:\work\angular.io\www-backup\docs\dart\latest\api'
```

This PR fixes that behaviour. This is especially relevant for setups where a full build is never created.

/cc @chalin 