### PR TITLE
Update router.jade: Fix missing anchor id

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -399,6 +399,7 @@ a#base-href
   :marked
     We should only need this trick for the live example, not production code.
 
+a#import
 :marked
   ### Configure the routes for the Router
 


### PR DESCRIPTION
The link *Importing from the router library* (https://angular.io/docs/ts/latest/guide/router.html#import) does not work.

I supposed that this was the corresponding section to be linked to.