### PR TITLE
BrowserSync: suggest to set "scrollRestoreTechnique" to "cookie"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1160,7 +1160,11 @@ function watchAndSync(options, cb) {
   execCommands(['npm run harp -- server .'], {}, cb);
 
   var browserSync = require('browser-sync').create();
-  browserSync.init({proxy: 'localhost:9000'});
+  browserSync.init(
+    {
+      proxy: 'localhost:9000',
+      scrollRestoreTechnique: 'cookie'
+    });
 
   // When using the --focus=name flag, only **/name/**/*.* example files and
   // **/name.jade files are watched. This is useful for performance reasons.


### PR DESCRIPTION
When refreshing, Browser Sync would remember where the page was last and scroll to the correct location. It is very handy for the l10n teams.