### PR TITLE
remove grid fluid from dart api list

### DIFF
--- a/public/docs/dart/latest/cheatsheet.jade
+++ b/public/docs/dart/latest/cheatsheet.jade
@@ -1,4 +1,4 @@
 - var base = current.path[4] ? '.' : './guide';
 
-.l-content-small.grid-fluid.docs-content.cheatsheet
+.l-content-small.docs-content.cheatsheet
   ngio-cheatsheet(src= base + '/cheatsheet.json')


### PR DESCRIPTION
This should ease the transition for Dart out of angular.io. This is similar to the changes done to api-list in https://github.com/angular/angular.io/pull/2819/files

cc @chalin @kwalrath 