### PR TITLE
chore(plunker): sub systemjs.config.extras.web.js for systemjs.config.extras.js

### DIFF
--- a/public/docs/_examples/_boilerplate/systemjs.config.web.build.js
+++ b/public/docs/_examples/_boilerplate/systemjs.config.web.build.js
@@ -18,6 +18,7 @@
       "sourceMap": true,
       "emitDecoratorMetadata": true,
       "experimentalDecorators": true,
+      "lib": ["es2015", "dom"],
       "noImplicitAny": true,
       "suppressImplicitAnyIndexErrors": true
     },

--- a/public/docs/_examples/_boilerplate/systemjs.config.web.js
+++ b/public/docs/_examples/_boilerplate/systemjs.config.web.js
@@ -16,6 +16,7 @@
       "sourceMap": true,
       "emitDecoratorMetadata": true,
       "experimentalDecorators": true,
+      "lib": ["es2015", "dom"],
       "noImplicitAny": true,
       "suppressImplicitAnyIndexErrors": true
     },

--- a/public/docs/_examples/setup/ts/systemjs.config.extras.web.js
+++ b/public/docs/_examples/setup/ts/systemjs.config.extras.web.js
@@ -1,0 +1,11 @@
+/**
+ * Web (plunker) version of systemjs.config.extras.js
+ * It should default to `.ts` extensions rather than `.js` extensions in almost all cases.
+ */
+// (function (global) {
+//   System.config({
+//     packages: {
+//       // add packages here
+//     }
+//   });
+// })(this);

--- a/public/docs/_examples/testing/ts/app/hero/hero-detail.component.ts
+++ b/public/docs/_examples/testing/ts/app/hero/hero-detail.component.ts
@@ -2,7 +2,7 @@
 // #docplaster
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute, Router }   from '@angular/router';
-import 'rxjs/add/operator/pluck';
+import 'rxjs/add/operator/map';
 
 import { Hero }              from '../model';
 import { HeroDetailService } from './hero-detail.service';
@@ -30,7 +30,7 @@ export class HeroDetailComponent implements OnInit {
   // #docregion ng-on-init
   ngOnInit(): void {
     // get hero when `id` param changes
-    this.route.params.pluck<string>('id')
+    this.route.params.map(p => p['id'])
       .forEach(id => this.getHero(id))
       .catch(() => this.hero = new Hero()); // no id; should edit new hero
   }

--- a/public/docs/_examples/testing/ts/systemjs.config.extras.web.js
+++ b/public/docs/_examples/testing/ts/systemjs.config.extras.web.js
@@ -1,0 +1,11 @@
+/**
+ * Web (plunker) version of systemjs.config.extras.js
+ * It should default to `.ts` extensions rather than `.js` extensions in almost all cases.
+ */
+System.config({
+  packages: {
+    // barrels
+    'app/model': {main:'index.ts', defaultExtension:'ts'},
+    'app/model/testing': {main:'index.ts', defaultExtension:'ts'}
+  }
+});

--- a/tools/plunker-builder/builder.js
+++ b/tools/plunker-builder/builder.js
@@ -122,6 +122,8 @@ class PlunkerBuilder {
       if (extn == '.png') {
         content = this._encodeBase64(fileName);
         fileName = fileName.substr(0, fileName.length - 4) + '.base64.png'
+      } else if (-1 < fileName.indexOf('systemjs.config.extras')) {
+        content = this._getSystemjsConfigExtras(config);
       } else {
         content = fs.readFileSync(fileName, 'utf-8');
       }
@@ -213,6 +215,26 @@ class PlunkerBuilder {
 
     // Copyright already added to web versions of systemjs.config
     // this.systemjsConfig +=  this.copyrights.jsCss;
+  }
+
+  // Try to replace `systemjs.config.extras.js` with the
+  // `systemjs.config.extras.web.js` web version that
+  // should default SystemJS barrels to `.ts` files rather than `.js` files
+  // Example: see docs `testing`.
+  // HACK-O-MATIC!
+  _getSystemjsConfigExtras(config) {
+    var extras =    config.basePath + '/systemjs.config.extras.js';
+    var webExtras = config.basePath + '/systemjs.config.extras.web.js';
+    if (fs.existsSync(webExtras)) {
+      // console.log('** Substituted "' + webExtras + '"  for "' + extras + '".');
+      return fs.readFileSync(webExtras, 'utf-8');
+    } else if (fs.existsSync(extras)){
+      console.log('** WARNING: no "' + webExtras + '" replacement for "' + extras + '".');
+      return fs.readFileSync(extras, 'utf-8');
+    } else {
+      console.log('** WARNING: no "' + extras + '" file; returning empty content.');
+      return '';
+    }
   }
 
   _htmlToElement(document, html) {


### PR DESCRIPTION
Solves sudden problem with plunker not handling the non-plunker version.
See illustrative plunker: http://plnkr.co/edit/osNMXqB4pgZugEckBDVF?p=info
Also switch from `pluck` to `map` because `pluck` typing stopped working.