### PR TITLE
docs(ngmodule-faq): fix typo

### DIFF
--- a/public/docs/ts/latest/cookbook/ngmodule-faq.jade
+++ b/public/docs/ts/latest/cookbook/ngmodule-faq.jade
@@ -169,7 +169,7 @@ a#q-browser-vs-common-module
   `BrowserModule` provides services that are essential to launch and run a browser app.
 
   `BrowserModule` also re-exports `CommonModule` from `@angular/common`
-  which means that component in the `AppModule` module also have access to
+  which means that components in the `AppModule` module also have access to
   the Angular directives every app needs such as `NgIf` and `NgFor`.
 
   _Do not import_ `BrowserModule` in any other module.


### PR DESCRIPTION
This PR fixes a typo in the NgModule FAQ Cookbook.