### PR TITLE
chore(util.js): getExampleName - support optional .html suffix

### DIFF
--- a/public/resources/js/util.js
+++ b/public/resources/js/util.js
@@ -77,7 +77,7 @@ var NgIoUtil = (function () {
             // TODO: use $location.path() instead(?). It seems to be empty.
             var loc = $location.absUrl();
             // E.g., https://example.com/docs/dart/latest/guide/displaying-data.html
-            var matches = loc.match(/.*\/([\w\.\-]+)\.html/);
+            var matches = loc.match(/.*\/([\w\-]+)(\.html)?$/);
             if (matches) NgIoUtil.setExampleName(matches[1]); // cache name
         }
         return NgIoUtil._exampleName;


### PR DESCRIPTION
The function `getExampleName` is used, e.g., by the `<live-example>` directive. This change helps support page URLs with and with out `.html` suffixes.