### PR TITLE
docs(glossary): fix app module filename

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -44,7 +44,7 @@ block includes
       An Angular module identifies the components, directives, and pipes that the application uses along with the list of external Angular modules that the application needs, such as `FormsModule`.
 
       Every Angular application has an application root module class. By convention, the class is
-      called `AppModule` and resides in a file named `app.component.ts`.
+      called `AppModule` and resides in a file named `app.module.ts`.
 
       For details and examples, see the [Angular Module](!{docsLatest}/guide/ngmodule.html) page.
 


### PR DESCRIPTION
Small error I noticed while going through docs.
As stated throughout angular.io, `AppModule` should be in `app.module.ts`