### PR TITLE
build(plunkers): don't emit AoT files

### DIFF
--- a/tools/plunker-builder/builder.js
+++ b/tools/plunker-builder/builder.js
@@ -284,7 +284,10 @@ class PlunkerBuilder {
       '!**/systemjs.config.js',
       '!**/wallaby.js',
       '!**/karma-test-shim.js',
-      '!**/karma.conf.js'
+      '!**/karma.conf.js',
+      // AoT related files
+      '!**/aot/**/*.*',
+      '!**/*-aot.*'
     ];
 
     // exclude all specs if no spec is mentioned in `files[]`


### PR DESCRIPTION
Currently plunkers for AoT enabled chapters (such as ToH-6) will emit a few AoT-only files.

This PR removes those files from plunker auto-generation.

![image](https://cloud.githubusercontent.com/assets/4172079/21482008/6bc19ea6-cb66-11e6-97e4-63f16bcb1aae.png)

//cc @Foxandxss 

