### PR TITLE
docs - lifecycle-hook - add ngProjectAs documentation

### DIFF
--- a/public/docs/_examples/lifecycle-hooks/ts/app/app.component.html
+++ b/public/docs/_examples/lifecycle-hooks/ts/app/app.component.html
@@ -7,6 +7,7 @@
 <a href="#after-content">AfterContentInit & AfterContentChecked</a><br>
 <a href="#spy">Spy: directive with OnInit & OnDestroy</a><br>
 <a href="#counter">Counter: OnChanges + Spy directive</a><br>
+<a href="#content-projection">Selective content projection and ngProjectAs attribute</a><br>
 
 <a id="hooks"></a>
 <peek-a-boo-parent></peek-a-boo-parent>
@@ -34,4 +35,8 @@
 
 <a id="counter"></a>
 <counter-parent></counter-parent>
+<a href="#top">back to top</a>
+
+<a id="content-projection"></a>
+<content-projection-parent></content-projection-parent>
 <a href="#top">back to top</a>

--- a/public/docs/_examples/lifecycle-hooks/ts/app/app.module.ts
+++ b/public/docs/_examples/lifecycle-hooks/ts/app/app.module.ts
@@ -38,6 +38,15 @@ import { PeekABooComponent } from './peek-a-boo.component';
 import { SpyParentComponent } from './spy.component';
 import { SpyDirective } from './spy.directive';
 
+import {
+  ContentProjectionParentComponent,
+  TextPainterComponent,
+  GreenTextDirective,
+  RedTextDirective,
+  SuperTextPainterComponent,
+  BlueTextDirective
+} from './content-projection.component';
+
 @NgModule({
   imports: [
     BrowserModule,
@@ -60,7 +69,13 @@ import { SpyDirective } from './spy.directive';
     PeekABooParentComponent,
     PeekABooComponent,
     SpyParentComponent,
-    SpyDirective
+    SpyDirective,
+    ContentProjectionParentComponent,
+    TextPainterComponent,
+    GreenTextDirective,
+    RedTextDirective,
+    SuperTextPainterComponent,
+    BlueTextDirective
   ],
   bootstrap: [ AppComponent ]
 })

--- a/public/docs/_examples/lifecycle-hooks/ts/app/content-projection.component.ts
+++ b/public/docs/_examples/lifecycle-hooks/ts/app/content-projection.component.ts
@@ -1,0 +1,105 @@
+// #docregion
+import { Component, Directive } from '@angular/core';
+
+@Component({
+  selector: 'content-projection-parent',
+  template: `
+    <div class="parent">
+      <h2>Selective Content Projection and ngProjectAs usage</h2>
+      <h3>Selective</h3>` +
+// #docregion text-painter-usage
+      `<text-painter>
+        <span red-text>I am RED.</span>
+        <span green-text>I am GREEN.</span>
+      </text-painter>`
+// #enddocregion text-painter-usage
+  + `<h3>ngProjectAs</h3>` +
+// #docregion super-text-painter-usage
+    `<super-text-painter>
+      <span red-text>I am RED.</span>
+      <span blue-text>I am BLUE.</span>
+      <span green-text>I am GREEN.</span>
+    </super-text-painter>`
+// #enddocregion super-text-painter-usage
+    + `</div>
+  `,
+  styles: [`
+    .parent {
+      background: ivory;
+    }
+    :host >>> .box {
+      border: 1px dotted gray;
+      font-size: 1.2em;
+      margin: 10px;
+      padding: 5px;
+      text-align: center;
+    }
+  `]
+})
+export class ContentProjectionParentComponent {
+
+}
+
+@Directive({
+  selector: '[red-text]'
+})
+export class RedTextDirective { }
+
+@Directive({
+  selector: '[green-text]'
+})
+export class GreenTextDirective { }
+
+
+@Component({
+  selector: 'text-painter',
+// #docregion text-painter-template
+  template: `
+  <div>
+    <div class="box red-text">
+      <ng-content select="[red-text]"></ng-content>
+    </div>
+    <div class="box green-text">
+      <ng-content select="[green-text]"></ng-content>
+    </div>
+  </div>
+  `,
+// #enddocregion text-painter-template
+  styles: [`
+    .red-text {
+      color: red;
+    }
+    .green-text {
+      color: green;
+    }
+  `]
+})
+export class TextPainterComponent { }
+
+@Directive({
+  selector: '[blue-text]'
+})
+export class BlueTextDirective { }
+
+@Component({
+  selector: 'super-text-painter',
+// #docregion super-text-painter-template
+  template: `
+  <div>
+    <text-painter>
+      <ng-content select="[red-text]" ngProjectAs="[red-text]"></ng-content>
+      <ng-content select="[green-text]" ngProjectAs="[green-text]"></ng-content>
+    </text-painter>
+    <div class="box blue-text">
+      <ng-content select="[blue-text]"></ng-content>
+    </div>
+  </div>
+  `,
+// #enddocregion super-text-painter-template
+  styles: [`
+    .blue-text {
+      color: blue;
+    }
+  `]
+})
+export class SuperTextPainterComponent { }

