### PR TITLE
docs: guide/index misc Jade fixes

### DIFF
--- a/public/docs/ts/latest/guide/index.jade
+++ b/public/docs/ts/latest/guide/index.jade
@@ -1,16 +1,14 @@
 block includes
   include ../_util-fns
 
-- var langName = current.path[1] == 'ts' ? 'TypeScript' : 'JavaScript'
 figure
-  img(src="/resources/images/devguide/intro/people.png" alt="Us" align="left" style="width:200px; margin-left:-40px;margin-right:10px" )
+  img(src="/resources/images/devguide/intro/people.png" alt="Us" align="left" style="width:200px; margin-left:-40px;margin-right:10px")
+
 :marked
   This is a practical guide to Angular for experienced programmers who
-  are building client applications in HTML and #{langName}.
+  are building client applications in HTML and #{_Lang}.
+  <br style="clear:left;">
 
-  <br clear="all">
-
-<a id="learning-path"></a>
 :marked
   # Organization
 


### PR DESCRIPTION
- Eliminate use of deprecated `clear=“all”` in `<br>`.
- No need for local `langName`; use global `_Lang` var instead.
- Remove duplicate id `learning-path`.

cc @ericjim 