### PR TITLE
docs(cookbook-aot-compiler): improve Ahead-of-Time compilation cookbook

### DIFF
--- a/public/docs/ts/latest/cookbook/aot-compiler.jade
+++ b/public/docs/ts/latest/cookbook/aot-compiler.jade
@@ -341,7 +341,7 @@ a#toh
 
   Fortunately, the source code can be compiled either way without change _if_ you account for a few key differences.
 
-  ***Index.html***
+  ***index.html***
 
   The JiT and AoT apps are setup and launched so differently that they require their own `index.html` files. 
   Here they are for comparison:
@@ -363,6 +363,26 @@ a#toh
 
   The AoT version loads the entire application in a single script, `aot/dist/build.js`.
   It does not need `SystemJS` or the `reflect-metadata` shim; those scripts are absent from its `index.html`
+  
+  ***main.ts***
+  
+  The JiT and AoT apps are also bootstraped differently that they require their own `main.ts` files. 
+  Here they are for comparison:
+
++makeTabs(
+  `toh-6/ts/app/main-aot.ts,
+   toh-6/ts/app/main.ts`,
+  null,
+  `app/main-aot.ts (AoT),
+   app/main.ts (JiT)`
+)
+
+:marked
+  They can and should exist in the same folder.
+  
+  The `app/main-aot.ts` file is used by the AoT config scripts (`tsconfig-aot.json` and `rollup-config.js`).
+  
+  Key differences are discussed in the [Bootstrap](#bootstrap) section, above.
 
   *Component-relative Template URLS*
 
@@ -395,6 +415,13 @@ a#toh
   `tsconfig-aot.json (AoT),
    tsconfig.json (JiT)`
 )
+
+.l-sub-section
+  :marked
+    _Note_ that the specific file structure of this project needs `typeRoots` to include `../../node_modules/@types/`, 
+    whereas in a typical setting it should include `node_modules/@types/` instead.
+    
+    Make sure to edit accordingly to your project needs.
 
 :marked
   ### Tree Shaking


### PR DESCRIPTION
Add additions/clarifications:
* Add `main-aot.ts` and `main.ts` comparison in the key differences.
* Add a sub note below `tsconfig-aot.json` and `tsconfig.json` comparison to highlight and explain
   the usage of `../../node_modules/@types/` instead of `node_modules/@types/`.