### PR TITLE
docs(template-syntax): Rectify the concept of 'context'

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -140,8 +140,7 @@ block template-expressions-cannot
   The component itself is usually the expression *context*, in which case
   the template expression usually references that component.
 
-  The expression context can include objects other than the component.
-  A [template reference variable](#ref-vars) is one such alternative context object.
+  The expression context can be objects other than the component.
 
 :marked
   <a id="no-side-effects"></a>
@@ -238,8 +237,7 @@ block statement-context
 :marked
   The *onSave* in `(click)="onSave()"` is sure to be a method of the data-bound component instance.
 
-  The statement context may include an object other than the component.
-  A [template reference variable](#ref-vars) is one such alternative context object.
+  The statement context may be an object other than the component.
   We'll frequently see the reserved `$event` symbol in event binding statements,
   representing the "message" or "payload" of the raised event.
 


### PR DESCRIPTION
A template reference variable (Component, Directive, ElementRef or TemplateRef instance) has nothing to do with being a context. 

If it's a **Component** instance, it may be a context of another template, but not relevant in this template, nor alternative.

If it's a **TemplateRef** instance, then it would always depends on an external context object to be passed in as the view model and needs template input variable to define what to get from that context.

If it's a **Directive** or **ElementRef** instance, there is nothing todo with context at all.

Above all, a template reference variable would never be an alternative context object.