### PR TITLE
[ng2] add support menu toggling; exclude all A1 & md1 scripts

### DIFF
--- a/public/_includes/_main-nav.jade
+++ b/public/_includes/_main-nav.jade
@@ -4,7 +4,7 @@
 nav(class="main-nav l-pinned-top l-layer-5", scroll-y-offset-element)
   h1 <a href="/" md-button>Angular <sup>by Google</sup></a>
 
-  button(class="main-nav-button main-nav-mobile-trigger l-right" aria-label="View Menu" ng-click="appCtrl.toggleMainMenu($event)" md-button) Site Menu <span class="icon icon-arrow-drop-down"></span>
+  button(class="main-nav-button main-nav-mobile-trigger l-right" aria-label="View Menu" onclick="NgIoUtil.showHideMenu(this.nextSibling)" md-button) Site Menu <span class="icon icon-arrow-drop-down"></span>
 
   ul(ng-class="appCtrl.showMainNav ? 'is-visible' : ''")
     li.l-left <a class="main-nav-button" href="/features.html" md-button>Features</a>

--- a/public/_includes/_main-nav.jade
+++ b/public/_includes/_main-nav.jade
@@ -4,7 +4,7 @@
 nav(class="main-nav l-pinned-top l-layer-5", scroll-y-offset-element)
   h1 <a href="/" md-button>Angular <sup>by Google</sup></a>
 
-  button(class="main-nav-button main-nav-mobile-trigger l-right" aria-label="View Menu" onclick="NgIoUtil.showHideMenu(this.nextSibling)" md-button) Site Menu <span class="icon icon-arrow-drop-down"></span>
+  button(class="main-nav-button main-nav-mobile-trigger l-right" aria-label="View Menu" onclick="NgIoUtil.toggleMenu(this.nextSibling)" md-button) Site Menu <span class="icon icon-arrow-drop-down"></span>
 
   ul(ng-class="appCtrl.showMainNav ? 'is-visible' : ''")
     li.l-left <a class="main-nav-button" href="/features.html" md-button>Features</a>

--- a/public/_includes/_scripts-include.jade
+++ b/public/_includes/_scripts-include.jade
@@ -20,18 +20,17 @@ if !ng2
 if !ng2
   script(src="https://cdn.firebase.com/libs/angularfire/1.2.0/angularfire.min.js")
 
+script(src="/resources/js/util.js")
 
 <!-- Angular.io Site JS -->
-script(src="/resources/js/site.js")
-script(src="/resources/js/util.js")
-script(src="/resources/js/controllers/app-controller.js")
 if !ng2
+  script(src="/resources/js/site.js")
+  script(src="/resources/js/controllers/app-controller.js")
   script(src="/resources/js/controllers/resources-controller.js")
   script(src="/resources/js/directives/cheatsheet.js")
   script(src="/resources/js/directives/api-list.js")
   script(src="/resources/js/directives/bio.js")
-script(src="/resources/js/directives/bold.js")
-if !ng2
+  script(src="/resources/js/directives/bold.js")
   script(src="/resources/js/directives/announcement-bar.js")
   script(src="/resources/js/directives/code.js")
   script(src="/resources/js/directives/copy.js")
@@ -39,9 +38,9 @@ if !ng2
   script(src="/resources/js/directives/code-pane.js")
   script(src="/resources/js/directives/code-example.js")
   script(src="/resources/js/directives/live-example.js")
-script(src="/resources/js/directives/if-docs.js")
-script(src="/resources/js/directives/ngio-ex-path.js")
-script(src="/resources/js/directives/scroll-y-offset-element.js")
+  script(src="/resources/js/directives/if-docs.js")
+  script(src="/resources/js/directives/ngio-ex-path.js")
+  script(src="/resources/js/directives/scroll-y-offset-element.js")
 
 if ng2
   app-root

--- a/public/_includes/_scripts-include.jade
+++ b/public/_includes/_scripts-include.jade
@@ -5,26 +5,23 @@ script(src="/resources/js/vendor/lang-dart.js")
 script(src="/resources/js/vendor/lodash.js")
 script(src="/resources/js/vendor/clipboard.min.js")
 
-
-<!-- Angular Material Dependencies -->
-script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.min.js")
-script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-animate.min.js")
-script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-aria.min.js")
-script(src="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0/angular-material.min.js")
-
-<!-- Firebase -->
 if !ng2
+  <!-- Angular Material Dependencies -->
+  script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.min.js")
+  script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-animate.min.js")
+  script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-aria.min.js")
+  script(src="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0/angular-material.min.js")
+
+  <!-- Firebase -->
   script(src="https://cdn.firebase.com/js/client/2.2.4/firebase.js")
 
