### PR TITLE
docs(systemjs.web): auto-bootstrap option that creates its own AppModule and boots it.

### DIFF
--- a/public/docs/_examples/_boilerplate/systemjs.config.web.build.js
+++ b/public/docs/_examples/_boilerplate/systemjs.config.web.build.js
@@ -77,9 +77,11 @@
     }
   });
 
-  if (!global.noBootstrap) { bootstrap(); }
+  if (global.autoBootstrap) { bootstrap(); }
 
-  // Bootstrap the `AppModule`(skip the `app/main.ts` that normally does this)
+  // Bootstrap with a default `AppModule`
+  // ignore an `app/app.module.ts` and `app/main.ts`, even if present
+  // This function exists primarily (exclusively?) for the QuickStart
   function bootstrap() {
     console.log('Auto-bootstrapping');
 
@@ -99,17 +101,10 @@
     .catch(function(err){ console.error(err); });
   }
 
-  // Import AppModule or make the default AppModule if there isn't one
+  // Make the default AppModule
   // returns a promise for the AppModule
   function getAppModule() {
-    if (global.noAppModule) {
-      return makeAppModule();
-    }
-    return System.import('app/app.module').catch(makeAppModule)
-  }
-
-  function makeAppModule() {
-    console.log('No AppModule; making a bare-bones, default AppModule');
+    console.log('Making a bare-bones, default AppModule');
 
     return Promise.all([
       System.import('@angular/core'),
@@ -135,3 +130,9 @@
     })
   }
 })(this);
+
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Use of this source code is governed by an MIT-style license that
+can be found in the LICENSE file at http://angular.io/license
+*/

--- a/public/docs/_examples/_boilerplate/systemjs.config.web.js
+++ b/public/docs/_examples/_boilerplate/systemjs.config.web.js
@@ -64,9 +64,11 @@
     }
   });
 
-  if (!global.noBootstrap) { bootstrap(); }
+  if (global.autoBootstrap) { bootstrap(); }
 
-  // Bootstrap the `AppModule`(skip the `app/main.ts` that normally does this)
+  // Bootstrap with a default `AppModule`
+  // ignore an `app/app.module.ts` and `app/main.ts`, even if present
+  // This function exists primarily (exclusively?) for the QuickStart
   function bootstrap() {
     console.log('Auto-bootstrapping');
 
@@ -86,17 +88,10 @@
     .catch(function(err){ console.error(err); });
   }
 
-  // Import AppModule or make the default AppModule if there isn't one
+  // Make the default AppModule
   // returns a promise for the AppModule
   function getAppModule() {
-    if (global.noAppModule) {
-      return makeAppModule();
-    }
-    return System.import('app/app.module').catch(makeAppModule)
-  }
-
-  function makeAppModule() {
-    console.log('No AppModule; making a bare-bones, default AppModule');
+    console.log('Making a bare-bones, default AppModule');
 
     return Promise.all([
       System.import('@angular/core'),
@@ -122,3 +117,9 @@
     })
   }
 })(this);
+
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Use of this source code is governed by an MIT-style license that
+can be found in the LICENSE file at http://angular.io/license
+*/

--- a/public/docs/_examples/ngmodule/ts/index.0.html
+++ b/public/docs/_examples/ngmodule/ts/index.0.html
@@ -13,7 +13,6 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.0').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/ngmodule/ts/index.1.html
+++ b/public/docs/_examples/ngmodule/ts/index.1.html
@@ -13,7 +13,6 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.1').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/ngmodule/ts/index.1b.html
+++ b/public/docs/_examples/ngmodule/ts/index.1b.html
@@ -13,7 +13,6 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.1b').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/ngmodule/ts/index.2.html
+++ b/public/docs/_examples/ngmodule/ts/index.2.html
@@ -13,7 +13,6 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.2').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/ngmodule/ts/index.3.html
+++ b/public/docs/_examples/ngmodule/ts/index.3.html
@@ -13,7 +13,6 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
-    <script>document.noBootstrap = true;</script>
     <script src="systemjs.config.js"></script>
     <script>
       System.import('app/main.3').catch(function(err){ console.error(err); });

--- a/public/docs/_examples/testing/ts/browser-test-shim.js
+++ b/public/docs/_examples/testing/ts/browser-test-shim.js
@@ -33,8 +33,6 @@ System.config({
   },
 });
 
-document['noBootstrap'] = true; // do not run system.config.web.js bootstrap
-
 System.import('systemjs.config.js')
   .then(importSystemJsExtras)
   .then(initTestBed)

--- a/tools/plunker-builder/builder.js
+++ b/tools/plunker-builder/builder.js
@@ -248,7 +248,6 @@ class PlunkerBuilder {
     });
 
     var defaultExcludes = [
-      '!**/app/main.ts',
       '!**/a2docs.css',
       '!**/tsconfig.json',
       '!**/*plnkr.*',

--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -21,7 +21,7 @@ var _rxRules = {
   },
   systemjs: {
     from: /<script src="systemjs.config.js"><\/script>/,
-    to:   '<script src="https://cdn.rawgit.com/angular/angular.io/74ef87f/public/docs/_examples/_boilerplate/systemjs.config.web.js"></script>'
+    to:   '<script src="https://cdn.rawgit.com/angular/angular.io/f2daab7/public/docs/_examples/_boilerplate/systemjs.config.web.js"></script>'
   },
   // Clear script like this:
   // <script>


### PR DESCRIPTION
For specific plunkers, e.g. "QuickStart (reboot edition)" PR #2762, that shouldn't have AppModule or main.ts
Rescinds the automatic bootstrapping and exclusion of `main.ts` in #2786 and #2756
Only autoBootstraps when `window.autoBootstrap === true`.