### PR TITLE
ci: update protractor

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -5,7 +5,7 @@
   "description": "Master package.json, the superset of all dependencies for all of the _example package.json files. See _boilerplate/package.json for example npm scripts.",
   "scripts": {
     "protractor": "protractor",
-    "webdriver:update": "webdriver-manager update"
+    "webdriver:update": "webdriver-manager update --standalone false --gecko false"
   },
   "keywords": [],
   "author": "",
@@ -67,7 +67,7 @@
     "lodash": "^4.16.2",
     "null-loader": "^0.1.1",
     "phantomjs-prebuilt": "^2.1.7",
-    "protractor": "4.0.9",
+    "protractor": "~4.0.13",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.4",
     "rollup": "^0.36.0",
@@ -79,7 +79,6 @@
     "ts-node": "^1.3.0",
     "tslint": "^3.15.1",
     "typescript": "~2.0.10",
-    "webdriver-manager": "10.2.5",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.14.1",
     "webpack-merge": "^0.14.0"


### PR DESCRIPTION
Followup to https://github.com/angular/angular.io/pull/2684, it is no longer needed.

/cc @wardbell @Foxandxss @cnishina