### PR TITLE
e2e(dependency-injection): fix for Dart and simplification for TS

### DIFF
--- a/public/docs/_examples/dependency-injection/dart/lib/app_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/app_component.dart
@@ -22,7 +22,9 @@ import 'providers_component.dart';
         <button (click)="nextUser()">Next User</button>
       <p>
       <my-heroes id="authorized" *ngIf="isAuthorized"></my-heroes>
-      <my-heroes id="unauthorized" *ngIf="!isAuthorized"></my-heroes>''',
+      <my-heroes id="unauthorized" *ngIf="!isAuthorized"></my-heroes>
+      <my-providers></my-providers>
+      ''',
     directives: const [
       CarComponent,
       HeroesComponent,

--- a/public/docs/_examples/dependency-injection/dart/lib/providers_component.dart
+++ b/public/docs/_examples/dependency-injection/dart/lib/providers_component.dart
@@ -224,7 +224,11 @@ class Provider9Component implements OnInit {
 
 // Sample providers 1 to 7 illustrate a required logger dependency.
 // Optional logger, can be null.
-@Component(selector: 'provider-10', template: '{{log}}')
+@Component(
+    selector: 'provider-10',
+    template: '{{log}}',
+    providers: const [const Provider(Logger, useValue: null)]
+)
 class Provider10Component implements OnInit {
   final Logger _logger;
   String log;

--- a/public/docs/_examples/dependency-injection/dart/web/index.html
+++ b/public/docs/_examples/dependency-injection/dart/web/index.html
@@ -10,6 +10,5 @@
   </head>
   <body>
     <my-app>Loading...</my-app>
-    <my-providers>Loading my-providers ...</my-providers>
   </body>
 </html>

--- a/public/docs/_examples/dependency-injection/dart/web/main.dart
+++ b/public/docs/_examples/dependency-injection/dart/web/main.dart
@@ -1,11 +1,9 @@
 import 'package:angular2/platform/browser.dart';
 
 import 'package:dependency_injection/app_component.dart';
-import 'package:dependency_injection/providers_component.dart';
 
 void main() {
   //#docregion bootstrap
   bootstrap(AppComponent);
   //#enddocregion bootstrap
-  bootstrap(ProvidersComponent);
 }

--- a/public/docs/_examples/dependency-injection/ts/app/app.component.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/app.component.ts
@@ -22,6 +22,7 @@ import { UserService } from './user.service';
     <p>
     <my-heroes id="authorized" *ngIf="isAuthorized"></my-heroes>
     <my-heroes id="unauthorized" *ngIf="!isAuthorized"></my-heroes>
+    <my-providers></my-providers>
   `,
   providers: [Logger]
 })

--- a/public/docs/_examples/dependency-injection/ts/app/app.module.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/app.module.ts
@@ -53,7 +53,7 @@ import {
     { provide: APP_CONFIG, useValue: HERO_DI_CONFIG }
   ],
   // #enddocregion ngmodule-providers
-  bootstrap: [ AppComponent, ProvidersComponent ]
+  bootstrap: [ AppComponent ]
 })
 export class AppModule { }
 // #enddocregion ngmodule

--- a/public/docs/_examples/dependency-injection/ts/app/providers.component.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/providers.component.ts
@@ -229,7 +229,8 @@ let some_message = 'Hello from the injected logger';
 
 @Component({
   selector: 'provider-10',
-  template: template
+  template: template,
+  providers: [{ provide: Logger, useValue: null }]
 })
 export class Provider10Component implements OnInit {
   log: string;

--- a/public/docs/_examples/dependency-injection/ts/index.html
+++ b/public/docs/_examples/dependency-injection/ts/index.html
@@ -22,7 +22,6 @@
   
   <body>
     <my-app>Loading my-app ...</my-app>
-    <my-providers>Loading my-providers ...</my-providers>
   </body>
 
 </html>


### PR DESCRIPTION
Fixes #2493

No need to dual boot `AppComponent` and `ProvidersComponent` only to ensure that we could demo optional injection; instead just inject null for the `@Optional` constructor parameter type.

**Prose is unaffected** by these changes.

```
Suites passed:
  public/docs/_examples/dependency-injection/dart
  public/docs/_examples/dependency-injection/ts
```