-<!-- AngularFire -->
-if !ng2
+  <!-- AngularFire -->
   script(src="https://cdn.firebase.com/libs/angularfire/1.2.0/angularfire.min.js")
 
-script(src="/resources/js/util.js")
 
-<!-- Angular.io Site JS -->
-if !ng2
+  <!-- Angular.io Site JS -->
   script(src="/resources/js/site.js")
+  script(src="/resources/js/util.js")
   script(src="/resources/js/controllers/app-controller.js")
   script(src="/resources/js/controllers/resources-controller.js")
   script(src="/resources/js/directives/cheatsheet.js")
@@ -41,9 +38,9 @@ if !ng2
   script(src="/resources/js/directives/if-docs.js")
   script(src="/resources/js/directives/ngio-ex-path.js")
   script(src="/resources/js/directives/scroll-y-offset-element.js")
-
-if ng2
+else
   app-root
+    script(src="/resources/js/util.js")
     script(src="/inline.js")
     script(src="/styles.bundle.js")
     script(src="/main.bundle.js")

--- a/public/_includes/_version-dropdown.jade
+++ b/public/_includes/_version-dropdown.jade
@@ -64,8 +64,8 @@ if language == 'dart'
 
 <!-- DROPDOWN BUTTON -->
 nav.dropdown
-  button(aria-label="Select a version of Angular" md-button class="dropdown-button" ng-click="appCtrl.toggleVersionMenu($event)") #{title}  <span class="icon icon-arrow-drop-down"></span>
-  div(class="overlay ng-hide" ng-click="appCtrl.toggleVersionMenu($event)" ng-show="appCtrl.showMenu")
+  button(aria-label="Select a version of Angular" md-button class="dropdown-button" onclick="NgIoUtil.showHideMenu(this.nextSibling.nextSibling.nextSibling)") #{title}  <span class="icon icon-arrow-drop-down"></span>
+  div(class="overlay ng-hide" onclick="NgIoUtil.showHideMenu(this.nextSibling)" ng-show="appCtrl.showMenu")
 
   <!-- DROPDOWN MENU -->
   ul(class="dropdown-menu" ng-class="appCtrl.showMenu ? 'is-visible' : ''")

--- a/public/_includes/_version-dropdown.jade
+++ b/public/_includes/_version-dropdown.jade
@@ -64,9 +64,8 @@ if language == 'dart'
 
 <!-- DROPDOWN BUTTON -->
 nav.dropdown
-  button(aria-label="Select a version of Angular" md-button class="dropdown-button" onclick="NgIoUtil.toggleMenu('versionMenu')") #{title}  <span class="icon icon-arrow-drop-down"></span>
-  div(class="overlay ng-hide" onclick="NgIoUtil.toggleMenu('versionMenu')" ng-show="appCtrl.showMenu")
-
+  button(aria-label="Select a version of Angular" md-button class="dropdown-button" onclick="NgIoUtil.toggleMenu('versionMenu');NgIoUtil.toggleMenu('versMenuBackdrop')") #{title}  <span class="icon icon-arrow-drop-down"></span>
+  div#versMenuBackdrop(class="overlay is-hidden" onclick="NgIoUtil.toggleMenu('versionMenu');NgIoUtil.toggleMenu('versMenuBackdrop')")
   <!-- DROPDOWN MENU -->
   ul#versionMenu(class="dropdown-menu" ng-class="appCtrl.showMenu ? 'is-visible' : ''")
     mixin tree(public.docs.ts, "/docs/ts", "Angular for TypeScript")

--- a/public/_includes/_version-dropdown.jade
+++ b/public/_includes/_version-dropdown.jade
@@ -64,11 +64,11 @@ if language == 'dart'
 
 <!-- DROPDOWN BUTTON -->
 nav.dropdown
-  button(aria-label="Select a version of Angular" md-button class="dropdown-button" onclick="NgIoUtil.showHideMenu(this.nextSibling.nextSibling.nextSibling)") #{title}  <span class="icon icon-arrow-drop-down"></span>
-  div(class="overlay ng-hide" onclick="NgIoUtil.showHideMenu(this.nextSibling)" ng-show="appCtrl.showMenu")
+  button(aria-label="Select a version of Angular" md-button class="dropdown-button" onclick="NgIoUtil.toggleMenu('versionMenu')") #{title}  <span class="icon icon-arrow-drop-down"></span>
+  div(class="overlay ng-hide" onclick="NgIoUtil.toggleMenu('versionMenu')" ng-show="appCtrl.showMenu")
 
   <!-- DROPDOWN MENU -->
