### PR TITLE
docs(cookbook): don't use shredder on intro page

### DIFF
--- a/public/docs/dart/latest/cookbook/aot-compiler.jade
+++ b/public/docs/dart/latest/cookbook/aot-compiler.jade
@@ -1,0 +1,1 @@
+include ../../../_includes/_ts-temp

--- a/public/docs/js/latest/cookbook/aot-compiler.jade
+++ b/public/docs/js/latest/cookbook/aot-compiler.jade
@@ -1,0 +1,1 @@
+include ../../../_includes/_ts-temp

--- a/public/docs/js/latest/cookbook/index.jade
+++ b/public/docs/js/latest/cookbook/index.jade
@@ -1,3 +1,1 @@
-include ../../../../_includes/_util-fns 
-
-+includeShared('../../../ts/latest/cookbook/index.jade', 'cookbook')
+include ../../../ts/latest/cookbook/index.jade

--- a/public/docs/ts/latest/cookbook/index.jade
+++ b/public/docs/ts/latest/cookbook/index.jade
@@ -1,6 +1,5 @@
 include ../_util-fns 
 
-// #docregion cookbook
 :marked
   # Angular Cookbook
   
@@ -12,6 +11,7 @@ include ../_util-fns
 .l-sub-section
   :marked
     The cookbook is just getting started. Many more recipes are on the way.
+
 :marked
   Each cookbook chapter links to a live sample with every recipe included.
   
@@ -28,4 +28,3 @@ include ../_util-fns
   [angular.io](https://github.com/angular/angular.io) github repository.
   
   Post issues with *Angular itself* to the [angular](https://github.com/angular/angular) github repository.
-// #enddocregion cookbook


### PR DESCRIPTION
Also added missing cookbook AoT chapter placeholders for JS and Dart, fixing 404s mentioned in #2389.