--- a/public/docs/ts/latest/guide/lifecycle-hooks.jade
+++ b/public/docs/ts/latest/guide/lifecycle-hooks.jade
@@ -7,8 +7,8 @@ figure
   img(src="/resources/images/devguide/lifecycle-hooks/hooks-in-sequence.png" alt="Us" align="left" style="width:200px; margin-left:-40px;margin-right:30px")
 
 :marked
-  A component has a lifecycle managed by Angular itself. 
-  
+  A component has a lifecycle managed by Angular itself.
+
   Angular creates it, renders it, creates and renders its children,
   checks it when its data-bound properties change, and destroys it before removing it from the DOM.
 
@@ -47,7 +47,7 @@ a#hooks-overview
   one or more of the *Lifecycle Hook* interfaces in the Angular `core` library.
 
   Each interface has a single hook method whose name is the interface name prefixed with `ng`.
-  For example, the `OnInit` interface has a hook method named `ngOnInit` 
+  For example, the `OnInit` interface has a hook method named `ngOnInit`
   that Angular calls shortly after creating the component:
 +makeExample('lifecycle-hooks/ts/app/peek-a-boo.component.ts', 'ngOnInit', 'peek-a-boo.component.ts (excerpt)')(format='.')
 :marked
@@ -73,7 +73,7 @@ table(width="100%")
       :marked
         Respond when Angular (re)sets data-bound input properties.
         The method receives a `SimpleChanges` object of current and previous property values.
-        
+
         Called before `ngOnInit` and whenever one or more data-bound input properties change.
 
   tr(style=top)
@@ -82,15 +82,15 @@ table(width="100%")
       :marked
         Initialize the directive/component after Angular first displays the data-bound properties
         and sets the directive/component's input properties.
-        
-        Called _once_, after the _first_ `ngOnChanges`. 
+
+        Called _once_, after the _first_ `ngOnChanges`.
 
   tr(style=top)
     td ngDoCheck
     td
       :marked
-        Detect and act upon changes that Angular can't or won't detect on its own. 
-        
+        Detect and act upon changes that Angular can't or won't detect on its own.
+
         Called during every change detection run, immediately after `ngOnChanges` and `ngOnInit`.
 
   tr(style=top)
@@ -138,13 +138,13 @@ table(width="100%")
     td
       :marked
         Cleanup just before Angular destroys the directive/component.
-        Unsubscribe observables and detach event handlers to avoid memory leaks.      
+        Unsubscribe observables and detach event handlers to avoid memory leaks.
 
         Called _just before_ Angular destroys the directive/component.
 
 +ifDocsFor('ts|js')
   a#interface-optional
-  .l-main-section  
+  .l-main-section
   :marked
     ## Interface are optional (technically)
 
@@ -160,7 +160,7 @@ table(width="100%")
 
     Nonetheless, it's good practice to add interfaces to TypeScript directive classes
     in order to benefit from strong typing and editor tooling.
-  
+
 a#other-lifecycle-hooks
 .l-main-section
 :marked
@@ -339,7 +339,7 @@ figure.image-display
 .l-sub-section
   :marked
     Misko Hevery, Angular team lead,
