### PR TITLE
chore(gulp): selectively shred guide examples using --filter

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -823,7 +823,8 @@ gulp.task('_harp-compile', function() {
 
 gulp.task('_shred-devguide-examples', ['_shred-clean-devguide', '_copy-example-boilerplate'], function() {
   // Split big shredding task into partials 2016-06-14
-  var examplePaths = globby.sync(EXAMPLES_PATH+'/*/', {ignore: ['**/node_modules', '**/_boilerplate']});
+  const exPath = path.join(EXAMPLES_PATH, (argv.filter || '') + '*');
+  var examplePaths = globby.sync(exPath, {ignore: ['**/node_modules', '**/_boilerplate']});
   var promise = Promise.resolve(true);
   examplePaths.forEach(function (examplePath) {
     promise = promise.then(() => docShredder.shredSingleExampleDir(_devguideShredOptions, examplePath));
@@ -847,7 +848,7 @@ gulp.task('_shred-clean-devguide-shared-jade', function(cb) {
 });
 
 gulp.task('_shred-clean-devguide', function(cb) {
-  var cleanPath = path.join(_devguideShredOptions.fragmentsDir, '**/*.*')
+  var cleanPath = path.join(_devguideShredOptions.fragmentsDir, (argv.filter || '*') + '*/*.*')
   return del([ cleanPath, '!**/*.ovr.*', '!**/_api/**']);
 });
 

--- a/public/docs/README.md
+++ b/public/docs/README.md
@@ -1,6 +1,0 @@
-# Why the _fragments dir is checked in
- 
-Within this repo files generated as a result of shredding the `_examples` dir ( the contents of the `_fragments` dir) are checked in so that we can avoid running the
-shredder over the entire `_examples` dir each time someone refreshes the repo ( the `shred-full` gulp task). 
-The gulp `serve-and-watch` shredder is only a ‘partial’ shredder. It only shred’s files in directories changed during
-the current session. 


### PR DESCRIPTION
E.g., `gulp _shred-devguide-examples --filter=dep`

Also removed docs/README.md since it was reporting something that is no longer true (we don’t commit `_fragments` anymore).