### PR TITLE
docs: fix remaining broken links

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -793,7 +793,9 @@ gulp.task('link-checker', function(done) {
     'resources/%7B%7Bresource.url%7D%7D',
     // API docs have links directly into GitHub repo sources; these can
     // quickly become invalid, so ignore them for now:
-    '*/angular/tree/*'
+    '*/angular/tree/*',
+    // harp.json "bios" for "Ryan Schmukler", URL isn't valid:
+    'http://slingingcode.com'
   ];
   var blcOptions = { requestMethod: method, excludedKeywords: exclude};
   return linkChecker({ blcOptions: blcOptions });

--- a/public/_includes/_version-dropdown.jade
+++ b/public/_includes/_version-dropdown.jade
@@ -61,16 +61,16 @@ if language == 'dart'
   else
     - var title = 'Angular ' + version + ' for Dart'
 
+if current.path[4] !== 'change-log'
+  //- DROPDOWN BUTTON
+  nav.dropdown
+    button(aria-label="Select a version of Angular" md-button class="dropdown-button" ng-click="appCtrl.toggleVersionMenu($event)") #{title}  <span class="icon icon-arrow-drop-down"></span>
+    div(class="overlay ng-hide" ng-click="appCtrl.toggleVersionMenu($event)" ng-show="appCtrl.showMenu")
 
-<!-- DROPDOWN BUTTON -->
-nav.dropdown
-  button(aria-label="Select a version of Angular" md-button class="dropdown-button" ng-click="appCtrl.toggleVersionMenu($event)") #{title}  <span class="icon icon-arrow-drop-down"></span>
-  div(class="overlay ng-hide" ng-click="appCtrl.toggleVersionMenu($event)" ng-show="appCtrl.showMenu")
-
-  <!-- DROPDOWN MENU -->
-  ul(class="dropdown-menu" ng-class="appCtrl.showMenu ? 'is-visible' : ''")
-    mixin tree(public.docs.ts, "/docs/ts", "Angular for TypeScript")
-    mixin tree(public.docs.js, "/docs/js", "Angular for JavaScript")
-    //- Disable cross-language link for API entry pages (but keep for top API search page):
-    if ! (current.path[3] === 'api' && public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]])
-      mixin tree(public.docs.dart, "/docs/dart", "Angular for Dart")
+    //- DROPDOWN MENU
+    ul(class="dropdown-menu" ng-class="appCtrl.showMenu ? 'is-visible' : ''")
+      mixin tree(public.docs.ts, "/docs/ts", "Angular for TypeScript")
+      mixin tree(public.docs.js, "/docs/js", "Angular for JavaScript")
+      //- Disable cross-language link for API entry pages (but keep for top API search page):
+      if ! (current.path[3] === 'api' && public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]])
+        mixin tree(public.docs.dart, "/docs/dart", "Angular for Dart")

--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -282,7 +282,7 @@ code-example(format="").
 
   Create a `styles.css` file in the *#{_indexHtmlDir}* folder and start styling, perhaps with the minimal
   styles shown below. For the full set of master styles used by the documentation samples,
-  see [styles.css](https://github.com/angular/angular.io/blob/master/public/docs/_examples/styles.css).
+  see [styles.css](https://github.com/angular/angular.io/blob/master/public/docs/_examples/_boilerplate/styles.css).
 +makeExample('quickstart/js/styles.1.css', null, 'styles.css')(format=".")
 
 .l-main-section


### PR DESCRIPTION
**[Best reviewed by ignoring whitespace diffs](https://github.com/angular/angular.io/pull/2832/files?w=1)**.

In particular, don’t show the language dropdown for the docs change-log page (since JS and Dart don’t have a change log).

Together with #2830, this
fixes #2150