### PR TITLE
docs: fixed path typo in tutorial(Routing, HTTP)

### DIFF
--- a/public/docs/_examples/toh-5/ts/app/app.component.ts
+++ b/public/docs/_examples/toh-5/ts/app/app.component.ts
@@ -2,6 +2,7 @@
 import { Component } from '@angular/core';
 
 @Component({
+  moduleId: module.id,
   selector: 'my-app',
   // #docregion template
   template: `

--- a/public/docs/_examples/toh-5/ts/app/app.component.ts
+++ b/public/docs/_examples/toh-5/ts/app/app.component.ts
@@ -14,7 +14,7 @@ import { Component } from '@angular/core';
   `,
   // #enddocregion template
   // #docregion styleUrls
-  styleUrls: ['app/app.component.css'],
+  styleUrls: ['app.component.css'],
   // #enddocregion styleUrls
 })
 export class AppComponent {

--- a/public/docs/_examples/toh-6/ts/app/app.component.ts
+++ b/public/docs/_examples/toh-6/ts/app/app.component.ts
@@ -13,7 +13,7 @@ import { Component }          from '@angular/core';
     </nav>
     <router-outlet></router-outlet>
   `,
-  styleUrls: ['app/app.component.css']
+  styleUrls: ['app.component.css']
 })
 export class AppComponent {
   title = 'Tour of Heroes';

--- a/public/docs/_examples/toh-6/ts/app/app.component.ts
+++ b/public/docs/_examples/toh-6/ts/app/app.component.ts
@@ -3,6 +3,7 @@
 import { Component }          from '@angular/core';
 
 @Component({
+  moduleId: module.id,
   selector: 'my-app',
 
   template: `


### PR DESCRIPTION
The path to `app.component.css` should start from current directory, not `app/`, since the file is already in `app/`