### PR TITLE
docs(router): warn about routing modules order

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -1334,7 +1334,8 @@ h3#merge-hero-routes Import hero module into AppModule
 .l-sub-section
   :marked
     Routes provided by feature modules are combined together into their imported module's routes by the router. 
-    This allows you to continue defining the feature module routes without modifying the main route configuration.
+    This allows you to continue defining the feature module routes without modifying the main route configuration. 
+    Remember to add `AppRoutingModule` after feature modules, otherwise the feature routes won't work.
 
 :marked
   As a result, the `AppModule` no longer has specific knowledge of the hero feature, its components, or its route details.


### PR DESCRIPTION
If `AppRoutingModule` is imported in `imports` before feature modules, their routes will be ignored. I think this should be added in the docs for clarity.