### PR TITLE
docs(js/guide): don't use shredder & _data.json fixes

### DIFF
--- a/public/docs/js/latest/guide/_data.json
+++ b/public/docs/js/latest/guide/_data.json
@@ -69,6 +69,12 @@
     "hide": true
   },
 
+  "animations": {
+    "title": "Animations",
+    "intro": "A guide to Angular's animation system.",
+    "hide": true
+  },
+
   "attribute-directives": {
     "title": "Attribute Directives",
     "intro": "Attribute directives attach behavior to elements."
@@ -108,7 +114,7 @@
 
   "npm-packages": {
     "title": "Npm Packages",
-    "intro": "Details of the recommended npm packages and the different kinds of package dependencies"
+    "intro": "Recommended npm packages, and how to specify package dependencies"
   },
 
   "pipes": {
@@ -118,12 +124,12 @@
 
   "router": {
     "title": "Routing & Navigation",
-    "intro": "Discover the basics of screen navigation with the Angular 2 router."
+    "intro": "Discover the basics of screen navigation with the Angular Router."
   },
 
   "security": {
     "title": "Security",
-    "intro": "Prevent security vulnerabilities"
+    "intro": "Developing for content security in Angular applications"
   },
 
   "structural-directives": {
@@ -139,7 +145,7 @@
 
   "typescript-configuration": {
     "title": "TypeScript Configuration",
-    "intro": "TypeScript configuration for Angular 2 developers",
+    "intro": "TypeScript configuration for Angular developers",
     "hide": true
   },
 
@@ -150,7 +156,7 @@
 
   "webpack": {
     "title": "Webpack: an introduction",
-    "intro": "Create your Angular 2 applications with a Webpack based tooling",
+    "intro": "Create your Angular applications with a Webpack based tooling",
     "hide": true
   }
 }

--- a/public/docs/js/latest/guide/index.jade
+++ b/public/docs/js/latest/guide/index.jade
@@ -1,12 +1,12 @@
-include ../_util-fns
+extends ../../../ts/latest/guide/index.jade
 
-+includeShared('{ts}', 'intro')
-+includeShared('{ts}', 'how-to-read-1')
-.alert.is-important
-  :marked
-    Most of the documentation has been written for TypeScript developers
-    and has not yet been translated to JavaScript.
-    Please bear with us. Meanwhile, we've provide links to the TypeScript chapters
-    where JavaScript versions are unavailable.
-+includeShared('{ts}', 'how-to-read-2')
-+includeShared('{ts}', 'the-rest')
+block includes
+  include ../_util-fns
+
+block js-alert
+  .alert.is-important
+    :marked
+      Most of the documentation has been written for TypeScript developers
+      and has not yet been translated to JavaScript.
+      Please bear with us. Meanwhile, we've provide links to the TypeScript chapters
+      where JavaScript versions are unavailable.

--- a/public/docs/ts/latest/guide/_data.json
+++ b/public/docs/ts/latest/guide/_data.json
@@ -122,7 +122,7 @@
 
   "router": {
     "title": "Routing & Navigation",
-    "intro": "Discover the basics of screen navigation with the Angular 2 Router."
+    "intro": "Discover the basics of screen navigation with the Angular Router."
   },
 
   "security": {
@@ -142,7 +142,7 @@
 
   "typescript-configuration": {
     "title": "TypeScript Configuration",
-    "intro": "TypeScript configuration for Angular 2 developers"
+    "intro": "TypeScript configuration for Angular developers"
   },
 
   "upgrade": {
@@ -152,6 +152,6 @@
 
   "webpack": {
     "title": "Webpack: an introduction",
-    "intro": "Create your Angular 2 applications with a Webpack based tooling"
+    "intro": "Create your Angular applications with a Webpack based tooling"
   }
 }

--- a/public/docs/ts/latest/guide/index.jade
+++ b/public/docs/ts/latest/guide/index.jade
@@ -1,7 +1,6 @@
 block includes
   include ../_util-fns
 
-// #docregion intro
 - var langName = current.path[1] == 'ts' ? 'TypeScript' : 'JavaScript'
 figure
   img(src="/resources/images/devguide/intro/people.png" alt="Us" align="left" style="width:200px; margin-left:-40px;margin-right:10px" )
@@ -10,17 +9,16 @@ figure
   are building client applications in HTML and #{langName}.
 
   <br clear="all">
-// #enddocregion intro
 
-// #docregion how-to-read-1
 <a id="learning-path"></a>
 :marked
   # Organization
 
   The documentation is divided into major thematic sections, each
   a collection of pages devoted to that theme.
-// #enddocregion how-to-read-1
-// #docregion how-to-read-2
+
+block js-alert
+
 - var top="vertical-align:top"
 table(width="100%")
   col(width="15%")
@@ -83,8 +81,7 @@ table(width="100%")
   1. [Template Syntax](template-syntax.html) is a comprehensive study of Angular template HTML.
 
   After reading the above sections, you can skip to any other pages on this site.
-// #enddocregion how-to-read-2
-// #docregion the-rest
+
 :marked
   # Code samples
 
@@ -119,4 +116,3 @@ block example-links
 
 
   Use the [Angular Github repo](https://github.com/angular/angular) to report issues with **Angular** itself.
-// #enddocregion the-rest


### PR DESCRIPTION
Also:
- synced `_data.json` with TS counterpart
- fixed some missed “Angular 2” -> “Angular” renamings (contributes to #2407)