### PR TITLE
fix(api-builder): escape double-quotes in JSON output

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cross-spawn": "^4.0.0",
     "del": "^2.2.0",
     "dgeni": "^0.4.0",
-    "dgeni-packages": "^0.15.2",
+    "dgeni-packages": "^0.16.0",
     "diff": "^2.1.3",
     "fs-extra": "^0.30.0",
     "globby": "^4.0.0",

--- a/tools/api-builder/angular.io-package/templates/api-list-audit.template.html
+++ b/tools/api-builder/angular.io-package/templates/api-list-audit.template.html
@@ -6,7 +6,7 @@
       "docType": "{$ item.docType $}",
       "stability": "{$ item.stability $}",
       "secure": "{$ item.security $}",
-      "howToUse": "{$ item.howToUse $}",
+      "howToUse": "{$ item.howToUse | replace('"','\\"') $}",
       "whatItDoes": {% if item.whatItDoes %}"Exists"{% else %}"Not Done"{% endif %},
       "barrel" : "{$ module | replace("/index", "") $}"
     }{% if not loop.last %},{% endif %}

--- a/tools/api-builder/angular.io-package/templates/api-list-data.template.html
+++ b/tools/api-builder/angular.io-package/templates/api-list-data.template.html
@@ -7,7 +7,7 @@
       "docType": "{$ item.docType $}",
       "stability": "{$ item.stability $}",
       "secure": "{$ item.security $}",
-      "howToUse": "{$ item.howToUse $}",
+      "howToUse": "{$ item.howToUse | replace('"','\\"') $}",
       "whatItDoes": {% if item.whatItDoes %}"Exists"{% else %}"Not Done"{% endif %},
       "barrel" : "{$ module | replace("/index", "") $}"
     }{% if not loop.last %},{% endif %}


### PR DESCRIPTION
This builds on top of #2324 and fixes the problem mentioned at https://github.com/angular/angular.io/pull/2321#issuecomment-246597648

It does this by updating to a newly released version of dgeni-packages that copes with mulitple declarations for a symbol.