### PR TITLE
chore(deploy): don't name project in firebase deploy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -754,7 +754,7 @@ gulp.task('check-deploy', ['firebase-use-proj-check', 'build-docs'], () => {
   }).then(function(shouldDeploy) {
     if (shouldDeploy) {
       gutil.log('deploying...');
-      return execPromise(`firebase deploy -p ${WWW}`);
+      return execPromise('firebase deploy');
     } else {
       return ['Not deploying'];
     }


### PR DESCRIPTION
Naming the project would sometimes cause gulp to report `An unexpected error has occurred` with exit code 2.