### PR TITLE
Fix minor typo in HTTP guide

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt6.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt6.jade
@@ -155,7 +155,7 @@ block get-heroes-details
     *Observables* are a powerful way to manage asynchronous data flows.
     We'll learn about [Observables](#observables) later in this chapter.
 
-    For *now* we get back on familiar ground by immediately by
+    For *now* we get back on familiar ground by immediately
     converting that `Observable` to a `Promise` using the `toPromise` operator.
 
   +makeExcerpt('app/hero.service.ts', 'to-promise', '')


### PR DESCRIPTION
Fix minor typo in HTTP guide

Change:

```
... get back on familiar ground by immediately by converting that Observable ...
```

to:

```
... get back on familiar ground by immediately converting that Observable ...
```