### PR TITLE
docs(toh-5): fix HeroesDetailComponent typo

### DIFF
--- a/public/docs/ts/_cache/tutorial/toh-pt5.jade
+++ b/public/docs/ts/_cache/tutorial/toh-pt5.jade
@@ -775,7 +775,7 @@ block heroes-component-cleanup
 :marked
   ### Update the _HeroesComponent_ class.
 
-  The `HeroesComponent` navigates to the `HeroesDetailComponent` in response to a button click. 
+  The `HeroesComponent` navigates to the `HeroDetailComponent` in response to a button click. 
   The button's _click_ event is bound to a `gotoDetail` method that navigates _imperatively_
   by telling the router where to go.
 


### PR DESCRIPTION
Looks like this was supposed to refer to the `HeroDetailComponent` instead (there is no `HeroesDetailComponent`)