### PR TITLE
fix(gulp): fix build and run task defaults

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -295,14 +295,16 @@ function runE2eTsTests(appDir, outputFile) {
   try {
     var exampleConfig = fs.readJsonSync(`${appDir}/${_exampleConfigFilename}`);
   } catch (e) {
-    exampleConfig = {
-      build: 'tsc',
-      run: 'http-server:e2e'
-    };
+    exampleConfig = {};
   }
+  
+  var config = {
+    build: exampleConfig.build || 'tsc',
+    run: exampleConfig.run || 'http-server:e2e'
+  };
 
-  var appBuildSpawnInfo = spawnExt('npm', ['run', exampleConfig.build], { cwd: appDir });
-  var appRunSpawnInfo = spawnExt('npm', ['run', exampleConfig.run, '--', '-s'], { cwd: appDir });
+  var appBuildSpawnInfo = spawnExt('npm', ['run', config.build], { cwd: appDir });
+  var appRunSpawnInfo = spawnExt('npm', ['run', config.run, '--', '-s'], { cwd: appDir });
 
   return runProtractor(appBuildSpawnInfo.promise, appDir, appRunSpawnInfo, outputFile);
 }


### PR DESCRIPTION
This PR fixes a problem we had with the `upgrade-phonecat-3-final` example where it failed CI due to missing defaults on our `gulp e2e` tasks. 

This caused our tests to report that an example had failed transpilation because we couldn't default to the normal build task.

/cc @wardbell @Foxandxss 