### PR TITLE
docs(architecture): copyedits + adjusted jade blocks

### DIFF
--- a/public/docs/ts/latest/guide/architecture.jade
+++ b/public/docs/ts/latest/guide/architecture.jade
@@ -3,12 +3,11 @@ block includes
   - var _library_module = 'library module'
   - var _at_angular = '@angular'
 
-:marked
-  Angular is a framework for building client applications in HTML and
-  either JavaScript or a language like TypeScript that compiles to JavaScript.
-
-block angular-parts
+block angular-intro
   :marked
+    Angular is a framework for building client applications in HTML and
+    either JavaScript or a language like TypeScript that compiles to JavaScript.
+
     The framework consists of several libraries, some of them core and some optional.
 
 :marked
@@ -568,15 +567,15 @@ block registering-providers
   by implementing the lifecycle hook interfaces.
 
   > [**Pipes**](pipes.html): Use pipes in your templates to improve the user experience by transforming values for display. Consider this `currency` pipe expression:
-<div style="margin-left:40px">
-code-example().
-  price | currency:'USD':true
-</div>
-:marked
-  > It displays a price of "42.33" as `$42.33`.
+  >
+  > > `price | currency:'USD':true`
+  >
+  > It displays a price of 42.33 as `$42.33`.
 
   > [**Router**](router.html): Navigate from page to page within the client
     application and never leave the browser.
 
-  > [**Testing**](testing.html): Run unit tests on your application parts as they interact with the Angular framework
-  using the _Angular Testing Platform_.
+block angular-feature-testing
+  :marked
+    > [**Testing**](testing.html): Run unit tests on your application parts as they interact with the Angular framework
+    using the _Angular Testing Platform_.


### PR DESCRIPTION
Minor adjustments, in particular, gets rid of custom styling in favor of using plain markdown for pipe example. This fixes the layout for some displays.

Followup to #2990

cc @kwalrath 