### PR TITLE
docs(api/cheatsheet): show ng version + lang in page header

### DIFF
--- a/public/_includes/_hero.jade
+++ b/public/_includes/_hero.jade
@@ -13,8 +13,12 @@
 if current.path[4] && current.path[3] == 'api'
   - var textFormat = 'is-standard-case'
 
+if current.path.indexOf('cheatsheet') > 0 || current.path[current.path.length-2] === 'api'
+  - var base = current.path[4] ? '../guide' : './guide';
+  - var ngVersion = '(v<ngio-cheatsheet src="' + base + '/cheatsheet.json" version-only>2.X.Y</ngio-cheatsheet>)'; 
+
 header.hero.background-sky
-  h1(class="hero-title #{textFormat}") #{headerTitle}
+  h1(class="hero-title #{textFormat}") #{headerTitle} !{ngVersion}
 
   if useBadges
     if stability

--- a/public/docs/dart/latest/_data.json
+++ b/public/docs/dart/latest/_data.json
@@ -49,9 +49,8 @@
   },
 
   "cheatsheet": {
-    "title": "Angular Cheat Sheet",
+    "title": "Cheat Sheet",
     "subtitle": "Dart",
-    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "reference": false
   },
 

--- a/public/docs/dart/latest/guide/_data.json
+++ b/public/docs/dart/latest/guide/_data.json
@@ -69,8 +69,8 @@
   },
 
   "cheatsheet": {
-    "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
+    "title": "Cheat Sheet",
+    "subtitle": "Dart",
     "nextable": true,
     "basics": true
   },

--- a/public/docs/js/latest/_data.json
+++ b/public/docs/js/latest/_data.json
@@ -41,9 +41,8 @@
   },
 
   "cheatsheet": {
-    "title": "Angular Cheat Sheet",
+    "title": "Cheat Sheet",
     "subtitle": "JavaScript",
-    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "reference": false
   },
 

--- a/public/docs/js/latest/guide/_data.json
+++ b/public/docs/js/latest/guide/_data.json
@@ -51,8 +51,8 @@
   },
 
   "cheatsheet": {
-    "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
+    "title": "Cheat Sheet",
+    "subtitle": "JavaScript",
     "nextable": true,
     "basics": true
   },

--- a/public/docs/ts/latest/_data.json
+++ b/public/docs/ts/latest/_data.json
@@ -49,9 +49,8 @@
   },
 
   "cheatsheet": {
-    "title": "Angular Cheat Sheet",
+    "title": "Cheat Sheet",
     "subtitle": "TypeScript",
-    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
     "reference": false
   },
 

--- a/public/docs/ts/latest/guide/_data.json
+++ b/public/docs/ts/latest/guide/_data.json
@@ -78,8 +78,8 @@
   },
 
   "cheatsheet": {
-    "title": "Angular Cheat Sheet",
-    "intro": "A quick guide to Angular syntax. (Content is provisional and may change.)",
+    "title": "Cheat Sheet",
+    "subtitle": "TypeScript",
     "nextable": true,
     "basics": true
   },

--- a/public/resources/js/directives/cheatsheet.js
+++ b/public/resources/js/directives/cheatsheet.js
@@ -1,21 +1,23 @@
 angularIO.directive('ngioCheatsheet', function() {
   return {
+    restrict: 'E',
+    scope: {},
     controllerAs: '$ctrl',
     controller: function($http, $attrs, $sce) {
       var $ctrl = this;
       $http.get($attrs.src).then(function(response) {
-        $ctrl.currentEnvironment = response.data.currentEnvironment;
-        $ctrl.version = response.data.version;
-        $ctrl.sections = response.data.sections;
+        if ($attrs.hasOwnProperty('versionOnly')) {
+          $ctrl.version = response.data.version.raw;
+        } else {
+          $ctrl.sections = response.data.sections;
+        }
       });
       $ctrl.getSafeHtml = function(html) {
         return $sce.trustAsHtml(html);
       };
     },
     template:
-      '<h2>Angular for {{$ctrl.currentEnvironment}} Cheat Sheet (v{{ $ctrl.version.raw }})</h2>' +
-      '<br>' +
-      '<div ng-if="!$ctrl.sections">Loading Cheatsheet...</div>\n' +
+      '<span ng-if="$ctrl.version">{{$ctrl.version}}</span>' +
       '<table ng-repeat="section in $ctrl.sections" ng-cloak>\n' +
       '<tr>\n' +
       '  <th>{{section.name}}</th>\n' +


### PR DESCRIPTION
Continuation of #2796, "duplicate header cleanup".

This PR also streamlines the cheatsheet page: the language and version are now shown in the header rather than in the page content.
> ![screen shot 2016-12-01 at 8 09 32 am](https://cloud.githubusercontent.com/assets/4140793/20802356/a6ce91ea-b7a0-11e6-82b7-a13968d555d0.png)

The Angular version is also shown on the API Reference page.

cc @kwalrath 