### PR TITLE
docs(quickstart): recover definition of _quickstartSrcURL

### DIFF
--- a/public/docs/ts/_cache/quickstart.jade
+++ b/public/docs/ts/_cache/quickstart.jade
@@ -5,6 +5,7 @@ block includes
   - var _angular_browser_uri = '@angular/platform-browser-dynamic'
   - var _angular_core_uri = '@angular/core'
   - var _stepInit = 4 // Step # after NgModule step
+  - var _quickstartSrcURL='https://github.com/angular/quickstart/blob/master/README.md'
 
 //- TS/Dart shared step counter
 - var step = _stepInit

--- a/public/docs/ts/latest/quickstart.jade
+++ b/public/docs/ts/latest/quickstart.jade
@@ -5,6 +5,7 @@ block includes
   - var _angular_browser_uri = '@angular/platform-browser-dynamic'
   - var _angular_core_uri = '@angular/core'
   - var _stepInit = 4 // Step # after NgModule step
+  - var _quickstartSrcURL='https://github.com/angular/quickstart/blob/master/README.md'
 
 //- TS/Dart shared step counter
 - var step = _stepInit


### PR DESCRIPTION
Recovering definition lost during updates in #2839.

Supersedes #2847
Fixes #2838