### PR TITLE
docs(toh): avoid dup header title

### DIFF
--- a/public/docs/dart/latest/tutorial/toh-pt1.jade
+++ b/public/docs/dart/latest/tutorial/toh-pt1.jade
@@ -1,8 +1,6 @@
 include ../_util-fns
 
 :marked
-  # Once Upon a Time
-
   Every story starts somewhere. Our story starts where the [QuickStart](../quickstart.html) ends.
 
 :marked

--- a/public/docs/dart/latest/tutorial/toh-pt2.jade
+++ b/public/docs/dart/latest/tutorial/toh-pt2.jade
@@ -1,7 +1,6 @@
 include ../_util-fns
 
 :marked
-  # It Takes Many Heroes
   Our story needs more heroes.
   We’ll expand our Tour of Heroes app to display a list of heroes,
   allow the user to select a hero, and display the hero’s details.

--- a/public/docs/dart/latest/tutorial/toh-pt4.jade
+++ b/public/docs/dart/latest/tutorial/toh-pt4.jade
@@ -1,7 +1,6 @@
 include ../_util-fns
 
 :marked
-  # Services
   The Tour of Heroes is evolving and we anticipate adding more components in the near future.
 
   Multiple components will need access to hero data and we don't want to copy and

--- a/public/docs/ts/_cache/tutorial/toh-pt5.jade
+++ b/public/docs/ts/_cache/tutorial/toh-pt5.jade
@@ -9,8 +9,6 @@ block includes
   - var _redirectTo = 'redirectTo'
 
 :marked
-  # Routing Around the App
-
   We received new requirements for our Tour of Heroes application:
 
   * Add a *Dashboard* view.

--- a/public/docs/ts/_cache/tutorial/toh-pt6.jade
+++ b/public/docs/ts/_cache/tutorial/toh-pt6.jade
@@ -12,8 +12,6 @@ block includes
 - var _promise = _Promise.toLowerCase()
 
 :marked
-  # Getting and Saving Data
-
   Our stakeholders appreciate our progress.
   Now they want to get the hero data from a server, let users add, edit, and delete heroes,
   and save these changes back to the server.
@@ -155,7 +153,7 @@ block get-heroes-details
     *Observables* are a powerful way to manage asynchronous data flows.
     We'll learn about [Observables](#observables) later in this chapter.
 
-    For *now* we get back on familiar ground by immediately by
+    For *now* we get back on familiar ground by immediately
     converting that `Observable` to a `Promise` using the `toPromise` operator.
 
   +makeExcerpt('app/hero.service.ts', 'to-promise', '')
@@ -219,7 +217,7 @@ block get-heroes-details
   Although we made significant *internal* changes to `getHeroes()`, the public signature did not change.
   We still return a !{_Promise}. We won't have to update any of the components that call `getHeroes()`.
 
-  Our stakeholders are thrilled with the added flexibility from the API integration. 
+  Our stakeholders are thrilled with the added flexibility from the API integration.
   Now they want the ability to create and delete heroes.
 
   Let's see first what happens when we try to update a hero's details.
@@ -229,7 +227,7 @@ block get-heroes-details
   ## Update hero details
 
   We can edit a hero's name already in the hero detail view. Go ahead and try
-  it. As we type, the hero name is updated in the view heading. 
+  it. As we type, the hero name is updated in the view heading.
   But when we hit the `Back` button, the changes are lost!
 
 .l-sub-section
@@ -294,7 +292,11 @@ block get-heroes-details
   When the given name is non-blank, the handler delegates creation of the
   named hero to the hero service, and then adds the new hero to our !{_array}.
 
-  Go ahead, refresh the browser and create some new heroes!
+  Finally, we implement the `create` method in the `HeroService` class.
++makeExcerpt('app/hero.service.ts', 'create')
+
+:marked
+  Refresh the browser and create some new heroes!
 
 .l-main-section
 :marked
@@ -344,6 +346,7 @@ block get-heroes-details
 :marked
   Refresh the browser and try the new delete functionality.
 
+#observables
 :marked
   ## !{_Observable}s
 
@@ -510,7 +513,7 @@ block observable-transformers
 - var _declarations = _docsFor == 'dart' ? 'directives' : 'declarations'
 - var declFile = _docsFor == 'dart' ? 'app/dashboard.component.ts' : 'app/app.module.ts'
 :marked
