### PR TITLE
docs(guide & api): feedback/issue links for Dart should refer to Dart repos

### DIFF
--- a/public/_includes/_util-fns.jade
+++ b/public/_includes/_util-fns.jade
@@ -37,6 +37,7 @@
 
 //- Location of sample code
 - var _liveLink = 'live link';
+- var _ngRepoURL = 'https://github.com/angular/angular';
 
 //- NgModule related
 - var _AppModuleVsAppComp = 'AppModule'

--- a/public/_includes/_util-fns.jade
+++ b/public/_includes/_util-fns.jade
@@ -38,6 +38,7 @@
 //- Location of sample code
 - var _liveLink = 'live link';
 - var _ngRepoURL = 'https://github.com/angular/angular';
+- var _ngDocRepoURL = 'https://github.com/angular/angular.io';
 
 //- NgModule related
 - var _AppModuleVsAppComp = 'AppModule'

--- a/public/docs/dart/latest/_util-fns.jade
+++ b/public/docs/dart/latest/_util-fns.jade
@@ -20,6 +20,8 @@ include ../../../_includes/_util-fns
 - var _indexHtmlDir = 'web';
 - var _mainDir = 'web';
 - var _ngRepoURL = 'https://github.com/dart-lang/angular2';
+//- Don't override this value quite yet:
+//- var _ngDocRepoURL = 'https://github.com/dart-lang/site-webdev';
 
 //- NgModule related
 - var _AppModuleVsAppComp = 'AppComponent'

--- a/public/docs/dart/latest/_util-fns.jade
+++ b/public/docs/dart/latest/_util-fns.jade
@@ -19,6 +19,7 @@ include ../../../_includes/_util-fns
 - var _appDir = 'lib';
 - var _indexHtmlDir = 'web';
 - var _mainDir = 'web';
+- var _ngRepoURL = 'https://github.com/dart-lang/angular2';
 
 //- NgModule related
 - var _AppModuleVsAppComp = 'AppComponent'

--- a/public/docs/dart/latest/api/index.jade
+++ b/public/docs/dart/latest/api/index.jade
@@ -1,9 +1,9 @@
 include ../_util-fns
 
 :marked
-  > **Known issues:** The angular.io issue tracker contains [all known
-  issues][api-issues]; if you notice others, please [report
-  them][new-issue]. Thanks!
+  > **Known issues:** The Angular issue tracker contains
+  [all known issues][api-issues]; if you notice others, please 
+  [report them][new-issue]. Thanks!
 
   [new-issue]: !{_ngRepoURL}/issues/new?title=%5BAPI%20docs%5D
   [api-issues]: !{_ngRepoURL}/issues

--- a/public/docs/dart/latest/api/index.jade
+++ b/public/docs/dart/latest/api/index.jade
@@ -1,9 +1,12 @@
+include ../_util-fns
+
 :marked
   > **Known issues:** The angular.io issue tracker contains [all known
   issues][api-issues]; if you notice others, please [report
   them][new-issue]. Thanks!
 
-  [new-issue]: https://github.com/angular/angular.io/issues/new?labels=dart,api&title=%5BDart%5D%5BAPI%5D%20
-  [api-issues]: https://github.com/angular/angular.io/issues?q=label%3Aapi+label%3Adart
+  [new-issue]: !{_ngRepoURL}/issues/new?title=%5BAPI%20docs%5D
+  [api-issues]: !{_ngRepoURL}/issues
+//- ?q=label%3Aapi
 
 api-list(src="api-list.json" lang="dart")

--- a/public/docs/dart/latest/guide/index.jade
+++ b/public/docs/dart/latest/guide/index.jade
@@ -2,12 +2,3 @@ extends ../../../ts/latest/guide/index.jade
 
 block includes
   include ../_util-fns
-
-block example-links
-  :marked
-    Look for a link to that sample near the top of each page.
-    For example, the sample repo https://github.com/angular-examples/architecture
-    contains the code
-    for the [Architecture](architecture.html) chapter's sample.
-    A running version of that sample is at
-    https://angular-examples.github.io/architecture/.

--- a/public/docs/ts/latest/guide/index.jade
+++ b/public/docs/ts/latest/guide/index.jade
@@ -104,5 +104,5 @@ table(width="100%")
 
   ## We welcome feedback! 
 
-  - Use the [site Github repo](!{_ngDocRepoURL}) for **documentation** issues and pull requests.
-  - Use the [Angular Github repo](!{_ngRepoURL}) to report issues with **Angular** itself.
+  - Use the [website GitHub repo](!{_ngDocRepoURL}) for **documentation** issues and pull requests.
+  - Use the [Angular GitHub repo](!{_ngRepoURL}) to report issues with **Angular** itself.

--- a/public/docs/ts/latest/guide/index.jade
+++ b/public/docs/ts/latest/guide/index.jade
@@ -104,5 +104,5 @@ table(width="100%")
 
   ## We welcome feedback! 
 
