### PR TITLE
docs(guide/router): fix grammar typo in basics-configuration

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -101,7 +101,7 @@ include ../../../_includes/_see-addr-bar
   We bootstrap our application with an array of routes that we'll provide to our **`RouterModule.forRoot`** function.
 
   In the following example, we configure our application with four route definitions. The configured `RouterModule` is
-  add to the `AppModule`'s `imports` array.
+  added to the `AppModule`'s `imports` array.
 
 +makeExcerpt('app/app.module.0.ts (excerpt)', 'route-config')
 


### PR DESCRIPTION
A small typo I caught while trying to learn routing.