### PR TITLE
examples(toh-6/dart): support case where `_initialHeroes` is empty

### DIFF
--- a/public/docs/_examples/toh-6/dart/lib/in_memory_data_service.dart
+++ b/public/docs/_examples/toh-6/dart/lib/in_memory_data_service.dart
@@ -25,7 +25,7 @@ class InMemoryDataService extends MockClient {
   ];
   static final List<Hero> _heroesDb =
       _initialHeroes.map((json) => new Hero.fromJson(json)).toList();
-  static int _nextId = _heroesDb.map((hero) => hero.id).reduce(max) + 1;
+  static int _nextId = _heroesDb.map((hero) => hero.id).fold(0, max) + 1;
 
   static Future<Response> _handler(Request request) async {
     var data;


### PR DESCRIPTION
In the ToH examples, the initial db has always been populated with some heroes. Deleting all heroes causes no problems (one can add more heroes after that). The reported issue is for the situation where the initial heroes db is empty.

Fixes https://github.com/angular-examples/toh-6/issues/2