### PR TITLE
chore: ignore debug.log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ public/docs/xref-*.*
 _zip-output
 www*
 npm-debug*.log*
+**/debug.log
 *.plnkr.html
 plnkr.html
 *.eplnkr.html


### PR DESCRIPTION
This file is generated when running `gulp e2e` and often enough committed by mistake.

/cc @foxandxss