### PR TITLE
chore: fix zone.js for plunkers

### DIFF
--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -45,7 +45,7 @@ var _rxData = [
   {
     pattern: 'script',
     from: 'node_modules/zone.js/dist/zone.js',
-    to:   'https://unpkg.com/zone.js@0.6.23?main=browser'
+    to:   'https://unpkg.com/zone.js@0.6.25?main=browser'
   },
   {
     pattern: 'script',


### PR DESCRIPTION
zone 0.6.23 is making conflicts with plunker and it is generating some weird side effects (opening a plunker run window in a new tab).