### PR TITLE
docs(ngmodule): fix typo

### DIFF
--- a/public/docs/ts/latest/guide/ngmodule.jade
+++ b/public/docs/ts/latest/guide/ngmodule.jade
@@ -381,7 +381,7 @@ a#import-name-conflict
   +makeExample('ngmodule/ts/app/app.module.1b.ts', 'import-alias')(format=".")
   :marked
     This solves the immediate problem of referencing both directive _types_ in the same file but
-    leaves another problem unresoved as we discuss [below](#resolve-conflicts).
+    leaves another problem unresolved as we discuss [below](#resolve-conflicts).
 
 :marked
   ### Provide the _ContactService_


### PR DESCRIPTION
This PR fixes a typo in the ngmodule documentation.