### PR TITLE
Update 2 Twitter Handels in harp.json

### DIFF
--- a/harp.json
+++ b/harp.json
@@ -388,6 +388,7 @@
           "name": "Ward Bell",
           "picture": "/resources/images/bios/wardbell.jpg",
           "website": "https://github.com/wardbell",
+          "twitter": "wardbell",
           "bio": "Ward is an all-around developer with JavaScript, node, and .net chops. He's a frequent conference speaker and podcaster, trainer, Google Developer Expert for Angular, Microsoft MVP, and PluralSight author. He is also president of IdeaBlade, an enterprise software consulting firm and the makers of breeze.js. He would like to get more sleep and spend more time in the mountains.",
           "type": "Community"
       },
@@ -534,6 +535,7 @@
         "name": "Kapunahele Wong",
         "picture": "/resources/images/bios/kapunahelewong.jpg",
         "website": " https://github.com/kapunahelewong",
+        "twitter": "kapunahele",
         "bio": "Kapunahele is a front-end developer at Capital One. She loves just about anything to do with JavaScript, Angular and electronics. She enjoys mapping Hawaiian star names and constellations to Western ones and loves dancing native Hawaiian hula.",
         "type": "Community"
       }


### PR DESCRIPTION
Currently, the links to Twitter on Kapunahele Wong's and Ward Bell's bios both point to https://twitter.com/undefined. These links are accessible when their bios are opened. This PR adds their proper Twitter handle, so their respective links point to the right place.
