### PR TITLE
docs: fix broken link on quickstart page

### DIFF
--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -28,7 +28,7 @@ figure.image-display
 
 +ifDocsFor('ts')
   :marked
-    You can also <a href="!{_quickstartSrcURL}" target="_blank">
+    You can also <a href="!{_qsRepo}" target="_blank">
     clone the entire QuickStart application</a> from GitHub.
 
 h1 Build this application!


### PR DESCRIPTION
Issue: #2838 