### PR TITLE
chore: update tslint rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -84,13 +84,10 @@
       "check-type"
     ],
 
-    "directive-selector-name": [true, "camelCase"],
     "component-selector-name": [true, "kebab-case"],
-    "directive-selector-type": [true, "attribute"],
     "component-selector-type": [true, "element"],
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
-    "use-host-property-decorator": true,
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,


### PR DESCRIPTION
the directive ones are incomplete so it breaks easily.

The host, we don't agree on that rule anymore so we are going to remove it.

This makes Travis green again.