### PR TITLE
add missing word in bootstrapping remark

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -405,7 +405,7 @@ a(href="#toc") Back to top
 
 .s-rule.do
   :marked
-    **Do** include error handling the bootstrapping logic.
+    **Do** include error handling in the bootstrapping logic.
 
 .s-rule.avoid
   :marked


### PR DESCRIPTION
This sentence just misses a word.