### PR TITLE
docs(ngmodule): fix plunkers

### DIFF
--- a/public/docs/_examples/ngmodule/ts/index.0.html
+++ b/public/docs/_examples/ngmodule/ts/index.0.html
@@ -13,7 +13,7 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-
+    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.0').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/ngmodule/ts/index.1.html
+++ b/public/docs/_examples/ngmodule/ts/index.1.html
@@ -13,7 +13,7 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-
+    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.1').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/ngmodule/ts/index.1b.html
+++ b/public/docs/_examples/ngmodule/ts/index.1b.html
@@ -13,7 +13,7 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-
+    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.1b').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/ngmodule/ts/index.2.html
+++ b/public/docs/_examples/ngmodule/ts/index.2.html
@@ -13,7 +13,7 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-
+    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.2').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/ngmodule/ts/index.3.html
+++ b/public/docs/_examples/ngmodule/ts/index.3.html
@@ -13,7 +13,7 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-
+    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.3').catch(function(err){ console.error(err); });

--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -28,7 +28,7 @@ var _rxRules = {
   //   System.import('app').catch(function(err){ console.error(err); });
   // </script>
   system_strip_import_app: {
-   from: /<script>[^]?\s*System.import\('app[^]*\/script>/,
+   from: /<script>[^]?\s*System.import\('app'\)[^]*\/script>/,
    to:   ''
   },
   system_extra_main: {


### PR DESCRIPTION
This will hide the `System.import('app')` only for custom ones.