### PR TITLE
chore: update example package.json to use in-mem-web-api 0.2.0

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-server": "~2.3.0",
     "@angular/router": "~3.3.0",
     "@angular/upgrade": "~2.3.0",
-    "angular-in-memory-web-api": "~0.1.17",
+    "angular-in-memory-web-api": "~0.2.0",
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.0-rc.4",


### PR DESCRIPTION
So that `Observable<Response>` returned by `Http` calls involving the in-mem-web-api are "cold".
That means they don't occur until someone subscribes.

See [in-mem repo's change log for 0.2.0](https://github.com/angular/in-memory-web-api/blob/master/CHANGELOG.md#020-2016-12-11).