### PR TITLE
fix(ts-config): fix tsconfig ref

### DIFF
--- a/public/docs/_examples/quickstart/ts/tsconfig.1.json
+++ b/public/docs/_examples/quickstart/ts/tsconfig.1.json
@@ -8,14 +8,6 @@
     "experimentalDecorators": true,
     "lib": [ "es2015", "dom" ],
     "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "typeRoots": [
-      "../../node_modules/@types/"
-    ]
-  },
-  "compileOnSave": true,
-  "exclude": [
-    "node_modules/*",
-    "**/*-aot.ts"
-  ]
+    "suppressImplicitAnyIndexErrors": true
+  }
 }

--- a/public/docs/ts/latest/guide/typescript-configuration.jade
+++ b/public/docs/ts/latest/guide/typescript-configuration.jade
@@ -24,7 +24,7 @@ a(id="tsconfig")
     [TypeScript wiki](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 :marked
   We created the following `tsconfig.json` during [Setup](setup.html):
-+makeJson('quickstart/ts/tsconfig.json', null, 'tsconfig.json')(format=".")
++makeJson('quickstart/ts/tsconfig.1.json', null, 'tsconfig.json')(format=".")
 :marked
   This file contains options and flags that are essential for Angular applications.
   


### PR DESCRIPTION
In https://angular.io/docs/ts/latest/guide/typescript-configuration.html we are showing the example tsconfig, which currently has additional properties (`typeRoots`, `compileOnSave`, `exclude`) used only by docs that do not match the one used in Quickstart.

This PR adds another file to quickstart that matches the one in https://github.com/angular/quickstart/blob/master/tsconfig.json.

/cc @Foxandxss 
