### PR TITLE
docs(style-guide): fix typo

### DIFF
--- a/public/docs/ts/latest/guide/style-guide.jade
+++ b/public/docs/ts/latest/guide/style-guide.jade
@@ -1074,7 +1074,7 @@ a(href="#toc") Back to top
 .s-why.s-why-last
   :marked
     **Why?** Being DRY is important, but not crucial if it sacrifices the other elements of LIFT.
-    That's why its calle _T-DRY_. 
+    That's why it's called _T-DRY_. 
     For example, it's redundant to name a component, `hero-view.component.html` because a component is obviously a view. 
     But if something is not obvious or departs from a convention, then spell it out.
 


### PR DESCRIPTION
Fix a typo on the T-DRY section.