### PR TITLE
* docs(toh-6): update 'let' to 'const' for delete hero

### DIFF
--- a/public/docs/_examples/toh-6/ts/app/hero.service.ts
+++ b/public/docs/_examples/toh-6/ts/app/hero.service.ts
@@ -42,7 +42,7 @@ export class HeroService {
 
   // #docregion delete
   delete(id: number): Promise<void> {
-    let url = `${this.heroesUrl}/${id}`;
+    const url = `${this.heroesUrl}/${id}`;
     return this.http.delete(url, {headers: this.headers})
       .toPromise()
       .then(() => null)


### PR DESCRIPTION
Since the update function does use const url instead of let url, this seemed like a good consistency to have between similar blocks of code. I just found it a little jarring when I was going through the tutorial myself