### PR TITLE
chore(api-builder): use Jade include rather than Harp partial

### DIFF
--- a/tools/api-builder/angular.io-package/templates/module.template.html
+++ b/tools/api-builder/angular.io-package/templates/module.template.html
@@ -8,6 +8,8 @@ p.location-badge.
 ul
   {% for page in doc.childPages -%}
   li
-    != partial("{$ relativePath(doc.path, '../../../_includes/_hover-card') $}", {name: "{$ page.title $}", url: "{$ relativePath(doc.moduleFolder, page.exportDoc.path) $}" })
+    - var name = "{$ page.title $}";
+    - var url = "{$ relativePath(doc.moduleFolder, page.exportDoc.path) $}";
+    include {$ relativePath(doc.path, '../../../_includes/_hover-card') $}
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
This change is in support of ng2.io. There is no net effect on ng1.io.