### PR TITLE
docs(search): proposal for a new search experience using DocSearch 📄

### DIFF
--- a/public/_includes/_head-include.jade
+++ b/public/_includes/_head-include.jade
@@ -40,6 +40,7 @@ link(href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesh
 link(rel="stylesheet" href="/resources/css/vendor/icomoon/style.css")
 link(rel="stylesheet" href="/resources/css/vendor/animate.css")
 link(rel="stylesheet" href="/resources/css/main.css")
+link(rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css")
 
 <!-- MOBILE ICONS -->
 <link rel="apple-touch-icon" sizes="57x57" href="/resources/images/favicons/apple-touch-icon-57x57.png">

--- a/public/_includes/_scripts-include.jade
+++ b/public/_includes/_scripts-include.jade
@@ -37,6 +37,7 @@ script(src="/resources/js/directives/if-docs.js")
 script(src="/resources/js/directives/live-example.js")
 script(src="/resources/js/directives/ngio-ex-path.js")
 script(src="/resources/js/directives/scroll-y-offset-element.js")
+script(src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js")
 
 <!-- GA -->
 script.
@@ -50,14 +51,15 @@ script.
 
 
 if current.path[0] == "docs"
-  <!-- SWIFTYPE -->
+  <!-- DOCSEARCH -->
   script.
-    (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
-    (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
-    e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
-    })(window,document,'script','//s.swiftypecdn.com/install/v1/st.js','_st');
-
-    _st('install','VsuU7kH5Hnnj9tfyNvfK');
+    docsearch({
+      apiKey: '4d0c7e9f3bc6a55d33a7c3a683a841f8',
+      indexName: 'angular',
+      inputSelector: '#docsearch',
+      algoliaOptions: {facetFilters: ['language:#{current.path[1]}'] },
+      debug: false // Set to true if you want to inspect the dropdown
+    });
 
 <!-- Google Feedback -->
 script(src="//www.gstatic.com/feedback/api.js" type="text/javascript")

--- a/public/docs/_includes/_side-nav.jade
+++ b/public/docs/_includes/_side-nav.jade
@@ -64,8 +64,8 @@ nav(class="sidenav l-pinned-left l-layer-4 l-offset-nav"  ng-class="appCtrl.show
   // SEARCH BAR
   header.sidenav-search.st-input-wrapper
     form.st-input-inner
-      label(for="search-io" class="is-hidden") Search Docs
-      input(type="search" id="search-io" placeholder="SEARCH DOCS...")
+      label(for="docsearch" class="is-hidden") Search Docs
+      input(type="search" id="docsearch" placeholder="SEARCH DOCS...")
     button(class="mobile-trigger button" aria-label="View Docs Menu" ng-click="appCtrl.toggleDocsMenu($event)" md-button) Docs <span class="icon icon-arrow-drop-down"></span>
 
   ul(class="sidenav-links")

--- a/public/resources/css/module/_side-nav.scss
+++ b/public/resources/css/module/_side-nav.scss
@@ -25,7 +25,8 @@ $sidenav-width: 240px;
 #{$sidenav} {
   background: $sidenav-background;
   box-shadow: 3px 0px 6px rgba($black, .24);
-  padding-bottom: 72px;
+  padding-top: 104px; // 48px (searchbar) + 56px (header)
+  padding-bottom: 72px; // nav footer fixed button
   width: $sidenav-width;
   bottom: 0px;
   overflow: auto;
@@ -38,6 +39,7 @@ $sidenav-width: 240px;
     right: 0;
     bottom: auto;
     padding-bottom: 0;
+    padding-top: 56px;
 
     #{$sidenav}-links  {
       display: none;
@@ -69,12 +71,15 @@ $sidenav-width: 240px;
   box-shadow: none;
   padding: $unit;
   height: $unit * 6;
-  position: relative;
+  position: fixed;
+  width: $sidenav-width;
+  z-index: $layer-10;
+  top: 56px;
 
   @include respond-to('mobile') {
     border-bottom: none;
     padding-right: $unit * 14;
-    overflow: hidden;
+    width: 100%;
   }
 
   input {
@@ -105,6 +110,40 @@ $sidenav-width: 240px;
     &:-moz-placeholder { /* Firefox 18- */
       color: $blue-grey-100;
       font-size: 12px;
+    }
+    &:focus {
+      outline: 0
+    }
+  }
+
+  .algolia-autocomplete {
+    width: 100%;
+
+    &.algolia-autocomplete-left {
+      // DROPDOWN MENU ON THE RIGHT ON DESKTOP
+      .ds-dropdown-menu {
+        top: -7px !important;
+        left: calc(100% + 10px) !important;
+
+        &::before { // arrow
+          transform: rotate(-135deg);
+          left: -6px !important;
+          top: 10px !important;
+        }
+
+        // DROPDOWN MENU BELOW ON MOBILE
+        @include respond-to('mobile') {
+          min-width: auto;
+          top: 100% !important;
+          left: 0 !important;
+
+          &::before { // arrow
+            transform: rotate(-45deg);
+            left: 48px !important;
+            top: -6px !important;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Hi,

This PR is a proposal to change the default search feature of https://angular.io to [DocSearch](https://community.algolia.com/docsearch).

We believe this change offers a better search experience for AngularJS developers than the
current search feature.

DocSearch is built by [Algolia](https://www.algolia.com/). It's free. You do not have to maintain it. We built it as a community effort
to bring good documentation search to developer communities. It is installed on 160+ websites,
maybe you already used it while browsing https://facebook.github.io/react/ or http://vuejs.org/api/.

@maxiloc and @vvo (me) did the DocSearch integration for angular.io, we work at @algolia.

Here's a demo of how it looks:
![angular io](https://cloud.githubusercontent.com/assets/123822/18590669/03bd786e-7c30-11e6-8ca6-bf6b0a4d149d.gif)

Differences with the current search:
- Isolates searches by language. If you are on `/docs/dart` then you only get the relevant search results for this language.
- Typo tolerance. Write `ngnodule`, we correct that to `ngmodule`
- Direct access to corresponding paragraph if a query matches one. Example: `architecture components` will directly scroll to `guide/architecture.html#components`
- Wider search results style allowing for a more comfortable experience
- Performance. This is subjective but you can maybe tell from the GIF that we show results at the first keystroke which is not the case today

angular.io search index is replicated in 10 regions in the world like any DocSearch index, bringing good search performance to most users.

If the ranking does not meet your expectations, **we can tune it**. I am sure, as AngularJS developers, you already know what would be a perfect ranking/display for a good search. We can tune it in many ways but we believe it could be ok for a first start.

I hope you appreciate this PR and the work we put on making the search on https://angular.io/ AWESOME :)
