### PR TITLE
design(style): fix ignored bottom padding on Firefox

### DIFF
--- a/public/resources/css/module/_side-nav.scss
+++ b/public/resources/css/module/_side-nav.scss
@@ -26,7 +26,6 @@ $sidenav-width: 240px;
 #{$sidenav} {
   background: $sidenav-background;
   box-shadow: 3px 0px 6px rgba($black, .24);
-  padding-bottom: 72px;
   width: $sidenav-width;
   bottom: 0px;
   overflow: auto;
@@ -47,7 +46,6 @@ $sidenav-width: 240px;
 
     &.is-visible {
       bottom: 0;
-      padding-bottom: 72px;
 
       #{$sidenav}-links  {
         display: block;
@@ -163,7 +161,7 @@ $sidenav-width: 240px;
 
 #{$sidenav}-links {
   list-style-type: none;
-  margin: 0px;
+  margin: 0 0 72px 0;
   padding: 0px;
 
   // SIDENAV MAIN SECTIONS


### PR DESCRIPTION
The bottom of the sidebar is obstructed by the TS/JS/Dart language picker in Firefox because the bottom padding amount is ignored. This is fixed by moving the padding into the margin of a child element.