-  - Use the [angular.io Github repo](https://github.com/angular/angular.io) for **documentation** issues and pull requests.
+  - Use the [site Github repo](!{_ngDocRepoURL}) for **documentation** issues and pull requests.
   - Use the [Angular Github repo](!{_ngRepoURL}) to report issues with **Angular** itself.

--- a/public/docs/ts/latest/guide/index.jade
+++ b/public/docs/ts/latest/guide/index.jade
@@ -16,6 +16,12 @@ figure
 
 block js-alert
 
+- var guideData = public.docs[_docsFor].latest.guide._data;
+- var advancedLandingPage = '';
+- for(var page in guideData) {
+-   if (!guideData[page].basics && !guideData[page].hide) { advancedLandingPage = page; break; }
+- }
+- var advancedUrl = './' + advancedLandingPage + '.html'
 - var top="vertical-align:top"
 table(width="100%")
   col(width="15%")
@@ -26,7 +32,7 @@ table(width="100%")
       :marked
         The foundation for every page and sample in this documentation.
   tr(style=top)
-    td <b>Guide</b>
+    td <b><a href="./">Guide</a></b>
     td
       :marked
         The essential ingredients of Angular development.
@@ -42,7 +48,7 @@ table(width="100%")
         A step-by-step, immersive approach to learning Angular that
         introduces the major features of Angular in an application context.
   tr(style=top)
-    td <b>Advanced</b>
+    td <b><a href="!{advancedUrl}">Advanced</a></b>
     td
       :marked
         In-depth analysis of Angular features and development practices.

--- a/public/docs/ts/latest/guide/index.jade
+++ b/public/docs/ts/latest/guide/index.jade
@@ -16,7 +16,8 @@ figure
 
 block js-alert
 
-- var guideData = public.docs[_docsFor].latest.guide._data;
+- var __lang = _docsFor || current.path[1] || 'ts';
+- var guideData = public.docs[__lang].latest.guide._data;
 - var advancedLandingPage = '';
 - for(var page in guideData) {
 -   if (!guideData[page].basics && !guideData[page].hide) { advancedLandingPage = page; break; }

--- a/public/docs/ts/latest/guide/index.jade
+++ b/public/docs/ts/latest/guide/index.jade
@@ -9,7 +9,6 @@ figure
   are building client applications in HTML and #{_Lang}.
   <br class="l-clear-left">
 
-:marked
   ## Organization
 
   The documentation is divided into major thematic sections, each
@@ -22,7 +21,7 @@ table(width="100%")
   col(width="15%")
   col
   tr(style=top)
-    td <b>QuickStart</b>
+    td <b><a href="../quickstart">QuickStart</a></b>
     td
       :marked
         The foundation for every page and sample in this documentation.
@@ -32,12 +31,12 @@ table(width="100%")
       :marked
         The essential ingredients of Angular development.
   tr(style=top)
-    td <b>API Reference</b>
+    td <b><a href="../api">API Reference</a></b>
     td
       :marked
         Authoritative details about each member of the Angular libraries.
   tr(style=top)
-    td <b>Tutorial</b>
+    td <b><a href="../tutorial">Tutorial</a></b>
     td
       :marked
         A step-by-step, immersive approach to learning Angular that
@@ -48,12 +47,14 @@ table(width="100%")
       :marked
         In-depth analysis of Angular features and development practices.
   tr(style=top)
-    td <b>Cookbook</b>
+    td <b><a href="../cookbook">Cookbook</a></b>
     td
       :marked
         Recipes for specific application challenges, mostly code snippets with a minimum of exposition.
+
 :marked
   ## Learning path
+  
   You don't have to read the guide straight through.  Most pages stand on their own.
 
   For those new to Angular, the recommended learning path runs through the *Guide* section:
@@ -80,37 +81,28 @@ table(width="100%")
 
   After reading the above sections, you can skip to any other pages on this site.
 
-:marked
   ## Code samples
 
   Each page includes code snippets that you can reuse in your applications.
   These snippets are excerpts from a sample application that accompanies the page.
 
-block example-links
-  :marked
-    Look for a link to a running version of that sample near the top of each page,
-    such as this <live-example name="architecture"></live-example> from the [Architecture](architecture.html) page.
+  Look for a link to a running version of that sample near the top of each page,
+  such as this <live-example name="architecture"></live-example> from the [Architecture](architecture.html) page.
+  <p if-docs="ts">
+  The link launches a browser-based code editor where you can inspect, modify, save, and download the code.
+  </p>
 
-    The link launches a browser-based code editor where you can inspect, modify, save, and download the code.
-
-:marked
   A few early pages are written as tutorials and are clearly marked as such.
   The rest of the pages highlight key points in code rather than explain each step necessary to build the sample.
   You can always get the full source through the #{_liveLink}.
 
   ## Reference pages
 
-  The [Cheat Sheet](cheatsheet.html) lists Angular syntax for common scenarios.
+  - The [Cheat Sheet](cheatsheet.html) lists Angular syntax for common scenarios.
+  - The [Glossary](glossary.html) defines terms that Angular developers should know.
+  - The [API Reference](../api/) is the authority on every public-facing member of the Angular libraries.
 
-  The [Glossary](glossary.html) defines terms that Angular developers should know.
+  ## We welcome feedback! 
 
-  The [API Reference](../api/) is the authority on every public-facing member of the Angular libraries.
-
-  ## Feedback
-
-  We welcome feedback! 
-
-  Use the [angular.io Github repo](https://github.com/angular/angular.io) for **documentation** issues and pull requests.
-
-
-  Use the [Angular Github repo](https://github.com/angular/angular) to report issues with **Angular** itself.
+  - Use the [angular.io Github repo](https://github.com/angular/angular.io) for **documentation** issues and pull requests.
+  - Use the [Angular Github repo](!{_ngRepoURL}) to report issues with **Angular** itself.


### PR DESCRIPTION
- Also added links to chapters mentioned in table.
- Other minor copyedits.