### PR TITLE
docs(ngmodule-faq):fix conceptual issues

### DIFF
--- a/public/docs/ts/latest/cookbook/ngmodule-faq.jade
+++ b/public/docs/ts/latest/cookbook/ngmodule-faq.jade
@@ -1118,7 +1118,7 @@ table
         Declarations are private by default.
         If this module does _not_ export `HeroComponent`, no other module can see it.
 
-        Importing a module does _not_ automatically re-export the imported module's exports.
+        Importing a module does _not_ automatically re-export the imported module's imports.
         Module 'B' can't use `ngIf` just because it imported module `A` which imported `CommonModule`.
         Module 'B' must import `CommonModule` itself.
 


### PR DESCRIPTION
Importing a module does _not_ automatically re-export the imported module's imports rather than exports.
