### PR TITLE
docs(dart): upgrade to beta.22

### DIFF
--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: developer_guide_intro
 description: Developer Guide Intro
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: attribute_directives
 description: Attribute directives example
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/component-styles/dart/pubspec.yaml
+++ b/public/docs/_examples/component-styles/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/component-styles/dart/pubspec.yaml
+++ b/public/docs/_examples/component-styles/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: component_styles
 description: Component Styles example
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/dependency-injection/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: dependency_injection
 description: Dependency injection sample
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/displaying-data/dart/pubspec.yaml
+++ b/public/docs/_examples/displaying-data/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/displaying-data/dart/pubspec.yaml
+++ b/public/docs/_examples/displaying-data/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: displaying_data
 description: Displaying Data
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: hero_form
 description: Form example
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: 'hierarchical_di'
 description: Hierarchical dependency injection example
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: lifecycle_hooks
 description: Lifecycle Hooks
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: pipe_examples
 description: Pipes Example
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/quickstart/dart/lib/app_component.dart
+++ b/public/docs/_examples/quickstart/dart/lib/app_component.dart
@@ -5,7 +5,7 @@ import 'package:angular2/core.dart';
 // #docregion metadata
 @Component(
     selector: 'my-app',
-    template: '<h1>My First Angular 2 App</h1>')
+    template: '<h1>My First Angular App</h1>')
 // #enddocregion metadata
 // #docregion class
 class AppComponent {}

--- a/public/docs/_examples/quickstart/dart/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: angular2_quickstart
 description: QuickStart
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/quickstart/dart/pubspec.yaml
+++ b/public/docs/_examples/quickstart/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/server-communication/dart/pubspec.yaml
+++ b/public/docs/_examples/server-communication/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: server_communication
 description: Server Communication
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/server-communication/dart/pubspec.yaml
+++ b/public/docs/_examples/server-communication/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
   http: ^0.11.3+3

--- a/public/docs/_examples/server-communication/dart/web/index.html
+++ b/public/docs/_examples/server-communication/dart/web/index.html
@@ -2,7 +2,7 @@
 <!-- #docregion -->
 <html>
   <head>
-    <title>Angular 2 Http Demo</title>
+    <title>Angular Http Demo</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: structural_directives
 description: Structural directives example
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/structural-directives/dart/web/index.html
+++ b/public/docs/_examples/structural-directives/dart/web/index.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-  <title>Angular 2 Structural Directives</title>
+  <title>Angular Structural Directives</title>
   <link rel="stylesheet" href="styles.css">
   <script defer src="main.dart" type="application/dart"></script>
   <script defer src="packages/browser/dart.js"></script>

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: template_syntax
 description: Template Syntax
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-1/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-1/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: angular2_tour_of_heroes
 description: Tour of Heroes
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/toh-1/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-1/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-1/dart/web/index.html
+++ b/public/docs/_examples/toh-1/dart/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Angular 2 Tour of Heroes</title>
+    <title>Angular Tour of Heroes</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">
 

--- a/public/docs/_examples/toh-2/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-2/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: angular2_tour_of_heroes
 description: Tour of Heroes
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/toh-2/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-2/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-2/dart/web/index.html
+++ b/public/docs/_examples/toh-2/dart/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Angular 2 Tour of Heroes</title>
+    <title>Angular Tour of Heroes</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">
 

--- a/public/docs/_examples/toh-3/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-3/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: angular2_tour_of_heroes
 description: Tour of Heroes
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/toh-3/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-3/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-3/dart/web/index.html
+++ b/public/docs/_examples/toh-3/dart/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Angular 2 Tour of Heroes</title>
+    <title>Angular Tour of Heroes</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">
 

--- a/public/docs/_examples/toh-4/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-4/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: angular2_tour_of_heroes
 description: Tour of Heroes
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/toh-4/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-4/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-4/dart/web/index.html
+++ b/public/docs/_examples/toh-4/dart/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Angular 2 Tour of Heroes</title>
+    <title>Angular Tour of Heroes</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">
 

--- a/public/docs/_examples/toh-5/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-5/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: angular2_tour_of_heroes
 description: Tour of Heroes
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/_examples/toh-5/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-5/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-5/dart/web/index.html
+++ b/public/docs/_examples/toh-5/dart/web/index.html
@@ -7,7 +7,7 @@
     <!-- For testing in WebStorm use: -->
     <!-- base href="/dart/web/" -->
     <!-- #enddocregion base-href -->
-    <title>Angular 2 Tour of Heroes</title>
+    <title>Angular Tour of Heroes</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- #enddocregion head -->

