### PR TITLE
chore: Dart API doc gen cleanup and refactoring

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1381,14 +1381,14 @@ function buildApiDocsForDart() {
   dabInfo.ngDartDocPath = path.join(ngPathFor('dart'), relDartDocApiDir);
   // Exclude API entries for developer/internal libraries. Also exclude entries for
   // the top-level catch all "angular2" library (otherwise every entry appears twice).
-  dabInfo.excludeLibRegExp = new RegExp(/^(?!angular2)|\.testing|_|codegen|^angular2$/);
+  dabInfo.excludeLibRegExp = new RegExp(/^(?!angular2)|testing|_|codegen|^angular2$/);
 
   try {
     checkAngularProjectPath(ngPathFor('dart'));
     var destPath = dabInfo.ngIoDartApiDocPath;
     var sourceDirs = fs.readdirSync(dabInfo.ngDartDocPath)
-      .filter((name) => !name.match(/^index/))
-      .map((name) => path.join(dabInfo.ngDartDocPath, name));
+      .filter(name => !name.match(/^index|^(?!angular2)|testing|codegen/))
+      .map(name => path.join(dabInfo.ngDartDocPath, name));
     log.info(`Building Dart API pages for ${sourceDirs.length} libraries`);
 
     return copyFiles(sourceDirs, [destPath]).then(() => {
@@ -1398,7 +1398,6 @@ function buildApiDocsForDart() {
       const tmpDocsPath = path.resolve(path.join(process.env.HOME, 'tmp/docs.json'));
       if (argv.dumpDocsJson) fs.writeFileSync(tmpDocsPath, JSON.stringify(apiEntries, null, 2));
       dab.createApiDataAndJadeFiles(apiEntries);
-
     }).catch((err) => {
       console.error(err);
     });


### PR DESCRIPTION
NOTE: this commit **only impacts Dart API page generation**.

This code cleanup & refactoring is being done because this new scheme works for both ng1.io and ng2.io whereas the current scheme works only for ng1.io.

- gulp task: don’t copy over internal libraries since they aren't being processed anyways.
- Adjust anchor hrefs rather than use `<base href>` in generated API pages. The net effect is the same.

Fixes ng2.io issue 359
cc @ericjim 