### PR TITLE
fix(live-example): correctly match example name

### DIFF
--- a/public/resources/js/util.js
+++ b/public/resources/js/util.js
@@ -77,7 +77,7 @@ var NgIoUtil = (function () {
             // TODO: use $location.path() instead(?). It seems to be empty.
             var loc = $location.absUrl();
             // E.g., https://example.com/docs/dart/latest/guide/displaying-data.html
-            var matches = loc.match(/.*\/([\w\-]+)(\.html)?$/);
+            var matches = loc.match(/.*\/([\w\-]+)(\.html)?/);
             if (matches) NgIoUtil.setExampleName(matches[1]); // cache name
         }
         return NgIoUtil._exampleName;


### PR DESCRIPTION
Currently, when visiting a page with a relative link e.g. https://angular.io/docs/ts/latest/guide/testing.html#!#top, `NgIoUtil.getExampleName` fails to match the example name. 

This results on `live-example` directives on that page missing the example name in the link: instead of linking to https://angular.io/resources/live-examples/testing/ts/plnkr.html it will link to https://angular.io/resources/live-examples//ts/plnkr.html (notice the missing `testing` and the double slashes).

/cc @Foxandxss 