### PR TITLE
Fix link to Filter/Pipes

### DIFF
--- a/public/docs/ts/latest/cookbook/a1-a2-quick-reference.jade
+++ b/public/docs/ts/latest/cookbook/a1-a2-quick-reference.jade
@@ -77,7 +77,7 @@ table(width="100%")
         Many (but not all) of the built-in filters from Angular&nbsp;1 are
         built-in pipes in Angular&nbsp;2.
 
-        For more information, see the heading [Filters/pipes](#Pipes) below.
+        For more information, see the heading [Filters/pipes](#filters-pipes) below.
   tr(style=top)
     td
       :marked


### PR DESCRIPTION
Link in "ANGULAR 1 TO 2 QUICK REFERENCE" was incorrect. Fixed from #Pipes to #filters-pipes