### PR TITLE
Fix display of heritage

### DIFF
--- a/tools/api-builder/angular.io-package/processors/matchUpDirectiveDecorators.js
+++ b/tools/api-builder/angular.io-package/processors/matchUpDirectiveDecorators.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
  * @description
  *
  */
-module.exports = function matchUpDirectiveDecoratorsProcessor(aliasMap) {
+module.exports = function matchUpDirectiveDecoratorsProcessor() {
 
   return {
     $runAfter: ['ids-computed', 'paths-computed'],
@@ -20,7 +20,7 @@ module.exports = function matchUpDirectiveDecoratorsProcessor(aliasMap) {
         if (doc.docType === 'directive') {
           doc.selector = doc.directiveOptions.selector;
 
-          for(decoratorName in decoratorMappings) {
+          for(var decoratorName in decoratorMappings) {
             var propertyName = decoratorMappings[decoratorName];
             doc[propertyName] = getDecoratorValues(doc.directiveOptions[propertyName], decoratorName, doc.members);
           }
@@ -31,7 +31,7 @@ module.exports = function matchUpDirectiveDecoratorsProcessor(aliasMap) {
 };
 
 function getDecoratorValues(classDecoratorValues, memberDecoratorName, members) {
-  var optionMap = {};
+
   var decoratorValues = {};
 
   // Parse the class decorator

--- a/tools/api-builder/angular.io-package/templates/class.template.html
+++ b/tools/api-builder/angular.io-package/templates/class.template.html
@@ -17,7 +17,7 @@ div(layout="row" layout-xs="column" class="ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Class Overview
   div(flex="80" flex-xs="100")
-    code(class="no-bg api-doc-code openParens") class {$ doc.name $} {
+    code(class="no-bg api-doc-code openParens") class {$ doc.name $}{$ doc.heritage $} {
 
     {% if doc.statics.length %}
     div(layout="column")

--- a/tools/api-builder/angular.io-package/templates/interface.template.html
+++ b/tools/api-builder/angular.io-package/templates/interface.template.html
@@ -17,7 +17,7 @@ div(layout="row" layout-xs="column" class="ng-cloak")
   div(flex="20" flex-xs="100")
     h2(class="h2-api-docs") Interface Overview
   div(flex="80" flex-xs="100")
-    code(class="no-bg api-doc-code openParens") interface {$ doc.name $} {
+    code(class="no-bg api-doc-code openParens") interface {$ doc.name $}{$ doc.heritage $} {
 
     {% if doc.members.length %}
     div(layout="column")


### PR DESCRIPTION
This is a first step to fixing the problem that classes like `Response` in `@angular/http` does not show that it derives from `Body`.  A heritage string is already extracted by the `typescript` dgeni-package. So this PR includes this information in the relevant templates for classes and interface.

But this is probably not enough since the heritage processing does not:
a) show type parameters for generic super types (e.g. `RouterState` extends `Tree<ActivatedRoute>`).
b) these super types are not explicitly exported from any modules and so there are no API docs pages for them.

I'll put together a fix for a). But I am not sure what the best solution for b) is...

Closes #2791