### PR TITLE
docs(testing):fix hash link

### DIFF
--- a/public/docs/ts/latest/guide/testing.jade
+++ b/public/docs/ts/latest/guide/testing.jade
@@ -268,7 +268,7 @@ table(width="100%")
 :marked
   **Put spec files somewhere within the `app/` folder.**
   The `karma.conf.js` tells karma to look for spec files there,
-  for reasons explained [below](#spec-file-location).
+  for reasons explained [below](#q-spec-file-location).
 
   Add the following code to `app/1st.spec.ts`.
 +makeExample('testing/ts/app/1st.spec.ts', '', 'app/1st.spec.ts')(format='.')


### PR DESCRIPTION
Now this link doesn't navigate to anywhere. I think this should be link to the faq section.