### PR TITLE
Add missing ` from styleguide rule

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -1679,7 +1679,7 @@ a(href="#toc") Back to top
 .s-rule.do
   :marked
     **Do** use `@Input` and `@Output` instead of the `inputs` and `outputs` properties of the 
-    `@Directive and `@Component` decorators:
+    `@Directive` and `@Component` decorators:
 
 .s-rule.do
   :marked


### PR DESCRIPTION
I was walking through the documentation and noticed a markdown issue. Cheers! 🍻 