### PR TITLE
fix(about): dialog should not show twitter if empty

### DIFF
--- a/public/about/index.jade
+++ b/public/about/index.jade
@@ -22,7 +22,7 @@
     for person, name in bios
       if person.type == type
         .c3
-          md-card(biocard class="bio-card" website="#{person.website}" twitter="#{person.twitter}" pic="#{person.picture}" bio="#{person.bio}"  name="#{person.name}")
+          md-card(biocard class="bio-card" website=person.website twitter=person.twitter pic=person.picture bio=person.bio name=person.name)
             header
               image(src="#{person.picture}" alt="#person.name")
 

--- a/public/resources/js/directives/bio.js
+++ b/public/resources/js/directives/bio.js
@@ -33,11 +33,11 @@ angularIO.directive('biocard', function($rootScope, $timeout, $mdDialog) {
             '     </div>' +
             '     <p class="text-body">{{bio}}</p>' +
             '  </md-content>' +
-            '  <div class="md-actions">' +
+            '  <md-dialog-actions>' +
             '    <md-button ng-click="closeDialog()">' +
             '      Close Bio' +
             '    </md-button>' +
-            '  </div>' +
+            '  </md-dialog-actions>' +
             '</md-dialog>'
         });
       });


### PR DESCRIPTION
- The bio directive accidentally shows the Twitter link in the dialog, even if it's undefined.
  
  > The directive is not able to track it, because Jade emits a `"undefined"` string, instead of an empty string.
  > 
  > `!!"undefined" ==> true` // Shows Twitter button
- Fix deprecation warning of Angular Material, where `md-dialog-actions` should be used instead of the class.
  
  ![](https://i.gyazo.com/8be76d1403238bc3bd2f60b4b9b76726.png)
