### PR TITLE
fix: merge the decorator data with the corresponding runtime symbol

### DIFF
--- a/tools/api-builder/angular.io-package/processors/addJadeDataDocsProcessor.js
+++ b/tools/api-builder/angular.io-package/processors/addJadeDataDocsProcessor.js
@@ -19,6 +19,65 @@ var titleCase = function(text) {
 *
 */
 
+
+function processExportDoc(exportDoc) {
+  // STABILITY STATUS
+  // Supported tags:
+  // @stable
+  // @experimental
+  // @deprecated
+  // Default is the empty string (no badge)
+  // Do not capitalize the strings, they are intended for use in constructing a css class from _hero.scss
+  // and used in _hero.jade
+  var stability = '';
+  if (_.has(exportDoc, 'stable')) {
+    stability = 'stable';
+  } else if (_.has(exportDoc, 'experimental')) {
+    stability = 'experimental';
+  } else if (_.has(exportDoc, 'deprecated')) {
+    stability = 'deprecated';
+    exportDoc.showDeprecatedNotes = true;
+  }
+  
+  var howToUse = '';
+  if(_.has(exportDoc, 'howToUse')) {
+    var howToUseArray = exportDoc.tags.tags.filter(function(tag) {
+      return tag.tagName === 'howToUse'
+    });
+    
+    // Remove line breaks, there should only be one tag
+    howToUse = howToUseArray[0].description.replace(/(\r\n|\n|\r)/gm," ");
+  }
+  
+  var whatItDoes = '';
+  if(_.has(exportDoc, 'whatItDoes')) {
+    var whatItDoesArray = exportDoc.tags.tags.filter(function(tag) {
+      return tag.tagName === 'whatItDoes'
+    });
+    
+    // Remove line breaks, there should only be one tag
+    whatItDoes = whatItDoesArray[0].description.replace(/(\r\n|\n|\r)/gm," ");
+  }
+  
+  // SECURITY STATUS
+  // Supported tags:
+  // @security
+  // Default is no security risk assessed for api
+  var security = false;
+  if (_.has(exportDoc, 'security')) {
+    var securityArray = exportDoc.tags.tags.filter(function(tag) {
+      return tag.tagName === 'security'
+    });
+    
+    // Remove line breaks, there should only be one tag
+    security = securityArray[0].description.replace(/(\r\n|\n|\r)/gm," ");
+    
+    exportDoc.showSecurityNotes = true;
+  }
+  
+  return {stability: stability, howToUse: howToUse, whatItDoes: whatItDoes, security: security};
+}
+
 module.exports = function addJadeDataDocsProcessor() {
   return {
     $runAfter: ['adding-extra-docs'],
@@ -51,7 +110,7 @@ module.exports = function addJadeDataDocsProcessor() {
       *
       * Modules must be public and have content
       */
-
+      
       _.forEach(docs, function(doc) {
         if (doc.docType === 'module' && !doc.internal && doc.exports.length) {
           modules.push(doc);
@@ -65,83 +124,60 @@ module.exports = function addJadeDataDocsProcessor() {
             intro: doc.description.replace('"', '\"').replace(/\s*(\r?\n|\r)\s*/g," "),
             docType: 'module'
           }];
-
+  
+          var decorators = {};
+  
           // GET DATA FOR EACH PAGE (CLASS, VARS, FUNCTIONS)
           var modulePageInfo  = _(doc.exports)
           .map(function(exportDoc) {
+            // if it ends with "Decorator", we store it in the map
+            // to later merge with the token
+            if (exportDoc.name.endsWith("Decorator")) {
+              var p = processExportDoc(exportDoc.callMember);
+              decorators[exportDoc.name] = {
+                stability : p.stability,
+                howToUse : p.howToUse,
+                whatItDoes : p.whatItDoes,
+                security : p.security,
+                description : exportDoc.callMember.description,
+                docType: 'decorator'
+              };
+              return null;
 
-            // STABILITY STATUS
-            // Supported tags:
-            // @stable
-            // @experimental
-            // @deprecated
-            // Default is the empty string (no badge)
-            // Do not capitalize the strings, they are intended for use in constructing a css class from _hero.scss
-            // and used in _hero.jade
-            var stability = '';
-            if (_.has(exportDoc, 'stable')) {
-              stability = 'stable';
-            } else if (_.has(exportDoc, 'experimental')) {
-              stability = 'experimental';
-            } else if (_.has(exportDoc, 'deprecated')) {
-              stability = 'deprecated';
-              exportDoc.showDeprecatedNotes = true;
+            } else {
+              var p = processExportDoc(exportDoc);
+              
+              // Data inserted into jade-data.template.html
+              var dataDoc = {
+                name: exportDoc.name + '-' + exportDoc.docType,
+                title: exportDoc.name,
+                docType: exportDoc.docType,
+                exportDoc: exportDoc,
+                stability: p.stability,
+                howToUse: p.howToUse,
+                whatItDoes: p.whatItDoes,
+                security: p.security
+              };
+  
+              if (exportDoc.symbolTypeName) dataDoc.varType = titleCase(exportDoc.symbolTypeName);
+              if (exportDoc.originalModule) dataDoc.originalModule = exportDoc.originalModule;
+              
+              return dataDoc;
             }
-
-            var howToUse = '';
-            if(_.has(exportDoc, 'howToUse')) {
-              var howToUseArray = exportDoc.tags.tags.filter(function(tag) {
-                return tag.tagName === 'howToUse'
-              });
-
-              // Remove line breaks, there should only be one tag
-              howToUse = howToUseArray[0].description.replace(/(\r\n|\n|\r)/gm," ");
-            }
-
-            var whatItDoes = '';
-            if(_.has(exportDoc, 'whatItDoes')) {
-              var whatItDoesArray = exportDoc.tags.tags.filter(function(tag) {
-                return tag.tagName === 'whatItDoes'
-              });
-
-              // Remove line breaks, there should only be one tag
-              whatItDoes = whatItDoesArray[0].description.replace(/(\r\n|\n|\r)/gm," ");
-            }
-
-            // SECURITY STATUS
-            // Supported tags:
-            // @security
-            // Default is no security risk assessed for api
-            var security = false;
-            if (_.has(exportDoc, 'security')) {
-              var securityArray = exportDoc.tags.tags.filter(function(tag) {
-                return tag.tagName === 'security'
-              });
-
-              // Remove line breaks, there should only be one tag
-              security = securityArray[0].description.replace(/(\r\n|\n|\r)/gm," ");
-
-              exportDoc.showSecurityNotes = true;
-            }
-
-            // Data inserted into jade-data.template.html
-            var dataDoc = {
-              name: exportDoc.name + '-' + exportDoc.docType,
-              title: exportDoc.name,
-              docType: exportDoc.docType,
-              exportDoc: exportDoc,
-              stability: stability,
-              howToUse: howToUse,
-              whatItDoes: whatItDoes,
-              security: security
-            };
-
-            if (exportDoc.symbolTypeName) dataDoc.varType = titleCase(exportDoc.symbolTypeName);
-            if (exportDoc.originalModule) dataDoc.originalModule = exportDoc.originalModule;
-            return dataDoc;
           })
+          .filter(function(s) { return !!s; }) // filter out all null values
           .sortBy('name')
           .value();
+          
+          // find a matching symbol for every decorator item
+          // and merge the data
+          _.forEach(Object.keys(decorators), function(name) {
+            var varToken = name.split("Decorator")[0];
+            var c = modulePageInfo.filter(function(n) { return n.exportDoc.name === varToken; });
+            
+            c[0].docType = decorators[name].docType;
+            Object.assign(c[0].exportDoc, decorators[name]);
+          });
 
           doc.childPages = modulePageInfo;
 
@@ -161,7 +197,6 @@ module.exports = function addJadeDataDocsProcessor() {
           });
         }
       });
-
 
       return docs.concat(extraDocs);
     }

--- a/tools/api-builder/docs-package/index.js
+++ b/tools/api-builder/docs-package/index.js
@@ -17,7 +17,7 @@ module.exports = new Package('angular-v2-docs', [jsdocPackage, nunjucksPackage, 
 .processor(require('./processors/checkUnbalancedBackTicks'))
 .processor(require('./processors/convertBackticksToCodeBlocks'))
 .processor(require('./processors/addNotYetDocumentedProperty'))
-.processor(require('./processors/mergeDecoratorDocs'))
+.processor(require('./processors/mergeDecoratorDocsEmpty'))
 .processor(require('./processors/extractDecoratedClasses'))
 
 .config(function(parseTagsProcessor) {

--- a/tools/api-builder/docs-package/processors/mergeDecoratorDocsEmpty.js
+++ b/tools/api-builder/docs-package/processors/mergeDecoratorDocsEmpty.js
@@ -1,0 +1,10 @@
+var _ = require('lodash');
+
+module.exports = function mergeDecoratorDocs() {
+  return {
+    $runAfter: ['processing-docs'],
+    $runBefore: ['docs-processed'],
+    $process: function(docs) {
+    }
+  };
+};


### PR DESCRIPTION
The PR merges the docs from decorator symbols and their corresponding runtime symbols (e.g., ContentChildren and ContentChildrenDecorator). The source code has to look this way because of the IDE support, but it doesn't make sense for the docs site because the users think of the two tokens as one.

cc @petebacondarwin @IgorMinar 