### PR TITLE
chore(gulpfile): make ng2 build the default; add ng-build-and-copy task

### DIFF
--- a/public/resources/css/_angular.scss
+++ b/public/resources/css/_angular.scss
@@ -5,4 +5,6 @@
  * too late because of the Jade pre-rendering.
  */
 
-.ng-cloak, [ng-cloak] {}
+.ng-cloak, [ng-cloak] {
+  display: none !important;
+}

--- a/public/resources/css/base/_type.scss
+++ b/public/resources/css/base/_type.scss
@@ -9,7 +9,9 @@ body {
   font-size: 14px;
   color: $blue-grey-600;
 
-  &.ng-cloak {}
+  &.ng-cloak {
+    display: none;
+  }
 }
 
 


### PR DESCRIPTION
Also restore `ng-cloak` definitions because we are resorting to stripping out `ng-cloak` where needed.