### PR TITLE
Update styles.css link in Routing tutorial

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -878,7 +878,7 @@ block css-files
 
 +makeExcerpt('styles.css (excerpt)', 'toh')
 
-- var styles_css = 'https://raw.githubusercontent.com/angular/angular.io/master/public/docs/_examples/styles.css'
+- var styles_css = 'https://raw.githubusercontent.com/angular/angular.io/master/public/docs/_examples/_boilerplate/styles.css'
 
 :marked
   Create the file <span ngio-ex>styles.css</span>, if it doesn't exist already.


### PR DESCRIPTION
The current link in the Routing tutorial leads to a 404 error.

This update fixes that to point to the correct GitHub "raw" file link. Nevertheless, in the "Quickstart" the link takes to the normal GitHub page, not the "raw" file.

---

Also, it isn't very clear that for relative "asset" loading (html and css files) it's needed to set the `moduleId` variable in every `@Component` declaration to `module.id`. Otherwise the loading fails. (It took me some time to discover that).

As in:

```ts
@Component({
  moduleId: module.id,
  selector: 'my-dashboard',
  templateUrl: 'dashboard.component.html',
  styleUrls: ['dashboard.component.css']
})
export class DashboardComponent implements OnInit {

...
```

Should I try to add that to the guide to make it more clear in another PR?