### PR TITLE
Fix github links

### DIFF
--- a/tools/api-builder/angular.io-package/templates/class.template.html
+++ b/tools/api-builder/angular.io-package/templates/class.template.html
@@ -140,6 +140,6 @@ div(layout="row" layout-xs="column" class="instance-members" class="row-margin n
 
 p(class="location-badge").
   exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} },
-  defined in {$ github.githubViewLink(doc) $}
+  defined in {$ github.githubViewLink(doc, versionInfo) $}
 
 {% endblock %}

--- a/tools/api-builder/angular.io-package/templates/decorator.template.html
+++ b/tools/api-builder/angular.io-package/templates/decorator.template.html
@@ -46,6 +46,6 @@ div(layout="row" layout-xs="column" class="metadata" class="row-margin ng-cloak"
 {% endif %}
 
 p.location-badge.
-  exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} } defined in {$ github.githubViewLink(doc) $}
+  exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} } defined in {$ github.githubViewLink(doc, versionInfo) $}
 
 {% endblock %}

--- a/tools/api-builder/angular.io-package/templates/function.template.html
+++ b/tools/api-builder/angular.io-package/templates/function.template.html
@@ -26,6 +26,6 @@ div(layout="row" layout-xs="column" class="row-margin ng-cloak")
       {% endif %}
 
 p.location-badge.
-  exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} } defined in {$ github.githubViewLink(doc) $}
+  exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} } defined in {$ github.githubViewLink(doc, versionInfo) $}
 
 {% endblock %}

--- a/tools/api-builder/angular.io-package/templates/interface.template.html
+++ b/tools/api-builder/angular.io-package/templates/interface.template.html
@@ -68,6 +68,6 @@ div(layout="row" layout-xs="column" class="instance-members" class="row-margin n
 
 p(class="location-badge").
   exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} },
-  defined in {$ github.githubViewLink(doc) $}
+  defined in {$ github.githubViewLink(doc, versionInfo) $}
 
 {% endblock %}

--- a/tools/api-builder/angular.io-package/templates/lib/githubLinks.html
+++ b/tools/api-builder/angular.io-package/templates/lib/githubLinks.html
@@ -1,7 +1,7 @@
-{% macro githubHref(doc) -%}
+{% macro githubHref(doc, versionInfo) -%}
 https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/modules/{$ doc.fileInfo.projectRelativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}
 {%- endmacro %}
 
-{% macro githubViewLink(doc) -%}
-  <a href="{$ githubHref(doc) $}">{$ doc.fileInfo.projectRelativePath $}</a>
+{% macro githubViewLink(doc, versionInfo) -%}
+  <a href="{$ githubHref(doc, versionInfo) $}">{$ doc.fileInfo.projectRelativePath $}</a>
 {%- endmacro %}

--- a/tools/api-builder/angular.io-package/templates/module.template.html
+++ b/tools/api-builder/angular.io-package/templates/module.template.html
@@ -3,7 +3,7 @@
 {% block body -%}
 include {$ relativePath(doc.path, '_util-fns') $}
 p.location-badge.
-  defined in {$ github.githubViewLink(doc) $}
+  defined in {$ github.githubViewLink(doc, versionInfo) $}
 
 ul
   {% for page in doc.childPages -%}

--- a/tools/api-builder/angular.io-package/templates/overview-dump.template.html
+++ b/tools/api-builder/angular.io-package/templates/overview-dump.template.html
@@ -47,20 +47,20 @@
 
   {% for export in module.exports %}
   <h3 {% if export.notYetDocumented %}class="not-documented"{% endif %}>
-    <a href="{$ github.githubHref(export) $}">
+    <a href="{$ github.githubHref(export, versionInfo) $}">
     <code>{$ export.docType $} {$ export.name $}</code>
     </a>
   </h3>
       {%- if export.constructorDoc %}
       <h4  {% if export.constructorDoc.notYetDocumented %}class="not-documented"{% endif %}>
-        <a href="{$ github.githubHref(export.constructorDoc) $}">
+        <a href="{$ github.githubHref(export.constructorDoc, versionInfo) $}">
         <code>{$ export.constructorDoc.name $}{$ params.paramList(export.constructorDoc.params) $}</code>
         </a>
       </h4>
     {% endif -%}
     {%- for member in export.members %}
       <h4 {% if member.notYetDocumented %}class="not-documented"{% endif %}>
-        <a href="{$ github.githubHref(member) $}">
+        <a href="{$ github.githubHref(member, versionInfo) $}">
         <code>{$ member.name $}{$ params.paramList(member.params) $}</code>
         </a>
       </h4>

--- a/tools/api-builder/angular.io-package/templates/pipe.template.html
+++ b/tools/api-builder/angular.io-package/templates/pipe.template.html
@@ -24,6 +24,6 @@ div(layout="row" layout-xs="column" class="row-margin ng-cloak")
 
 p(class="location-badge").
   exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
-  defined in {$ github.githubViewLink(doc) $}
+  defined in {$ github.githubViewLink(doc, versionInfo) $}
 
 {% endblock %}

--- a/tools/api-builder/angular.io-package/templates/var.template.html
+++ b/tools/api-builder/angular.io-package/templates/var.template.html
@@ -27,6 +27,6 @@ div(layout="row" layout-xs="column" class="row-margin ng-cloak")
 
 p.location-badge.
   exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
-  defined in {$ github.githubViewLink(doc) $}
+  defined in {$ github.githubViewLink(doc, versionInfo) $}
 
 {% endblock %}

--- a/tools/api-builder/docs-package/templates/module.template.html
+++ b/tools/api-builder/docs-package/templates/module.template.html
@@ -3,7 +3,7 @@
 
 {% block body %}
 <h1 class="id">{$ doc.id $} <span class="type">module</span></h1>
-<p>defined in {$ github.githubViewLink(doc) $}</p>
+<p>defined in {$ github.githubViewLink(doc, versionInfo) $}</p>
 <p>{$ doc.description | marked $}</p>
 
 {% if doc.exports.length %}


### PR DESCRIPTION
The update to dgeni-packages led to a breaking change in the Nunjucks
templates, where macros are now isolated from their calling site.

This means that we must pass the `versionInfo` object through to the
macro rather than expecting it to be in scope already.