### PR TITLE
docs(devguide): fix syntax error in hero-form.component.js

### DIFF
--- a/public/docs/_examples/forms/js/app/hero-form.component.js
+++ b/public/docs/_examples/forms/js/app/hero-form.component.js
@@ -48,5 +48,5 @@
 
       // #docregion first, final
     });
-  // #enddocregion first, final
 })(window.app || (window.app = {}));
+// #enddocregion first, final


### PR DESCRIPTION

Fix Unmatched '{' JavaScript syntax error in hero-form.component.js example