### PR TITLE
chore(examples): don't gitignore _examples/tsconfig.json

### DIFF
--- a/public/docs/_examples/.gitignore
+++ b/public/docs/_examples/.gitignore
@@ -5,7 +5,7 @@ karma-test-shim.js
 package.json
 */**/styles.css
 systemjs.config.js
-tsconfig.json
+*/**/tsconfig.json
 tslint.json
 wallaby.js
 

--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Master package.json, the superset of all dependencies for all of the _example package.json files. See _boilerplate/package.json for example npm scripts.",
   "scripts": {
+    "http-server": "http-server",
     "protractor": "protractor",
     "webdriver:update": "webdriver-manager update --standalone false --gecko false"
   },


### PR DESCRIPTION
Tweak to `.gitignore` so that only the `tsconfig.json` files in subdirectories are ignored, not the one directly in this `_examples` folder.

Also, add a package.json script definition for `http-server` for more convenient access (w/o invoking tsc as is forced in the script definition given in `_boilerplate/package.json`.

cc @kwalrath 