### PR TITLE
docs: fix broken links (mainly for Dart)

### DIFF
--- a/public/docs/dart/latest/glossary.jade
+++ b/public/docs/dart/latest/glossary.jade
@@ -13,7 +13,7 @@ block annotation-defn
     details.
 
     The corresponding term in TypeScript and JavaScript is
-    [_decorator_](!{docsPath}/ts/latest/glossary.html#decorator).
+    [_decorator_](https://angular.io/docs/ts/latest/glossary.html#decorator).
 
     [metadata]: https://www.dartlang.org/guides/language/language-tour#metadata
 

--- a/public/docs/dart/latest/guide/dependency-injection.jade
+++ b/public/docs/dart/latest/guide/dependency-injection.jade
@@ -39,7 +39,7 @@ block ngmodule-vs-component
     But its child `HeroListComponent` does, so we head there next.
 
 block injectable-not-always-needed-in-ts
-  //- The [Angular Dart Transformer](https://github.com/angular/angular/wiki/Angular-2-Dart-Transformer)
+  //- The [Angular Dart Transformer](https://github.com/dart-lang/angular2/wiki/Transformer)
   //- generates static code to replace the use of dart:mirrors. It requires that types be
   //- identified as targets for static code generation. Generally this is achieved
   //- by marking the class as @Injectable (though there are other mechanisms).

--- a/public/docs/dart/latest/guide/server-communication.jade
+++ b/public/docs/dart/latest/guide/server-communication.jade
@@ -25,7 +25,7 @@ block http-providers
     for DI, we must add a `resolved_identifiers` parameter to the `angular2`
     transformer in `pubspec.yaml`:
 
-    [ng2dtri]: https://github.com/angular/angular/wiki/Angular-2-Dart-Transformer#resolved_identifiers
+    [ng2dtri]: https://github.com/dart-lang/angular2/wiki/Transformer#resolved_identifiers
 
   - var stylePattern = { pnk: /(resolved_identifiers:|Browser.*)/gm, otl: /(- angular2:)|(transformers:)/g };
   +makeExcerpt('pubspec.yaml', 'transformers', null, stylePattern)

--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -185,7 +185,7 @@ a#aot
     Angular has a rich data binding framework with a variety of data binding
     operations and supporting declaration syntax.
 
-     Read about the forms of binding in the [Template Syntax](!{docsLatest}/guide/template-syntax.html#data-binding) page:
+     Read about the forms of binding in the [Template Syntax](!{docsLatest}/guide/template-syntax.html) page:
      * [Interpolation](!{docsLatest}/guide/template-syntax.html#interpolation).
      * [Property binding](!{docsLatest}/guide/template-syntax.html#property-binding).
      * [Event binding](!{docsLatest}/guide/template-syntax.html#event-binding).


### PR DESCRIPTION
Fixes a broken link+anchor in TS too.

Addresses, in part https://github.com/dart-lang/site-webdev/issues/204