-  Finally, we import `HeroSearchComponent` from 
+  Finally, we import `HeroSearchComponent` from
   <span ngio-ex>hero-search.component.ts</span>
   and add it to the `!{_declarations}` !{_array}:
 
@@ -532,7 +535,7 @@ figure.image-display
 
 block filetree
   .filetree
-    .file angular2-tour-of-heroes
+    .file angular-tour-of-heroes
     .children
       .file app
       .children
@@ -577,7 +580,7 @@ block filetree
   - We configured an in-memory web API.
   - We learned how to use !{_Observable}s.
 
-  Here are the files we added or changed in this chapter.
+  Here are the files we _added or changed_ in this chapter.
 
 block file-summary
   +makeTabs(

--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -401,7 +401,7 @@ table
   (element | component | directive) event, or (rarely) an attribute name.
   The following table summarizes:
 
-// If you update this table, UPDATE it in Dart & JS, too.
+//- If you update this table, UPDATE it in Dart & JS, too.
 <div width="90%">
 table
   tr
@@ -813,7 +813,7 @@ block style-property-name-dart-diff
   including queries and saves to a remote server.
   These changes percolate through the system and are ultimately displayed in this and other views.
 
-//
+//-
   :marked
     ### Event bubbling and propagation [TODO: reinstate this section when it becomes true]
     Angular invokes the event-handling statement if the event is raised by the current element or one of its child elements.

--- a/public/docs/ts/latest/tutorial/_data.json
+++ b/public/docs/ts/latest/tutorial/_data.json
@@ -32,6 +32,7 @@
   },
   "toh-pt6": {
     "title": "HTTP",
+    "subtitle": "Getting and saving data",
     "intro": "We convert our service and components to use Angular's HTTP service",
     "nextable": true
   }

--- a/public/docs/ts/latest/tutorial/index.jade
+++ b/public/docs/ts/latest/tutorial/index.jade
@@ -2,9 +2,7 @@ block includes
   include ../_util-fns
 
 :marked
-  # Tour of Heroes: the vision
-
-  Our grand plan is to build an app to help a staffing agency manage its stable of heroes.
+  Our grand plan for this tutorial is to build an app to help a staffing agency manage its stable of heroes.
   Even heroes need to find work.
 
   Of course we'll only make a little progress in this tutorial. What we do build will

--- a/public/docs/ts/latest/tutorial/toh-pt1.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt1.jade
@@ -1,8 +1,6 @@
 include ../_util-fns
 
 :marked
-  # Once Upon a Time
-
   Every story starts somewhere. Our story starts where the [QuickStart](../quickstart.html) ends.
 
   Run the <live-example></live-example> for this part.

--- a/public/docs/ts/latest/tutorial/toh-pt2.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt2.jade
@@ -1,7 +1,6 @@
 include ../_util-fns
 
 :marked
-  # It Takes Many Heroes
   Our story needs more heroes.
   We’ll expand our Tour of Heroes app to display a list of heroes,
   allow the user to select a hero, and display the hero’s details.

--- a/public/docs/ts/latest/tutorial/toh-pt4.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt4.jade
@@ -1,7 +1,6 @@
 include ../_util-fns
 
 :marked
-  # Services
   The Tour of Heroes is evolving and we anticipate adding more components in the near future.
   
   Multiple components will need access to hero data and we don't want to copy and 

--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -9,8 +9,6 @@ block includes
   - var _redirectTo = 'redirectTo'
 
 :marked
-  # Routing Around the App
-
   We received new requirements for our Tour of Heroes application:
 
   * Add a *Dashboard* view.

--- a/public/docs/ts/latest/tutorial/toh-pt6.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt6.jade
@@ -12,8 +12,6 @@ block includes
 - var _promise = _Promise.toLowerCase()
 
 :marked
-  # Getting and Saving Data
-
   Our stakeholders appreciate our progress.
   Now they want to get the hero data from a server, let users add, edit, and delete heroes,
   and save these changes back to the server.


### PR DESCRIPTION
Doc page headers are defined in `_data.json` files via a `title` attribute. Main page .jade files should not start with an `<h1>` header since Harp layout template generates a `<h1>` header from the `_data.json` files. Not all ToH pages followed this convention. This fixes the issue; and in one case I moved the `<h1>` text into `_data.json` as a `subtitle` attribute.

Also updated `_cache` files for all ToH.