### PR TITLE
docs(aot): remove typescript instruction

### DIFF
--- a/public/docs/ts/latest/cookbook/aot-compiler.jade
+++ b/public/docs/ts/latest/cookbook/aot-compiler.jade
@@ -89,7 +89,7 @@ a#compile
 :marked
   Install a few new npm dependencies with the following command: 
 code-example(format='.').
-  npm install @angular/compiler-cli @angular/platform-server typescript@2.0.2 --save
+  npm install @angular/compiler-cli @angular/platform-server --save
 :marked
   You will run the `ngc` compiler provided in the `@angular/compiler-cli` npm package
   instead of the TypeScript compiler (`tsc`). 


### PR DESCRIPTION
Now that we have TS2 everywhere in our docs (and quickstart) we don't need to tell people to install typescript 2 by hand.

The good part is that installing TS2 by hand ends with a big red INVALID that can scare people off.