### PR TITLE
chore: update samples to "angular-in-memory-web-api"

### DIFF
--- a/public/docs/_examples/cb-dependency-injection/ts/app/app.module.ts
+++ b/public/docs/_examples/cb-dependency-injection/ts/app/app.module.ts
@@ -9,7 +9,7 @@ import { LocationStrategy,
 import { NgModule }                     from '@angular/core';
 
 import { HeroData }                     from './hero-data';
-import { InMemoryWebApiModule }         from 'angular2-in-memory-web-api';
+import { InMemoryWebApiModule }         from 'angular-in-memory-web-api';
 
 
 import { AppComponent }                 from './app.component';

--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-server": "2.0.0",
     "@angular/router": "3.0.0",
     "@angular/upgrade": "2.0.0",
-    "angular2-in-memory-web-api": "0.0.20",
+    "angular-in-memory-web-api": "0.1.0",
     "bootstrap": "^3.3.6",
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.3",

--- a/public/docs/_examples/quickstart/ts/systemjs.config.1.js
+++ b/public/docs/_examples/quickstart/ts/systemjs.config.1.js
@@ -25,8 +25,8 @@
       '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
 
       // other libraries
-      'rxjs':                       'npm:rxjs',
-      'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
+      'rxjs':                      'npm:rxjs',
+      'angular-in-memory-web-api': 'npm:angular-in-memory-web-api',
     },
     // packages tells the System loader how to load when no filename and/or no extension
     packages: {
@@ -37,7 +37,7 @@
       rxjs: {
         defaultExtension: 'js'
       },
-      'angular2-in-memory-web-api': {
+      'angular-in-memory-web-api': {
         main: './index.js',
         defaultExtension: 'js'
       }

--- a/public/docs/_examples/server-communication/ts/app/app.module.ts
+++ b/public/docs/_examples/server-communication/ts/app/app.module.ts
@@ -4,7 +4,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { HttpModule, JsonpModule }  from '@angular/http';
 
-import { InMemoryWebApiModule }     from 'angular2-in-memory-web-api';
+import { InMemoryWebApiModule }     from 'angular-in-memory-web-api';
 import { HeroData }                 from './hero-data';
 
 import { AppComponent }             from './app.component';

--- a/public/docs/_examples/server-communication/ts/app/hero-data.ts
+++ b/public/docs/_examples/server-communication/ts/app/hero-data.ts
@@ -1,5 +1,5 @@
 // #docregion
-import { InMemoryDbService } from 'angular2-in-memory-web-api';
+import { InMemoryDbService } from 'angular-in-memory-web-api';
 export class HeroData implements InMemoryDbService {
   createDb() {
     let heroes = [

--- a/public/docs/_examples/server-communication/ts/app/toh/hero.service.ts
+++ b/public/docs/_examples/server-communication/ts/app/toh/hero.service.ts
@@ -15,13 +15,13 @@ import { Observable }     from 'rxjs/Observable';
 
 @Injectable()
 export class HeroService {
-  // #docregion ctor
-  constructor (private http: Http) {}
-  // #enddocregion ctor
-
   // #docregion endpoint
   private heroesUrl = 'app/heroes';  // URL to web API
   // #enddocregion endpoint
+
+  // #docregion ctor
+  constructor (private http: Http) {}
+  // #enddocregion ctor
 
   // #docregion methods, error-handling, http-get
   getHeroes (): Observable<Hero[]> {

--- a/public/docs/_examples/style-guide/ts/app/main.ts
+++ b/public/docs/_examples/style-guide/ts/app/main.ts
@@ -3,7 +3,7 @@ import { platformBrowserDynamic }   from '@angular/platform-browser-dynamic';
 import { BrowserModule }            from '@angular/platform-browser';
 
 import { HttpModule }           from '@angular/http';
-import { InMemoryWebApiModule } from 'angular2-in-memory-web-api';
+import { InMemoryWebApiModule } from 'angular-in-memory-web-api';
 
 import { RouterModule } from '@angular/router';
 

--- a/public/docs/_examples/systemjs.config.js
+++ b/public/docs/_examples/systemjs.config.js
@@ -25,8 +25,8 @@
       '@angular/upgrade': 'npm:@angular/upgrade/bundles/upgrade.umd.js',
 
       // other libraries
-      'rxjs':                       'npm:rxjs',
-      'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
+      'rxjs':                      'npm:rxjs',
+      'angular-in-memory-web-api': 'npm:angular-in-memory-web-api',
     },
     // packages tells the System loader how to load when no filename and/or no extension
     packages: {
@@ -37,7 +37,7 @@
       rxjs: {
         defaultExtension: 'js'
       },
-      'angular2-in-memory-web-api': {
+      'angular-in-memory-web-api': {
         main: './index.js',
         defaultExtension: 'js'
       }

--- a/public/docs/_examples/systemjs.config.plunker.build.js
+++ b/public/docs/_examples/systemjs.config.plunker.build.js
@@ -50,10 +50,10 @@
       '@angular/forms/testing': 'ng:forms-builds/master/bundles/forms-testing.umd.js',
 
       // other libraries
-      'rxjs':                       'npm:rxjs',
-      'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
-      'ts':                         'npm:plugin-typescript@4.0.10/lib/plugin.js',
-      'typescript':                 'npm:typescript@2.0.2/lib/typescript.js',
+      'rxjs':                      'npm:rxjs',
+      'angular-in-memory-web-api': 'npm:angular-in-memory-web-api',
+      'ts':                        'npm:plugin-typescript@4.0.10/lib/plugin.js',
+      'typescript':                'npm:typescript@2.0.2/lib/typescript.js',
 
     },
     // packages tells the System loader how to load when no filename and/or no extension
@@ -65,7 +65,7 @@
       rxjs: {
         defaultExtension: 'js'
       },
-      'angular2-in-memory-web-api': {
+      'angular-in-memory-web-api': {
         main: './index.js',
         defaultExtension: 'js'
       }

--- a/public/docs/_examples/systemjs.config.plunker.js
+++ b/public/docs/_examples/systemjs.config.plunker.js
@@ -37,10 +37,10 @@
       '@angular/upgrade': 'npm:@angular/upgrade/bundles/upgrade.umd.js',
 
       // other libraries
-      'rxjs':                       'npm:rxjs',
-      'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
-      'ts':                         'npm:plugin-typescript@4.0.10/lib/plugin.js',
-      'typescript':                 'npm:typescript@2.0.2/lib/typescript.js',
+      'rxjs':                      'npm:rxjs',
+      'angular-in-memory-web-api': 'npm:angular-in-memory-web-api',
+      'ts':                        'npm:plugin-typescript@4.0.10/lib/plugin.js',
+      'typescript':                'npm:typescript@2.0.2/lib/typescript.js',
 
     },
     // packages tells the System loader how to load when no filename and/or no extension
@@ -52,7 +52,7 @@
       rxjs: {
         defaultExtension: 'js'
       },
-      'angular2-in-memory-web-api': {
+      'angular-in-memory-web-api': {
         main: './index.js',
         defaultExtension: 'js'
       }

--- a/public/docs/_examples/toh-6/ts/app/app.module.ts
+++ b/public/docs/_examples/toh-6/ts/app/app.module.ts
@@ -12,7 +12,7 @@ import { HttpModule }    from '@angular/http';
 
 // #enddocregion v1
 // Imports for loading & configuring the in-memory web api
-import { InMemoryWebApiModule } from 'angular2-in-memory-web-api';
+import { InMemoryWebApiModule } from 'angular-in-memory-web-api';
 import { InMemoryDataService }  from './in-memory-data.service';
 
 // #docregion v1

--- a/public/docs/_examples/toh-6/ts/app/in-memory-data.service.ts
+++ b/public/docs/_examples/toh-6/ts/app/in-memory-data.service.ts
@@ -1,5 +1,5 @@
 // #docregion , init
-import { InMemoryDbService } from 'angular2-in-memory-web-api';
+import { InMemoryDbService } from 'angular-in-memory-web-api';
 export class InMemoryDataService implements InMemoryDbService {
   createDb() {
     let heroes = [

--- a/public/docs/_examples/upgrade-phonecat-2-hybrid/ts/systemjs.config.1.js
+++ b/public/docs/_examples/upgrade-phonecat-2-hybrid/ts/systemjs.config.1.js
@@ -7,17 +7,17 @@
   // map tells the System loader where to look for things
   // #docregion paths
   var map = {
-    'app':                        '/app', // 'dist',
+    'app':                       '/app', // 'dist',
 
-    '@angular':                   '/node_modules/@angular',
-    'angular2-in-memory-web-api': '/node_modules/angular2-in-memory-web-api',
-    'rxjs':                       '/node_modules/rxjs'
+    '@angular':                  '/node_modules/@angular',
+    'angular-in-memory-web-api': '/node_modules/angular-in-memory-web-api',
+    'rxjs':                      '/node_modules/rxjs'
   };
 
   var packages = {
-    '/app':                       { main: 'main.js',  defaultExtension: 'js' },
-    'rxjs':                       { defaultExtension: 'js' },
-    'angular2-in-memory-web-api': { main: 'index.js', defaultExtension: 'js' },
+    '/app':                      { main: 'main.js',  defaultExtension: 'js' },
+    'rxjs':                      { defaultExtension: 'js' },
+    'angular-in-memory-web-api': { main: 'index.js', defaultExtension: 'js' },
   };
   // #enddocregion paths
 

--- a/public/docs/_examples/upgrade-phonecat-3-final/ts/systemjs.config.1.js
+++ b/public/docs/_examples/upgrade-phonecat-3-final/ts/systemjs.config.1.js
@@ -7,17 +7,17 @@
   // map tells the System loader where to look for things
   // #docregion paths
   var map = {
-    'app':                        '/app', // 'dist',
+    'app':                       '/app', // 'dist',
 
-    '@angular':                   '/node_modules/@angular',
-    'angular2-in-memory-web-api': '/node_modules/angular2-in-memory-web-api',
-    'rxjs':                       '/node_modules/rxjs'
+    '@angular':                  '/node_modules/@angular',
+    'angular-in-memory-web-api': '/node_modules/angular-in-memory-web-api',
+    'rxjs':                      '/node_modules/rxjs'
   };
 
   var packages = {
-    '/app':                       { main: 'main.js',  defaultExtension: 'js' },
-    'rxjs':                       { defaultExtension: 'js' },
-    'angular2-in-memory-web-api': { main: 'index.js', defaultExtension: 'js' },
+    '/app':                      { main: 'main.js',  defaultExtension: 'js' },
+    'rxjs':                      { defaultExtension: 'js' },
+    'angular-in-memory-web-api': { main: 'index.js', defaultExtension: 'js' },
   };
   // #enddocregion paths
 

--- a/public/docs/ts/_cache/guide/server-communication.jade
+++ b/public/docs/ts/_cache/guide/server-communication.jade
@@ -669,7 +669,7 @@ a#in-mem-web-api
 .l-sub-section
   :marked
     The in-memory web api is not part of the Angular core. 
-    It's an optional service in its own `angular2-in-memory-web-api` library
+    It's an optional service in its own `angular-in-memory-web-api` library
     that we installed with npm (see `package.json`) and 
     registered for module loading by SystemJS (see `systemjs.config.js`)
 

--- a/public/docs/ts/latest/guide/npm-packages.jade
+++ b/public/docs/ts/latest/guide/npm-packages.jade
@@ -129,7 +129,7 @@ a(id="other")
 :marked
   ### Other helper libraries
   
-  ***angular2-in-memory-web-api*** - An Angular-supported library that simulates a remote server's web api 
+  ***angular-in-memory-web-api*** - An Angular-supported library that simulates a remote server's web api 
   without requiring an actual server or real http calls. 
   Good for demos, samples, and early stage development (before we even have a server).
   Read about it in the [Http Client](server-communication.html#appendix-tour-of-heroes-in-memory-server) page.

--- a/public/docs/ts/latest/guide/server-communication.jade
+++ b/public/docs/ts/latest/guide/server-communication.jade
@@ -654,7 +654,7 @@ a#in-mem-web-api
 .l-sub-section
   :marked
     The in-memory web api is not part of the Angular core. 
-    It's an optional service in its own `angular2-in-memory-web-api` library
+    It's an optional service in its own `angular-in-memory-web-api` library
     that we installed with npm (see `package.json`) and 
     registered for module loading by SystemJS (see `systemjs.config.js`)
 


### PR DESCRIPTION
"angular2-in-mem-web-api" becomes "angular-in-memory-web-api"
also made ready for aot

**coordinate merge with [angular/in-mem-web-api PR #31](https://github.com/angular/in-memory-web-api/pull/31)**