### PR TITLE
docs(toh-pt5): add instruc for adding `moduleId` to `AppComponent` (#2967)

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -869,7 +869,9 @@ block css-files
     +makeExcerpt('app/app.component.ts (active router links)', 'template')
 
 :marked
-  Set the `AppComponent`’s `styleUrls` property to this CSS file.
+  First add `moduleId: module.id` to the `@Component` metadata of the `AppComponent`
+  to enable _module-relative_ file URLs.
+  Then add a `styleUrls` property that points to this CSS file as follows.
 
 +makeExcerpt('app/app.component.ts','styleUrls')
 


### PR DESCRIPTION
closes #2967.