### PR TITLE
Fixed typo which was referring to 'imports' section and not 'setup'

### DIFF
--- a/public/docs/ts/latest/guide/testing.jade
+++ b/public/docs/ts/latest/guide/testing.jade
@@ -438,7 +438,7 @@ a#simple-component-test
 +makeExample('testing/ts/app/banner.component.spec.ts', 'imports', 'app/banner.component.spec.ts (imports)')(format='.')
 :marked
   Here's the setup for the tests followed by observations about the `beforeEach`:
-+makeExample('testing/ts/app/banner.component.spec.ts', 'setup', 'app/banner.component.spec.ts (imports)')(format='.')
++makeExample('testing/ts/app/banner.component.spec.ts', 'setup', 'app/banner.component.spec.ts (setup)')(format='.')
 :marked
   `TestBed.configureTestingModule` takes an `@NgModule`-like metadata object.
   This one simply declares the component to test, `BannerComponent`.


### PR DESCRIPTION
I noticed that there is a v minor typo in the [testing guide](https://angular.io/docs/ts/latest/testing/#!#simple-component-test).  The second code block for `app/banner.component.spec.ts` duplicates the '(imports)' text

![imports](https://cloud.githubusercontent.com/assets/6249838/18633017/300da9d6-7e72-11e6-9d6e-fdbde9db3215.png)
