### PR TITLE
docs(news): Fix RC7 announcement link

### DIFF
--- a/public/news.jade
+++ b/public/news.jade
@@ -23,7 +23,7 @@
       .title
         a(
         target="_blank"
-        href="http://angularjs.blogspot.com/2016/08/angular-2-rc5-ngmodules-lazy-loading.html"
+        href="http://angularjs.blogspot.com/2016/09/rc7-now-available.html"
         ) RC7 Now Available
       p Today we’re happy to announce that we are shipping Angular 2.0.0-rc.7. This small release is focused on bugfixes. What's fixed? Lazy loading, RxJS, IDE Docs Integration...
       .author


### PR DESCRIPTION
It may be a bit outdated but the url of the RC7 announcement link was not correct.