### PR TITLE
API doc-gen updates

### DIFF
--- a/tools/api-builder/angular.io-package/index.js
+++ b/tools/api-builder/angular.io-package/index.js
@@ -101,7 +101,7 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
   computePathsProcessor.pathTemplates.push({
     docTypes: ['module'],
     getPath: function computeModulePath(doc) {
-      doc.moduleFolder = doc.id.replace(/^@angular\//, '');
+      doc.moduleFolder = doc.id.replace(/^@angular\//, '').replace(/\/index$/, '');
       return doc.moduleFolder + '/index.html';
     },
     getOutputPath: function computeModulePath(doc) {
@@ -111,15 +111,15 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
 
   computePathsProcessor.pathTemplates.push({
     docTypes: EXPORT_DOC_TYPES,
-    pathTemplate: '${moduleDoc.moduleFolder}/${name}-${docType}.html',
-    outputPathTemplate:'${moduleDoc.moduleFolder}/${name}-${docType}.jade',
+    pathTemplate: '${moduleDoc.moduleFolder}/${name}.html',
+    outputPathTemplate:'${moduleDoc.moduleFolder}/${name}.jade',
   });
 
 
   computePathsProcessor.pathTemplates.push({
     docTypes: ['decorator'],
-    pathTemplate: '${moduleDoc.moduleFolder}/${name}-${docType}.html',
-    outputPathTemplate:'${moduleDoc.moduleFolder}/${name}-${docType}.jade',
+    pathTemplate: '${moduleDoc.moduleFolder}/${name}.html',
+    outputPathTemplate:'${moduleDoc.moduleFolder}/${name}.jade',
   });
 
   computePathsProcessor.pathTemplates.push({

--- a/tools/api-builder/angular.io-package/tag-defs/index.js
+++ b/tools/api-builder/angular.io-package/tag-defs/index.js
@@ -9,4 +9,5 @@ module.exports = [
   require('./experimental'),
   require('./docsNotRequired'),
   require('./security'),
+  require('./ngModule'),
 ];

--- a/tools/api-builder/angular.io-package/tag-defs/ngModule.js
+++ b/tools/api-builder/angular.io-package/tag-defs/ngModule.js
@@ -1,0 +1,6 @@
+module.exports = function() {
+  return {
+    name: 'ngModule',
+    multi: true
+  };
+};


### PR DESCRIPTION
- Add an `@ngModule @angular/core` dgeni tag that can be used to document in what NgModule a directive is exported. This is a "multi" tag in that it can be used multiple times in a single doc, to indicate that a directive is exported from more than one class. This means that the property `ngModule` on the doc will be an array of strings, rather than a simple string.
- Fix the the paths to the API docs to remove the unwanted `index` and `-doctype` parts.

cc @IgorMinar 

TODO:
- at the very least we will need to update the directive template to display the ngModule
- think about if the change to the URLs of the API docs will have an impact from external sites linking to the docs
