### PR TITLE
chore: fix api docs issue on angular 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
     - DISPLAY=:99.0
     - CHROME_BIN=chromium-browser
-    - LATEST_RELEASE=2.0.0
+    # using SHA instead of version to fix build-compile issue
+    - LATEST_RELEASE=cfc12c653970c9ad6d807a6a8ebff58edbc568a0
     - TASK_FLAGS="--dgeni-log=warn"
   matrix:
     - TASK=lint

--- a/scripts/deploy-install.sh
+++ b/scripts/deploy-install.sh
@@ -10,7 +10,8 @@ else
     travis_fold start install.ng2
     echo GETTING Angular2 from GitHub ...
     set -x
-    git clone https://github.com/angular/angular.git --branch $LATEST_RELEASE $NG2_REPO
+    git clone https://github.com/angular/angular.git $NG2_REPO
+    git -C $NG2_REPO checkout $LATEST_RELEASE
     set +x
     travis_fold end install.ng2
 fi


### PR DESCRIPTION
Currently our build-compile task fails against 2.0.0 because of an API docs building issue. It has since been fixed in https://github.com/angular/angular/pull/11619 but not included in 2.0.0.

This PR allows our setup to use a SHA instead of a tag to specify the latest release we should test against, and sets the SHA to that of the PR that fixes our issue.

/cc @IgorMinar @naomiblack @chalin 