### PR TITLE
chore(harp): use official pre-release 0.21 of harp

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-tslint": "^5.0.0",
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.4",
-    "harp": "git://github.com/filipesilva/harp.git#8da8d3497ddbfcbcbadd8be63e0fd731d7310cc4",
+    "harp": "0.21.0-pre.1",
     "html2jade": "^0.8.4",
     "indent-string": "^2.1.0",
     "jasmine-core": "^2.3.4",


### PR DESCRIPTION
@filipesilva's harp patch was just merged so we can start using the official pre-release again (as we had tried to do in #2301, but were forced to revert in #2308).

cc @naomiblack 