### PR TITLE
docs(testing): Added missing tick()

### DIFF
--- a/public/docs/_examples/testing/ts/app/hero/hero-detail.component.spec.ts
+++ b/public/docs/_examples/testing/ts/app/hero/hero-detail.component.spec.ts
@@ -186,6 +186,8 @@ function heroModuleSetup() {
       // dispatch a DOM event so that Angular learns of input value change.
       page.nameInput.dispatchEvent(newEvent('input'));
 
+      // NgModel updates asynchronously
+      tick();
       // Tell Angular to update the output span through the title pipe
       fixture.detectChanges();
 


### PR DESCRIPTION
Since rc.5, ngModel updates are async (see f444c11), so the change won't be reflected in the model immediately. Waiting a tick solves the issue.