### PR TITLE
chore: remove bootstrap package

### DIFF
--- a/public/docs/_examples/cb-form-validation/ts/index.html
+++ b/public/docs/_examples/cb-form-validation/ts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">
 
-    <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="forms.css">
 

--- a/public/docs/_examples/forms/js/index.html
+++ b/public/docs/_examples/forms/js/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- #docregion bootstrap -->
-    <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css">
     <!-- #enddocregion bootstrap -->
     <!-- #docregion styles -->
     <link rel="stylesheet" href="styles.css">

--- a/public/docs/_examples/forms/ts/index.html
+++ b/public/docs/_examples/forms/ts/index.html
@@ -8,7 +8,7 @@
 
      <!-- #docregion bootstrap -->
     <link rel="stylesheet" 
-          href="node_modules/bootstrap/dist/css/bootstrap.min.css">
+          href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css">
      <!-- #enddocregion bootstrap -->
      <!-- #docregion styles -->
     <link rel="stylesheet" href="styles.css">

--- a/public/docs/_examples/homepage-tabs/ts/index.html
+++ b/public/docs/_examples/homepage-tabs/ts/index.html
@@ -5,7 +5,7 @@
     <title>Angular Tabs</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="styles.css">
 
     <!-- Polyfill(s) for older browsers -->

--- a/public/docs/_examples/homepage-todo/ts/index.html
+++ b/public/docs/_examples/homepage-todo/ts/index.html
@@ -5,7 +5,7 @@
     <title>Angular Todos</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="styles.css">
 
     <!-- Polyfill(s) for older browsers -->

--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -28,7 +28,6 @@
     "@angular/upgrade": "~2.1.1",
 
     "angular-in-memory-web-api": "~0.1.13",
-    "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.8",
     "rollup": "^0.36.0",

--- a/public/docs/_examples/quickstart/js/package.1.json
+++ b/public/docs/_examples/quickstart/js/package.1.json
@@ -23,7 +23,6 @@
     "@angular/upgrade": "~2.1.1",
 
     "angular-in-memory-web-api": "~0.1.5",
-    "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.0-beta.12",

--- a/public/docs/_examples/quickstart/ts/package.1.json
+++ b/public/docs/_examples/quickstart/ts/package.1.json
@@ -25,7 +25,6 @@
     "@angular/upgrade": "~2.1.1",
 
     "angular-in-memory-web-api": "~0.1.13",
-    "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.0-beta.12",

--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -91,14 +91,6 @@ var _rxData = [
     from: 'node_modules/jasmine-core/lib/jasmine-core/jasmine.css',
     to:   'https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.4.1/jasmine.css'
   },
-
-
-  {
-    pattern: 'link',
-    from: 'node_modules/bootstrap/dist/css/bootstrap.min.css',
-    // Official source per http://getbootstrap.com/getting-started/
-    to:   'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css'
-  },
   {
     pattern: 'angular_pkg',
   },


### PR DESCRIPTION
The main reason behind this change is to not confuse the end user with "Why do we have bootstrap as a dependency"? "Does Angular depend on bootstrap"?

The idea was to replicate the minimum css needed from bootstrap into those two forms guides but I think it is better for the time being to use a cdn (I saw that phonecat, AKA upgrade guide uses a cdn with bootstrap already) and then change it later.