--- a/public/docs/_examples/toh-6/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-6/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.13.0 <2.0.0'
   # #docregion additions
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   # #enddocregion additions
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1

--- a/public/docs/_examples/toh-6/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-6/dart/pubspec.yaml
@@ -4,7 +4,7 @@ name: angular2_tour_of_heroes
 description: Tour of Heroes
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
   # #docregion additions
 dependencies:
   angular2: 2.0.0-beta.22

--- a/public/docs/_examples/toh-6/dart/web/index.html
+++ b/public/docs/_examples/toh-6/dart/web/index.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <base href="/">
-    <title>Angular 2 Tour of Heroes</title>
+    <title>Angular Tour of Heroes</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="stylesheet" href="styles.css">

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: user_input
 description: User input example
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0

--- a/public/docs/dart/latest/_data.json
+++ b/public/docs/dart/latest/_data.json
@@ -4,7 +4,7 @@
     "title": "Angular Docs",
     "subtitle": "Dart",
     "menuTitle": "Docs Home",
-    "banner": "Angular release is <b>beta.21</b>. View the <a href='https://github.com/dart-lang/angular2/blob/master/CHANGELOG.md' target='_blank'>change log</a> to see enhancements, fixes, and breaking changes."
+    "banner": "Angular release is <b>beta.22</b>. View the <a href='https://github.com/dart-lang/angular2/blob/master/CHANGELOG.md' target='_blank'>change log</a> to see enhancements, fixes, and breaking changes."
   },
 
   "quickstart": {

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -79,7 +79,7 @@ block run-app
 block build-app
   .alert.is-important
     :marked
-      If you don't see **My First Angular 2 App**, make sure you've entered all the code correctly,
+      If you don't see **My First Angular App**, make sure you've entered all the code correctly,
       in the [proper folders](#wrap-up),
       and run `pub get`.
 

--- a/public/docs/dart/latest/quickstart.jade
+++ b/public/docs/dart/latest/quickstart.jade
@@ -30,7 +30,7 @@ block package-and-config-files
     packages as dependencies, as well as the `angular2` transformer.
     It can also specify other packages and transformers for the app to use,
     such as [dart_to_js_script_rewriter](https://pub.dartlang.org/packages/dart_to_js_script_rewriter).
-    Angular 2 is still changing, so provide an exact version: **2.0.0-beta.21**.
+    Angular 2 is still changing, so provide an exact version: **2.0.0-beta.22**.
 
     [pubspec]: https://www.dartlang.org/tools/pub/pubspec.html
 

--- a/public/docs/ts/_cache/quickstart.jade
+++ b/public/docs/ts/_cache/quickstart.jade
@@ -290,7 +290,7 @@ p.
     The **template** specifies the component's companion template,
     written in an enhanced form of HTML that tells Angular how to render this component's view.
 
-    >Our template is a single line of HTML announcing "*My First Angular 2 App*".
+    >Our template is a single line of HTML announcing "*My First Angular App*".
 
     >A more advanced template could contain data bindings to component properties
     and might identify other application components which have their own templates.
@@ -556,7 +556,7 @@ block build-app
 :marked
   ## Make some changes
 
-  Try changing the message to "My SECOND Angular 2 app".
+  Try changing the message to "My SECOND Angular app".
 block server-watching
   :marked
     The TypeScript compiler and `lite-server` are watching.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.21
+  angular2: 2.0.0-beta.22
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular2_io
 description: Angular 2 for Dart Website
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.19.0 <2.0.0'
 dependencies:
   angular2: 2.0.0-beta.22
   browser: ^0.10.0


### PR DESCRIPTION
Dart docs and samples updated.

Sample `pubspec.yaml` edits:
- upgraded to beta.22
- SDK 1.19.0 is now the minimal version required.

All test suites pass but two (#2492, #2493) after tweaking a few sample titles (to remove mention of the Angular version):
```
Suites passed:
  public/docs/_examples/architecture/dart
  public/docs/_examples/attribute-directives/dart
  public/docs/_examples/displaying-data/dart
  public/docs/_examples/forms/dart
  public/docs/_examples/lifecycle-hooks/dart
  public/docs/_examples/quickstart/dart
  public/docs/_examples/server-communication/dart
  public/docs/_examples/template-syntax/dart
  public/docs/_examples/toh-1/dart
  public/docs/_examples/toh-2/dart
  public/docs/_examples/toh-3/dart
  public/docs/_examples/toh-4/dart
  public/docs/_examples/toh-5/dart
  public/docs/_examples/toh-6/dart
  public/docs/_examples/user-input/dart
Suites failed:
  public/docs/_examples/dependency-injection/dart
  public/docs/_examples/pipes/dart
```