### PR TITLE
docs(testing): use marked Jade filter rather than deprecated markdown

### DIFF
--- a/public/docs/ts/latest/guide/testing.jade
+++ b/public/docs/ts/latest/guide/testing.jade
@@ -518,7 +518,7 @@ a(href="#top").to-top Back to top
   ### The tests
   Jasmine runs this `beforeEach` before each test of which there are two
 +makeExample('testing/ts/app/banner.component.spec.ts', 'tests', 'app/banner.component.spec.ts (tests)')(format='.')
-:markdown
+:marked
   These tests ask the `DebugElement` for the native HTML element to satisfy their expectations.
 
 #detect-changes


### PR DESCRIPTION
When the testing page is rendered using Jade, the following warning is generated:
```
Transformers.markdown is deprecated, you must replace the :markdown
jade filter, with :marked and install jstransformer-marked before you
update to jade@2.0.0.
```
This fixes the issue.

cc @wardbell @ericjim 