### PR TITLE
docs(typescript): Fix name of typings config file

### DIFF
--- a/public/docs/ts/latest/guide/typescript-configuration.jade
+++ b/public/docs/ts/latest/guide/typescript-configuration.jade
@@ -111,7 +111,7 @@ code-example(format="").
   npm run typings list
 :marked
   The following command installs or updates the typings file for the Jasmine test library from the *DefinitelyTyped* repository,
-  and updates the `typings.config` file so you receive it automatically the next time you install typings.
+  and updates the `typings.json` file so you receive it automatically the next time you install typings.
 code-example(format="").
   npm run typings -- install dt~jasmine --save --global
 .l-sub-section


### PR DESCRIPTION
I believe name of the typings config file is typings.json, not typings.config.