### PR TITLE
docs(webpack): move to core-js in testing

### DIFF
--- a/public/docs/_examples/webpack/ts/config/karma-test-shim.js
+++ b/public/docs/_examples/webpack/ts/config/karma-test-shim.js
@@ -2,7 +2,7 @@
 Error.stackTraceLimit = Infinity;
 
 require('core-js/es6');
-require('reflect-metadata');
+require('core-js/es7/reflect');
 
 require('zone.js/dist/zone');
 require('zone.js/dist/long-stack-trace-zone');


### PR DESCRIPTION
This matches what the CLI does.

Fixes #2317 