### PR TITLE
examples(styles): drop duplicate `items` classes but keep `li.selected`

### DIFF
--- a/public/docs/_examples/_boilerplate/styles.css
+++ b/public/docs/_examples/_boilerplate/styles.css
@@ -83,40 +83,10 @@ nav a.active {
   background-color: #DDD;
   left: .1em;
 }
-.items li.selected:hover {
-  background-color: #BBD8DC;
-  color: white;
-}
-.items .text {
-  position: relative;
-  top: -3px;
-}
-.items {
-  margin: 0 0 2em 0;
-  list-style-type: none;
-  padding: 0;
-  width: 24em;
-}
-.items li {
-  cursor: pointer;
-  position: relative;
-  left: 0;
-  background-color: #EEE;
-  margin: .5em;
-  padding: .3em 0;
-  height: 1.6em;
-  border-radius: 4px;
-}
-.items li:hover {
-  color: #607D8B;
-  background-color: #DDD;
-  left: .1em;
-}
 .items li.selected {
   background-color: #CFD8DC;
   color: white;
 }
-
 .items li.selected:hover {
   background-color: #BBD8DC;
 }


### PR DESCRIPTION
Supersedes #2872 but ensures that we don’t loose `.items li.selected`.