### PR TITLE
docs(forms/dart): remove mention of FORM_DIRECTIVES

### DIFF
--- a/public/docs/dart/latest/guide/forms.jade
+++ b/public/docs/dart/latest/guide/forms.jade
@@ -96,12 +96,6 @@ figure.image-display
 
 +makeTabs('forms/dart/pubspec.yaml, forms/dart/web/index.html, forms/dart/web/main.dart', ',initial,', 'pubspec.yaml, web/index.html, web/main.dart')
 
-.l-sub-section
-  :marked
-    Note the `platform_directives` entry in `pubspec.yaml`.
-    It imports core directives and, more importantly for this chapter,
-    **form directives**.
-
 :marked
   So that the code can run,
   let's create a stub for the `<hero-form>` component.


### PR DESCRIPTION
Fixes #2752