### PR TITLE
chore(dart): update to ng Dart version 2.0.0

### DIFF
--- a/public/docs/_examples/architecture/dart/pubspec.yaml
+++ b/public/docs/_examples/architecture/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/attribute-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/attribute-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/component-styles/dart/pubspec.yaml
+++ b/public/docs/_examples/component-styles/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/displaying-data/dart/pubspec.yaml
+++ b/public/docs/_examples/displaying-data/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/forms/dart/pubspec.yaml
+++ b/public/docs/_examples/forms/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
+++ b/public/docs/_examples/hierarchical-dependency-injection/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
+++ b/public/docs/_examples/lifecycle-hooks/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/pipes/dart/pubspec.yaml
+++ b/public/docs/_examples/pipes/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/server-communication/dart/pubspec.yaml
+++ b/public/docs/_examples/server-communication/dart/pubspec.yaml
@@ -5,12 +5,12 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
-  http: ^0.11.3+3
+  http: ^0.11.0
   jsonpadding: ^0.1.0
-  stream_transformers: ^0.3.0+3
+  stream_transformers: ^0.3.0
   http_in_memory_web_api: ^0.2.0
 # #docregion transformers
 transformers:

--- a/public/docs/_examples/structural-directives/dart/pubspec.yaml
+++ b/public/docs/_examples/structural-directives/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/template-syntax/dart/pubspec.yaml
+++ b/public/docs/_examples/template-syntax/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-1/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-1/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-2/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-2/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-3/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-3/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-4/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-4/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-5/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-5/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/public/docs/_examples/toh-6/dart/pubspec.yaml
+++ b/public/docs/_examples/toh-6/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.19.0 <2.0.0'
   # #docregion additions
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   # #enddocregion additions
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1

--- a/public/docs/_examples/user-input/dart/pubspec.yaml
+++ b/public/docs/_examples/user-input/dart/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.0.0
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:


### PR DESCRIPTION
This is part 2 of 2. The first round of changes went in via https://github.com/angular/angular.io/commit/e9d40ab2d793817b67be06e87c91d4a02db18773.