### PR TITLE
fix(ci): pin webdriver and zone versions

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -28,7 +28,7 @@
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.0-rc.4",
     "systemjs": "0.19.39",
-    "zone.js": "^0.7.2"
+    "zone.js": "0.7.2"
   },
   "devDependencies": {
     "@types/angular": "^1.5.16",
@@ -40,7 +40,7 @@
     "@types/angular-sanitize": "^1.3.3",
     "@types/jasmine": "~2.5.36",
     "@types/node": "^6.0.45",
-    "@types/selenium-webdriver": "^2.53.32",
+    "@types/selenium-webdriver": "2.53.32",
     "angular2-template-loader": "^0.4.0",
     "awesome-typescript-loader": "^2.2.4",
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
When https://github.com/angular/protractor/pull/3848 is ready it should fix the webdriver types issues, and the pinning can be reverted.

Will bring up the zone breakage with a repro in it's repo.