### PR TITLE
docs(quickstart): quickstart text rev + drop app.module.1

### DIFF
--- a/public/docs/_examples/quickstart/ts/app/app.component.ts
+++ b/public/docs/_examples/quickstart/ts/app/app.component.ts
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
 // #docregion metadata
 @Component({
   selector: 'my-app',
-  template: '<h1>My First Angular App</h1>'
+  template: `<h1>My First Angular App</h1>`
 })
 // #enddocregion metadata
 // #docregion class

--- a/public/docs/_examples/quickstart/ts/app/app.module.1.ts
+++ b/public/docs/_examples/quickstart/ts/app/app.module.1.ts
@@ -1,8 +1,0 @@
-// #docregion
-import { NgModule }      from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-
-@NgModule({
-  imports:      [ BrowserModule ]
-})
-export class AppModule { }

--- a/public/docs/_examples/quickstart/ts/app/app.module.ts
+++ b/public/docs/_examples/quickstart/ts/app/app.module.ts
@@ -2,7 +2,7 @@
 import { NgModule }      from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { AppComponent }   from './app.component';
+import { AppComponent }  from './app.component';
 
 @NgModule({
   imports:      [ BrowserModule ],

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -4,7 +4,7 @@ block includes
   - var _prereq = 'Node.js and npm'
   - var _angular_browser_uri = '@angular/platform-browser-dynamic'
   - var _angular_core_uri = '@angular/core'
-  - var _stepInit = 3 // Step # after NgModule step
+  - var _stepInit = 1 
   - var _quickstartSrcURL='https://github.com/angular/quickstart/blob/master/README.md'
 
 //- TS/Dart shared step counter
@@ -42,10 +42,10 @@ h2 Build this application!
 
 :marked
   - [Prerequisite](#prereq): Install #{_prereq}.
-  - [Step 1](#create-and-configure): Create and configure the project.
-  <span if-docs="ts"><li>[Step 2](#ngmodule): Create your application.</span>
-  - [Step !{step++}](#root-component): Create a component and add it to your application.
-  - [Step !{step++}](#main): Start up your application.
+  - [Step !{step++}](#create-and-configure): Create and configure the project.
+  - [Step !{step++}](#root-component): Create a component.
+  <span if-docs="ts"><li>[Step !{step++}](#ngmodule): Create the application's _NgModule_.</span>
+  - [Step !{step++}](#main): Start with _main_.
   - [Step !{step++}](#index): Define the web page that hosts the application.
   - [Step !{step++}](#build-and-run): Build and run the application.
   - [Step !{step++}](#make-changes): Make some live changes.
@@ -64,7 +64,7 @@ block setup-tooling
     in a terminal window.
 
 .l-main-section
-h1#create-and-configure Step 1: Create and configure the project
+h1#create-and-configure Step !{step++}: Create and configure the project
 
 - var _package_and_config_files = _docsFor == 'dart' ? 'pubspec.yaml' : 'configuration files'
 
@@ -154,9 +154,57 @@ block install-packages
 
 :marked
   You're now ready to write some code!
+
+.l-main-section
+h1#root-component Step !{step++}: Create a component and add it to your application
+:marked
+  Every Angular application has at least one component: the _root component_, named `AppComponent`
+  by convention.
+
+  Components are the basic building blocks of Angular applications. A component controls a portion
+  of the screen &mdash; a *view* &mdash; through its associated template. 
+  This QuickStart has just one component.
+
+a#app-component
+
+p.
+  #[b Create #{_an} #{_appDir} subfolder] off the project root directory
+
+code-example.code-shell.
+  mkdir #{_appDir}  
+p.
+  #[b Create the component file]
+  #[code #[+adjExPath('app/app.component.ts')]] with the following content:
+
++makeExample('app/app.component.ts')
+
+:marked
+  The QuickStart `AppComponent` has the same essential structure as any other Angular component:
+
+    * **An import statement**. Importing gives your component access to
+    Angular's core [`@Component` decorator function](../latest/api/core/index/Component-decorator.html).
+
+    * **A @Component #{_decorator}** that associates *metadata* with the
+        `AppComponent` component class:
+
+        - a *selector* that specifies a simple CSS selector for an HTML element that represents
+          the component.
+        - a *template* that tells Angular how to render the component's view.
+      +ifDocsFor('ts')
+        - *backticks* (`) surrounding the template HTML.
+        Use backticks instead of quote marks (' or ") 
+        so the HTML can span multiple lines as the template grows.
+
+    * **A component class** that controls the appearance and behavior of a view
+    through its template. Here, you only have the root component, `AppComponent`. Since you don't
+    need any application logic in the simple QuickStart example, it's empty.
+
+  You *export* the `AppComponent` class so that you can *import* it into the application module that you're
+  about to create.
+  
 +ifDocsFor('ts')
   .l-main-section
-  h1#ngmodule Step 2: Create your application
+  h1#ngmodule Step !{step++}: Create your application module
   :marked
     You compose Angular applications into closely related blocks of functionality with
     [NgModules](guide/ngmodule.html). Angular itself is split into separate Angular Modules. This
@@ -165,26 +213,18 @@ block install-packages
 
     Every Angular application has at least one module: the _root module_, named `AppModule` here.
 
-    **Create #{_an} #{_appDir} subfolder** off the project root directory:
-
-  code-example.code-shell.
-    mkdir #{_appDir}
-
   :marked
     Create the file `app/app.module.ts` with the following content:
 
-  +makeExample('app/app.module.1.ts')(format='.')
+  +makeExample('app/app.module.ts')(format='.')
 
   :marked
-    This is the entry point to your application.
+    The root `AppModule` is where you tell Angular how the application is structured and loaded.
+    Here you've added the `AppComponent` to the `declarations` and `bootstrap` fields in the `@NgModule` decorator.
 
-    Since the QuickStart application is a web application that runs in a browser, your root module
-    needs to import the
+    Since the QuickStart application is a web application that runs in a browser, you import the
     [`BrowserModule`](../latest/api/platform-browser/index/BrowserModule-class.html)
-    from `@angular/platform-browser` to the `imports` array.
-
-    This is the smallest amount of Angular that is needed for a minimal application to run in the
-    browser.
+    from `@angular/platform-browser` and add it to the root module's `imports` array.
 
     The QuickStart application doesn't do anything else, so you don't need any other modules. In a real
     application, you'd likely import [`FormsModule`](../latest/api/forms/index/FormsModule-class.html) 
@@ -193,50 +233,11 @@ block install-packages
     [Tour of Heroes Tutorial](./tutorial/).
 
 .l-main-section
-h1#root-component Step !{step++}: Create a component and add it to your application
-:marked
-  Every Angular application has at least one component: the _root component_, named `AppComponent`
-  here.
-
-  Components are the basic building blocks of Angular applications. A component controls a portion
-  of the screen&mdash;a *view*&mdash;through its associated template.
-
-a#app-component
-p.
-  #[b Create the component file]
-  #[code #[+adjExPath('app/app.component.ts')]] with the following content:
-
-+makeExample('app/app.component.ts')
-
-:marked
-  The QuickStart application has the same essential structure as any other Angular component:
-
-    * **An import statement**. Importing gives your component access to
-    Angular's core [`@Component` decorator function](../latest/api/core/index/Component-decorator.html).
-    * **A @Component #{_decorator}** that associates *metadata* with the
-        `AppComponent` component class:
-
-        - a *selector* that specifies a simple CSS selector for an HTML element that represents
-          the component.
-        - a *template* that tells Angular how to render the component's view.
-    * **A component class** that controls the appearance and behavior of a view
-    through its template. Here, you only have the root component, `AppComponent`. Since you don't
-    need any application logic in the simple QuickStart example, it's empty.
-
-  You *export* the `AppComponent` class so that you can *import* it into the application that you
-   just created.
-
-  Edit the file `app/app.module.ts` to import your new `AppComponent` and add it in the
-  declarations and bootstrap fields in the `NgModule` decorator:
-
-+makeExample('app/app.module.ts', null, title='app/app.module.ts')
-
-.l-main-section
-h1#main Step !{step++}: Start up your application
+h1#main Step !{step++}: Start with #[i main]
 
 block create-main
   :marked
-    Now you need to tell Angular to start up your application.
+    You need an entry point that tells Angular how to start your application.
 
     Create the file `app/main.ts` with the following content:
 
@@ -246,10 +247,10 @@ block create-main
 - var _pBD_bootstrapModule = _docsFor == 'dart' ? _bootstrapModule : 'platformBrowserDynamic().bootstrapModule'
 
 :marked
-  This code initializes the platform that your application runs in, then uses the platform to
+  This code initializes the platform that your application runs in, then uses that platform to
   bootstrap your `!{_AppModuleVsAppComp}`.
 
-  ### Why create separate *<span ngio-ex>main.ts</span>*<span if-docs="ts">, app module</span> and app component files?
+  ### Why create separate main<span if-docs="ts">, app module</span> and app component files?
 
   App bootstrapping is a separate concern from<span if-docs="ts"> creating a module or</span>
   presenting a view. Testing the component is much easier if it doesn't also try to run the entire application.


### PR DESCRIPTION
The main text change is to create the component _before_ the ngModule so that the reader isn't going ngModule -> component -> ngModule to add the declarations. This refactor also eliminates need for `app.module.1.ts`
