### PR TITLE
Corrected RouterOutlet description

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -470,7 +470,7 @@ a#router-outlet
   ### *RouterOutlet*
 
   `RouterOutlet` is a component from the router library.
-  The router displays views within the bounds of the `<router-outlet>` tags.
+  The router displays views immediately ***after*** each `<router-outlet>`'s corresponding closing tag.
 
 .l-sub-section
   :marked


### PR DESCRIPTION
<router-outlet> does not wrap the views, the views are inserted next to its closing tag, not within its content.