### PR TITLE
test(deps): fix webdriver logging entry type

### DIFF
--- a/public/docs/_examples/animations/e2e-spec.ts
+++ b/public/docs/_examples/animations/e2e-spec.ts
@@ -1,4 +1,4 @@
-'use strict'; // necessary for es6 output in node 
+'use strict'; // necessary for es6 output in node
 
 import { browser, element, by, ElementFinder } from 'protractor';
 import { logging, promise } from 'selenium-webdriver';
@@ -296,7 +296,7 @@ describe('Animation Tests', () => {
     it('fires a callback on start and done', () => {
       addActiveHero();
       browser.manage().logs().get(logging.Type.BROWSER)
-        .then((logs: webdriver.logging.Entry[]) => {
+        .then((logs: logging.Entry[]) => {
           const animationMessages = logs.filter((log) => {
             return log.message.indexOf('Animation') !== -1 ? true : false;
           });


### PR DESCRIPTION
https://github.com/angular/angular.io/pull/3018 broke our animations test because it was still relying on a type present in webdriver typings. This PR uses the type from `selenium-webdriver` instead.