### PR TITLE
chore(plunker-builder): don't strip `import ('app')` from index

### DIFF
--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -114,9 +114,9 @@ var _rxData = [
   {
     pattern: 'systemjs',
   },
-  {
-    pattern: 'system_strip_import_app',
-  },
+  // {
+  //   pattern: 'system_strip_import_app',
+  // },
   {
     pattern: 'system_extra_main'
   },


### PR DESCRIPTION
Don't strip 
```
    <script>
      System.import('app').catch(function(err){ console.error(err); });
    </script>
```
from `index.html` now that all but QS plunkers should have both `main.ts` and `AppModule`