### PR TITLE
chore(travis): use latest Dart SDK

### DIFF
--- a/scripts/install-dart-sdk.sh
+++ b/scripts/install-dart-sdk.sh
@@ -13,8 +13,8 @@ if  [[ -z "$(type -t dart)" ]]; then
     # https://storage.googleapis.com/dart-archive/channels/stable/release/latest/dartium/dartium-macos-x64-release.zip
 
     DART_ARCHIVE=https://storage.googleapis.com/dart-archive/channels
-    # VERS=stable/release/latest
-    VERS=stable/release/1.18.1
+    VERS=stable/release/latest
+    # VERS=stable/release/1.18.1 # If necessary, pin a specific version like this
 
     mkUrl() {
         local dir=$1


### PR DESCRIPTION
Dartdoc has been fixed and can now generate the API docs for angular2, so we no longer need to be pinned to SDK v1.18.1.

cc @kwalrath 