### PR TITLE
docs(cb-aot): add missing module.id to sample

### DIFF
--- a/public/docs/_examples/cb-aot-compiler/ts/app/app.component.ts
+++ b/public/docs/_examples/cb-aot-compiler/ts/app/app.component.ts
@@ -1,8 +1,8 @@
 // #docregion
-// #docregion
 import { Component } from '@angular/core';
 
 @Component({
+  moduleId: module.id,
   selector: 'my-app',
   templateUrl: 'app.component.html'
 })

--- a/public/docs/_examples/cb-aot-compiler/ts/index.html
+++ b/public/docs/_examples/cb-aot-compiler/ts/index.html
@@ -9,7 +9,9 @@
 
     <script src="node_modules/core-js/client/shim.min.js"></script>
     <script src="node_modules/zone.js/dist/zone.js"></script>
-
+    <!-- #docregion moduleId -->
+    <script>window.module = 'aot';</script>
+    <!-- #enddocregion moduleId -->
   </head>
 
   <!-- #docregion bundle -->

--- a/public/docs/ts/latest/cookbook/aot-compiler.jade
+++ b/public/docs/ts/latest/cookbook/aot-compiler.jade
@@ -129,6 +129,24 @@ code-example(format='.').
   The `"skipMetadataEmit" : true` property prevents the compiler from generating metadata files with the compiled application. 
   Metadata files are not necessary when targeting TypeScript files, so there is no reason to include them.
 
+:marked
+  ***Component-relative Template URLS***
+
+  The AoT compiler requires that `@Component` URLS for external templates and css files be _component-relative_.
+  That means that the value of `@Component.templateUrl` is a URL value _relative_ to the component class file.
+  For example, an `'app.component.html'` URL means that the template file is a sibling of its companion `app.component.ts` file.
+
+  While JiT app URLs are more flexible, stick with _component-relative_ URLs for compatibility with AoT compilation.
+  
+  JiT-compiled applications that use the SystemJS loader and _component-relative_ URLs *must set the* `@Component.moduleId` *property to* `module.id`.
+  The `module` object is undefined when an AoT-compiled app runs. 
+  The app fails with a null reference error unless you assign a global `module` value in the `index.html` like this:
++makeExample('cb-aot-compiler/ts/index.html','moduleId')(format='.')  
+.l-sub-section
+  :marked
+    Setting a global `module` is a temporary expedient. 
+
+:marked
   ### Compiling the application
 
   Initiate AoT compilation from the command line using the previously installed `ngc` compiler by executing:
@@ -376,22 +394,6 @@ a#toh
    app/main.ts (JiT)`
 )
 
-:marked
-  ***Component-relative Template URLS***
-
-  The AoT compiler requires that `@Component` URLS for external templates and css files be _component-relative_.
-  That means that the value of `@Component.templateUrl` is a URL value _relative_ to the component class file.
-  For example, a `'hero.component.html'` URL means that the template file is a sibling of its companion `hero.component.ts` file.
-
-  While JiT app URLs are more flexible, stick with _component-relative_ URLs for compatibility with AoT compilation.
-  
-  JiT-compiled applications that use the SystemJS loader and _component-relative_ URLs *must set the* `@Component.moduleId` *property to* `module.id`.
-  The `module` object is undefined when an AoT-compiled app runs. 
-  The app fails with a null reference error unless you assign a global `module` value in the `index.html` like this:
-+makeExample('toh-6/ts/aot/index.html','moduleId')(format='.')  
-.l-sub-section
-  :marked
-    Setting a global `module` is a temporary expedient. 
 :marked
   ***TypeScript configuration***
 


### PR DESCRIPTION
@wardbell Adding module.id to the AoT CB

Moved the Component-relative Template URLS (with minor tweaks) higher up in the prose to explain it as part of the first sample.