### PR TITLE
docs(lifecycle-hooks): update event hooks to match directives capabilities

### DIFF
--- a/public/docs/ts/latest/guide/lifecycle-hooks.jade
+++ b/public/docs/ts/latest/guide/lifecycle-hooks.jade
@@ -15,7 +15,7 @@ figure
   Angular offers **lifecycle hooks**
   that provide visibility into these key life moments and the ability to act when they occur.
 
-  A directive has the same set of lifecycle hooks, minus the hooks that are specific to component content and views.
+  A directive has the same set of lifecycle hooks.
   <br clear="all">
   ## Table of Contents
     * [Overview](#hooks-overview)
@@ -51,7 +51,7 @@ a#hooks-overview
   that Angular calls shortly after creating the component:
 +makeExample('lifecycle-hooks/ts/app/peek-a-boo.component.ts', 'ngOnInit', 'peek-a-boo.component.ts (excerpt)')(format='.')
 :marked
-  No directive or component will implement all of the lifecycle hooks and some of the hooks only make sense for components.
+  No directive or component will implement all of the lifecycle hooks.
   Angular only calls a directive/component hook method *if it is defined*.
 
 a#hooks-purpose-timing
@@ -97,41 +97,33 @@ table(width="100%")
     td ngAfterContentInit
     td
       :marked
-        Respond after Angular projects external content into the component's view.
+        Respond after Angular projects external content into the directive/component's view.
 
         Called _once_ after the first `NgDoCheck`.
-
-        _A component-only hook_.
-
+        
   tr(style=top)
     td ngAfterContentChecked
     td
       :marked
-        Respond after Angular checks the content projected into the component.
+        Respond after Angular checks the content projected into the directive/component.
 
         Called after the `ngAfterContentInit` and every subsequent `NgDoCheck`.
-
-        _A component-only hook_.
-
+        
   tr(style=top)
     td ngAfterViewInit
     td
       :marked
-        Respond after Angular initializes the component's views and child views.
+        Respond after Angular initializes the directive/component's views and child views.
 
         Called _once_ after the first `ngAfterContentChecked`.
-
-        _A component-only hook_.
 
   tr(style=top)
     td ngAfterViewChecked
     td
       :marked
-        Respond after Angular checks the component's views and child views.
+        Respond after Angular checks the directive/component's views and child views.
 
         Called after the `ngAfterViewInit` and every subsequent `ngAfterContentChecked`.
-
-        _A component-only hook_.
 
   tr(style=top)
     td ngOnDestroy


### PR DESCRIPTION

Minor documentation update to include event hooks that were assumed to only work on components.

Closes angular/angular#10221