### PR TITLE
docs(router): fix typo originally identified by PR #2945

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -94,14 +94,13 @@ include ../../../_includes/_see-addr-bar
     We cover other options in the [details below](#browser-url-styles).
 :marked
   ### Configuration
-  The application will have one *`router`*. When the browser's URL changes, the router looks for a corresponding **`Route`**
+  The application will have one, singleton instance of the *`Router`* service. 
+  When the browser's URL changes, that router looks for a corresponding **`Route`**
   from which it can determine the component to display.
 
   A router has no routes until we configure it.
-  We bootstrap our application with an array of routes that we'll provide to our **`RouterModule.forRoot`** function.
-
-  In the following example, we configure our application with four route definitions. The configured `RouterModule` is
-  add to the `AppModule`'s `imports` array.
+  In the following example, we create four route definitions, configure the router via the **`RouterModule.forRoot`** method,
+  and add the result to the `AppModule`'s `imports` array.
 
 +makeExcerpt('app/app.module.0.ts (excerpt)', 'route-config')
 


### PR DESCRIPTION
Starts from the typo identified by PR #2945, then re-phrases it and the surrounding passage.