### PR TITLE
docs(architecture): update wording

### DIFF
--- a/public/docs/ts/latest/guide/architecture.jade
+++ b/public/docs/ts/latest/guide/architecture.jade
@@ -432,7 +432,7 @@ figure
 +makeExcerpt('app/logger.service.ts', 'class')
 
 :marked
-  Here's a `HeroService` that fetches heroes and returns them in a resolved !{_PromiseLinked}.
+  Here's a `HeroService` that uses a !{_PromiseLinked} to fetch heroes.
   The `HeroService` depends on the `Logger` service and another `BackendService` that handles the server communication grunt work.
 
 +makeExcerpt('app/hero.service.ts', 'class')


### PR DESCRIPTION
This PR updates the wording so it aligns with the actual code that is displayed under the wording.

Before:
Here's a `HeroService` that fetches heroes and returns them in a resolved Promise.

After:
Here's a `HeroService` that uses a Promise to fetch heroes.

Code:
```typescript
getHeroes() {
  this.backend.getAll(Hero).then( (heroes: Hero[]) => {
    this.logger.log(`Fetched ${heroes.length} heroes.`);
    this.heroes.push(...heroes); // fill cache
  });
  return this.heroes;
}
```

The code does not return a promise so I believe the new wording is more accurate.