### PR TITLE
Typo fix 'nestled'=>'nested'

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -349,7 +349,7 @@ block redirect-vs-use-as-default
 
 .l-sub-section
   :marked
-    We nestled the two links within `<nav>` tags.
+    We nested the two links within `<nav>` tags.
     They don't do anything yet but they'll be convenient when we style the links a little later in the chapter.
 
 :marked


### PR DESCRIPTION
Technically 'nestled' still makes sense in this context, but is a little too Christmas-y! - I assume you meant 'nested' :P