-    [explains why](http://misko.hevery.com/code-reviewers-guide/flaw-constructor-does-real-work/) 
+    [explains why](http://misko.hevery.com/code-reviewers-guide/flaw-constructor-does-real-work/)
     you should avoid complex constructor logic.
 
 :marked
@@ -347,7 +347,7 @@ figure.image-display
   You shouldn't worry that a new component will try to contact a remote server when
   created under test or before you decide to display it.
   Constructors should do no more than set the initial local variables to simple values.
-  
+
   An `ngOnInit` is a good place for a component to fetch its initial data. The
   [Tutorial](../tutorial/toh-pt4.html#oninit) and [HTTP](server-communication.html#oninit) chapter
   show how.
@@ -401,7 +401,7 @@ figure.image-display
   img(src='/resources/images/devguide/lifecycle-hooks/on-changes-anim.gif' alt="OnChanges")
 
 :marked
-  The log entries appear as the string value of the *power* property changes. 
+  The log entries appear as the string value of the *power* property changes.
   But the `ngOnChanges` does not catch changes to `hero.name`
   That's surprising at first.
 
@@ -470,7 +470,7 @@ figure.image-display
   Angular throws an error if the hook updates the component's data-bound `comment` property immediately (try it!).
 block tick-methods
   :marked
-    The `LoggerService.tick_then()` postpones the log update 
+    The `LoggerService.tick_then()` postpones the log update
     for one turn of the browser's JavaScript cycle ... and that's just long enough.
 
 :marked
@@ -513,14 +513,47 @@ figure.image-display
   In this case, the projected content is the `<my-child>` from the parent.
 figure.image-display
   img(src='/resources/images/devguide/lifecycle-hooks/projected-child-view.png' width="230" alt="Projected Content")
-:marked
+
 .l-sub-section
   :marked
     The tell-tale signs of *content projection* are (a) HTML between component element tags
     and (b) the presence of `<ng-content>` tags in the component's template.
+
+:marked
+  ### Selective content projection
+
+.l-sub-section
+  :marked
+    Angular 1 developers know this technique as *multi-slot transclusion* (Angular 1.5+).
+
+:marked
+  The content can be selectively projected into multiple locations using `select` attribute of `ng-content` tag.
+  Here is an example component that accepts text elements from the user and renders them in red and green color.
++makeExample('lifecycle-hooks/ts/app/content-projection.component.ts', 'text-painter-template', 'TextPainter Component (template)')(format=".")
+:marked
+  It can be used as follows:
++makeExample('lifecycle-hooks/ts/app/content-projection.component.ts', 'text-painter-usage', 'TextPainter Component Usage')(format=".")
+:marked
+  The user can mark *span* elements using *red-text* and *green-text* attributes. *TextPainter* component then uses `ng-content` tags with appropriate selector (*[red-text]* and *[green-text]*) in its template to cherry-pick elements and place them at desired location.
+
+:marked
+  ### ngProjectAs attribute
+  Let's assume we would like to extend the *TextPainter* component with ability to render blue text. We can create a new *SuperTextPainter* component that uses *textPainter* component internally.
++makeExample('lifecycle-hooks/ts/app/content-projection.component.ts', 'super-text-painter-template', 'SuperTextPainter Component (template)')(format=".")
+:marked
+  It can be used as follows:
++makeExample('lifecycle-hooks/ts/app/content-projection.component.ts', 'super-text-painter-usage', 'SuperTextPainter Component Usage')(format=".")
+:marked
+  The content is first projected into *SuperTextPainter* component template that uses selector *[blue-text]*
+  to render blue text and passes on the elements needed by the embedded *TextPainter* component template. It can be viewed as
+  two level projection and achieved by using `ngProjectAs` attribute in *SuperTextPainter* component template. The value of
+  this tag should match the `ng-content` selectors of the mebedded *TextPainter* component template.
+
+  Note that this example won't work if `ngProjectAs` attribute is omitted from *SuperTextPainter* component template.
+
 :marked
   ### AfterContent hooks
-  *AfterContent* hooks are similar to the *AfterView* hooks. 
+  *AfterContent* hooks are similar to the *AfterView* hooks.
   The key difference is in the child component
 
   * The *AfterView* hooks concern `ViewChildren`, the child components whose element tags


### PR DESCRIPTION
Add documentation and example for selective content projection and _ngProjectAs_ attribute usage. For #1683.