-  ul(class="dropdown-menu" ng-class="appCtrl.showMenu ? 'is-visible' : ''")
+  ul#versionMenu(class="dropdown-menu" ng-class="appCtrl.showMenu ? 'is-visible' : ''")
     mixin tree(public.docs.ts, "/docs/ts", "Angular for TypeScript")
     mixin tree(public.docs.js, "/docs/js", "Angular for JavaScript")
     //- Disable cross-language link for API entry pages (but keep for top API search page):

--- a/public/docs/_includes/_side-nav.jade
+++ b/public/docs/_includes/_side-nav.jade
@@ -60,13 +60,13 @@
 - if (language !== 'ts' || language !== 'js' || language !== 'dart') { language = 'ts'; }
 
 
-nav(class="sidenav l-pinned-left l-layer-4 l-offset-nav")
+nav#sideNav(class="sidenav l-pinned-left l-layer-4 l-offset-nav")
   // SEARCH BAR
   header.sidenav-search.st-input-wrapper
     .st-input-inner
       label(for="search-io" class="is-hidden") Search Docs
       input(type="text" class="st-default-search-input" placeholder="SEARCH DOCS...")
-    button(class="mobile-trigger button" aria-label="View Docs Menu" onclick="NgIoUtil.showHideMenu(this.parentNode.parentNode)" md-button) Docs <span class="icon icon-arrow-drop-down"></span>
+    button(class="mobile-trigger button" aria-label="View Docs Menu" onclick="NgIoUtil.toggleMenu('sideNav')" md-button) Docs <span class="icon icon-arrow-drop-down"></span>
 
   ul(class="sidenav-links")
     li.sidenav-section.no-border

--- a/public/docs/_includes/_side-nav.jade
+++ b/public/docs/_includes/_side-nav.jade
@@ -60,13 +60,13 @@
 - if (language !== 'ts' || language !== 'js' || language !== 'dart') { language = 'ts'; }
 
 
-nav(class="sidenav l-pinned-left l-layer-4 l-offset-nav"  ng-class="appCtrl.showDocsNav ? 'is-visible' : ''")
+nav(class="sidenav l-pinned-left l-layer-4 l-offset-nav")
   // SEARCH BAR
   header.sidenav-search.st-input-wrapper
     .st-input-inner
       label(for="search-io" class="is-hidden") Search Docs
       input(type="text" class="st-default-search-input" placeholder="SEARCH DOCS...")
-    button(class="mobile-trigger button" aria-label="View Docs Menu" ng-click="appCtrl.toggleDocsMenu($event)" md-button) Docs <span class="icon icon-arrow-drop-down"></span>
+    button(class="mobile-trigger button" aria-label="View Docs Menu" onclick="NgIoUtil.showHideMenu(this.parentNode.parentNode)" md-button) Docs <span class="icon icon-arrow-drop-down"></span>
 
   ul(class="sidenav-links")
     li.sidenav-section.no-border

--- a/public/resources/js/util.js
+++ b/public/resources/js/util.js
@@ -83,10 +83,9 @@ var NgIoUtil = (function () {
         return NgIoUtil._exampleName;
     };
 
-    NgIoUtil.showHideMenu = function (menu) {
-      if (!menu) return;
-      console.log('menu tag: ' + menu.tagName);
-      if (menu.className.indexOf('is-visible') > -1) {
+    NgIoUtil.toggleMenu = function (menu) {
+      if (typeof menu === 'string') menu = document.getElementById(menu);
+      if (menu.classList.contains('is-visible')) {
         menu.classList.remove('is-visible');
       } else {
         menu.classList.add('is-visible');

--- a/public/resources/js/util.js
+++ b/public/resources/js/util.js
@@ -83,5 +83,15 @@ var NgIoUtil = (function () {
         return NgIoUtil._exampleName;
     };
 
+    NgIoUtil.showHideMenu = function (menu) {
+      if (!menu) return;
+      console.log('menu tag: ' + menu.tagName);
+      if (menu.className.indexOf('is-visible') > -1) {
+        menu.classList.remove('is-visible');
+      } else {
+        menu.classList.add('is-visible');
+      }
+    }
+
     return NgIoUtil;
 } ());


### PR DESCRIPTION
Support menu toggling w/o using A1 controller. Menus affected:
- Main menu
- Sidenav
- Language delection menu.

With this commit, we are able to exclude all A1 and MD1 scripts.

Fixes #2703.