### PR TITLE
chore: ability to add unit test boilerplate

### DIFF
--- a/public/docs/_examples/upgrade-phonecat-2-hybrid/ts/example-config.json
+++ b/public/docs/_examples/upgrade-phonecat-2-hybrid/ts/example-config.json
@@ -1,0 +1,3 @@
+{
+  "unittesting": true
+}

--- a/public/docs/_examples/upgrade-phonecat-3-final/ts/example-config.json
+++ b/public/docs/_examples/upgrade-phonecat-3-final/ts/example-config.json
@@ -1,0 +1,3 @@
+{
+  "unittesting": true
+}


### PR DESCRIPTION
For those examples that needs testing, this PR adds the ability to add a _flag_ into the `example-config.json` for copying the testing boilerplate.