### PR TITLE
docs(setup): fix typo

### DIFF
--- a/public/docs/ts/latest/guide/setup.jade
+++ b/public/docs/ts/latest/guide/setup.jade
@@ -63,7 +63,7 @@ code-example(language="sh" class="code-shell").
 block qs-seed
   :marked
     The **QuickStart seed** contains the same application as the QuickStart playground.
-    But it's true purpose is to provide a solid foundation for _local_ development.
+    But its true purpose is to provide a solid foundation for _local_ development.
     Consequently, there are _many more files_ in the project folder on your machine, 
     most of which you can [learn about later](setup-systemjs-anatomy.html "Setup Anatomy").
 


### PR DESCRIPTION
This PR fixes a small typo in the Setup guide.