### PR TITLE
chore: add firebase project name to prompt

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,6 +1,8 @@
 {
   "projects": {
     "live": "angular-io",
-    "ngdocsdev": "ngdocsdev"
+    "ngdocsdev": "ngdocsdev",
+    "kw-dev": "kw-angular-io",
+    "dev": "angular-io-dev"
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -1,75 +1,76 @@
 {
-  "firebase": "angular-io",
-  "public": "www",
-  "rewrites": [
-    {
-    "source": "/docs/dart/latest/testing",
-    "destination":"/docs/dart/latest/guide/testing.html"
-    },
-    {
-      "source": "/docs/dart/latest/tutorial",
-      "destination": "/docs/dart/latest/index.html"
-    },
-    {
-      "source": "/docs/js/latest/testing",
-      "destination": "/docs/js/latest/guide/testing.html"
-    },
-    {
-      "source": "/docs/js/latest/tutorial",
-      "destination": "/docs/js/latest/index.html"
-    },
-    {
-      "source": "/docs/ts/latest/guide/setup.html",
-      "destination": "/docs/ts/latest/index.html"
-    },
-    {
-      "source": "/docs/ts/latest/testing",
-      "destination": "/docs/ts/latest/guide/testing.html"
-    },
-    {
-      "source": "/cheatsheet",
-      "destination": "/docs/ts/latest/guide/cheatsheet.html"
-    },
-    {
-      "source": "/cheatsheet.json",
-      "destination": "/docs/ts/latest/guide/cheatsheet.json"
-    },
-    {
-      "source": "/AngularCheatSheet_Letter.pdf",
-      "destination": "/docs/ts/latest/guide/AngularCheatSheet_Letter.pdf"
-    },
-    {
-      "source": "/AngularCheatSheet_Poster.pdf",
-      "destination": "/docs/ts/latest/guide/AngularCheatSheet_Poster.pdf"
-    },
-    {
-      "source": "/cardboard",
-      "destination": "/cardboard/index.html"
-    },
-    {
-      "source": "/license",
-      "destination": "/license.txt"
-    },
-    {
-      "source": "/events",
-      "destination": "/events.html"
-    },
-    {
-      "source": "/survey",
-      "destination": "/survey.html"
-    },
-    {
-      "source": "/dart",
-      "destination": "/docs/dart/latest/index.html"
-    },
-    {
-      "source": "/styleguide",
-      "destination": "/docs/ts/latest/guide/style-guide.html"
-    }
-  ],
-  "ignore": [
-    "firebase.json",
-    "**/.*",
-    "**/node_modules/**"
-  ]
+  "hosting": {
+    "public": "www",
+    "rewrites": [
+      {
+        "source": "/docs/dart/latest/testing",
+        "destination": "/docs/dart/latest/guide/testing.html"
+      },
+      {
+        "source": "/docs/dart/latest/tutorial",
+        "destination": "/docs/dart/latest/index.html"
+      },
+      {
+        "source": "/docs/js/latest/testing",
+        "destination": "/docs/js/latest/guide/testing.html"
+      },
+      {
+        "source": "/docs/js/latest/tutorial",
+        "destination": "/docs/js/latest/index.html"
+      },
+      {
+        "source": "/docs/ts/latest/guide/setup.html",
+        "destination": "/docs/ts/latest/index.html"
+      },
+      {
+        "source": "/docs/ts/latest/testing",
+        "destination": "/docs/ts/latest/guide/testing.html"
+      },
+      {
+        "source": "/cheatsheet",
+        "destination": "/docs/ts/latest/guide/cheatsheet.html"
+      },
+      {
+        "source": "/cheatsheet.json",
+        "destination": "/docs/ts/latest/guide/cheatsheet.json"
+      },
+      {
+        "source": "/AngularCheatSheet_Letter.pdf",
+        "destination": "/docs/ts/latest/guide/AngularCheatSheet_Letter.pdf"
+      },
+      {
+        "source": "/AngularCheatSheet_Poster.pdf",
+        "destination": "/docs/ts/latest/guide/AngularCheatSheet_Poster.pdf"
+      },
+      {
+        "source": "/cardboard",
+        "destination": "/cardboard/index.html"
+      },
+      {
+        "source": "/license",
+        "destination": "/license.txt"
+      },
+      {
+        "source": "/events",
+        "destination": "/events.html"
+      },
+      {
+        "source": "/survey",
+        "destination": "/survey.html"
+      },
+      {
+        "source": "/dart",
+        "destination": "/docs/dart/latest/index.html"
+      },
+      {
+        "source": "/styleguide",
+        "destination": "/docs/ts/latest/guide/style-guide.html"
+      }
+    ],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
 }


### PR DESCRIPTION
Remove project name from `firebase.json`, since that is deprecated.

The `check-deploy` gulp task now checks that an active project is defined at the start of `check-deploy`.

To set the active project use: `firebase use <project-or-alias-name>`.

Fixes #2576

cc @kwalrath 