### PR TITLE
docs(user-input): misc fixes

### DIFF
--- a/public/docs/dart/latest/guide/user-input.jade
+++ b/public/docs/dart/latest/guide/user-input.jade
@@ -23,7 +23,7 @@ include ../_util-fns
 :marked
   The `(click)` to the left of the equal sign identifies the button's click event as the **target of the binding**.
   The text within quotes on the right is the **template statement** in which we
-  respond to the click event by calling the component's `onClickMe` method. A template statement <!-- PENDING: link to ./template-syntax.html#template-statements --> is a subset
+  respond to the click event by calling the component's `onClickMe` method. A [template statement](./template-syntax.html#template-statements) is a subset
   of Dart with restrictions and a few added tricks.
 
   When writing a binding we must be aware of a template statement's **execution context**.
@@ -49,7 +49,6 @@ include ../_util-fns
   which we pass to the component's `onKey()` method.
   The user data we want is in that variable somewhere.
 
-important
 .callout.is-important
   header $event vs. \$event
   :marked
@@ -67,7 +66,7 @@ important
 
   The `onKey()` component method is where we extract the user's input
   from the event object, adding that input to the list of user data that we're accumulating in the component's `values` property.
-  We then use interpolation <!-- PENDING: link to ./template-syntax.html#interpolation) -->
+  We then use [interpolation](./template-syntax.html#interpolation)
   to display the accumulating `values` property back on screen.
 
   Enter the letters "abc", and then backspace to remove them.


### PR DESCRIPTION
- Remove nonexistent `<important>` element since it causes problems for ng2.io. This is probably a typo. It was more likely meant to be an anchor name than an element name.
- Fix two PENDING links.

cc @ericjim