### PR TITLE
clicking on Books & Training sends user to Education

### DIFF
--- a/public/_includes/_footer.jade
+++ b/public/_includes/_footer.jade
@@ -20,7 +20,7 @@ else
         // TODO: (ericjim) make a libraries page to showcase all angular libraries
         //li <a href="/libraries.html">Libraries</a>
         li <a href="/about/">About</a>
-        li <a href="/resources/">Books & Training</a>
+        li <a href="/resources/#Education">Books & Training</a>
         li <a href="/resources/">Tools & Libraries</a>
         li <a href="/resources/">Community</a>
         li <a href="/presskit.html">Press Kit</a>


### PR DESCRIPTION
When user clicks in Books & Training item in footer the website should take them to Education section (anchor) in the middle of the page, not to the top where Development section is.