### PR TITLE
docs(style-guide): attributes aren't comma separated

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -1845,7 +1845,7 @@ a(href="#toc") Back to top
     **Consider** using [snippets](https://marketplace.visualstudio.com/items?itemName=johnpapa.Angular2) for [Visual Studio Code](https://code.visualstudio.com/) that follow these styles and guidelines.
 
     <a href="https://marketplace.visualstudio.com/items?itemName=johnpapa.Angular2">
-      <img src="https://github.com/johnpapa/vscode-angular2-snippets/raw/master/images/use-extension.gif", width="80%", alt="Use Extension">
+      <img src="https://github.com/johnpapa/vscode-angular2-snippets/raw/master/images/use-extension.gif" width="80%" alt="Use Extension">
     </a>  
 
     **Consider** using [snippets](https://atom.io/packages/angular-2-typescript-snippets) for [Atom](https://atom.io/) that follow these styles and guidelines.


### PR DESCRIPTION
A fix necessary for ng2.io

cc @kwalrath @Foxandxss @ericjim 