### PR TITLE
chore(deps): remove reflect-metadata

### DIFF
--- a/public/docs/_examples/animations/ts/index.html
+++ b/public/docs/_examples/animations/ts/index.html
@@ -13,7 +13,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/architecture/ts/index.html
+++ b/public/docs/_examples/architecture/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/attribute-directives/ts/index.html
+++ b/public/docs/_examples/attribute-directives/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-a1-a2-quick-reference/ts/index.html
+++ b/public/docs/_examples/cb-a1-a2-quick-reference/ts/index.html
@@ -13,7 +13,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-component-communication/ts/index.html
+++ b/public/docs/_examples/cb-component-communication/ts/index.html
@@ -13,7 +13,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-component-relative-paths/ts/index.html
+++ b/public/docs/_examples/cb-component-relative-paths/ts/index.html
@@ -17,7 +17,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-dependency-injection/ts/index.html
+++ b/public/docs/_examples/cb-dependency-injection/ts/index.html
@@ -14,7 +14,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-dynamic-form/ts/index.html
+++ b/public/docs/_examples/cb-dynamic-form/ts/index.html
@@ -14,7 +14,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-form-validation/ts/index.html
+++ b/public/docs/_examples/cb-form-validation/ts/index.html
@@ -13,7 +13,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-i18n/ts/index.html
+++ b/public/docs/_examples/cb-i18n/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-set-document-title/ts/index.html
+++ b/public/docs/_examples/cb-set-document-title/ts/index.html
@@ -18,7 +18,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-ts-to-js/js-es6-decorators/index.html
+++ b/public/docs/_examples/cb-ts-to-js/js-es6-decorators/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-ts-to-js/js-es6/index.html
+++ b/public/docs/_examples/cb-ts-to-js/js-es6/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cb-ts-to-js/js/index.html
+++ b/public/docs/_examples/cb-ts-to-js/js/index.html
@@ -9,7 +9,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
 
     <!-- Angular and RxJS umd scripts -->
     <script src="node_modules/rxjs/bundles/Rx.js"></script>

--- a/public/docs/_examples/cb-ts-to-js/ts/index.html
+++ b/public/docs/_examples/cb-ts-to-js/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/cli-quickstart/ts/angular-cli-build.js
+++ b/public/docs/_examples/cli-quickstart/ts/angular-cli-build.js
@@ -9,7 +9,6 @@ module.exports = function(defaults) {
       'systemjs/dist/system.src.js',
       'zone.js/dist/**/*.+(js|js.map)',
       'es6-shim/es6-shim.js',
-      'reflect-metadata/**/*.+(js|js.map)',
       'rxjs/**/*.+(js|js.map)',
       '@angular/**/*.+(js|js.map)'
     ]

--- a/public/docs/_examples/cli-quickstart/ts/config/karma.conf.js
+++ b/public/docs/_examples/cli-quickstart/ts/config/karma.conf.js
@@ -16,7 +16,6 @@ module.exports = function (config) {
     files: [
       { pattern: 'dist/vendor/es6-shim/es6-shim.js', included: true, watched: false },
       { pattern: 'dist/vendor/zone.js/dist/zone.js', included: true, watched: false },
-      { pattern: 'dist/vendor/reflect-metadata/Reflect.js', included: true, watched: false },
       { pattern: 'dist/vendor/systemjs/dist/system-polyfills.js', included: true, watched: false },
       { pattern: 'dist/vendor/systemjs/dist/system.src.js', included: true, watched: false },
       { pattern: 'dist/vendor/zone.js/dist/async-test.js', included: true, watched: false },

--- a/public/docs/_examples/component-styles/ts/index.html
+++ b/public/docs/_examples/component-styles/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/dependency-injection/ts/index.html
+++ b/public/docs/_examples/dependency-injection/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>
@@ -19,7 +18,7 @@
       System.import('app').catch(function(err){ console.error(err); });
     </script>
   </head>
-  
+
   <body>
     <my-app>Loading my-app ...</my-app>
   </body>

--- a/public/docs/_examples/displaying-data/ts/index.html
+++ b/public/docs/_examples/displaying-data/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/forms/js/index.html
+++ b/public/docs/_examples/forms/js/index.html
@@ -18,7 +18,6 @@
    <script src="node_modules/core-js/client/shim.min.js"></script>
 
    <script src="node_modules/zone.js/dist/zone.js"></script>
-   <script src="node_modules/reflect-metadata/Reflect.js"></script>
 
    <script src="node_modules/rxjs/bundles/Rx.js"></script>
    <script src="node_modules/@angular/core/bundles/core.umd.js"></script>

--- a/public/docs/_examples/forms/ts/index.html
+++ b/public/docs/_examples/forms/ts/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
      <!-- #docregion bootstrap -->
-    <link rel="stylesheet" 
+    <link rel="stylesheet"
           href="https://unpkg.com/bootstrap@3.3.7/dist/css/bootstrap.min.css">
      <!-- #enddocregion bootstrap -->
      <!-- #docregion styles -->
@@ -19,7 +19,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/hierarchical-dependency-injection/ts/index.html
+++ b/public/docs/_examples/hierarchical-dependency-injection/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/homepage-hello-world/ts/index.1.html
+++ b/public/docs/_examples/homepage-hello-world/ts/index.1.html
@@ -12,7 +12,6 @@
     <script src="https://unpkg.com/core-js/client/shim.min.js"></script>
 
     <script src="https://unpkg.com/zone.js@0.7.4"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.8"></script>
     <script src="https://unpkg.com/systemjs@0.19.39/dist/system.src.js"></script>
     <script src="https://unpkg.com/typescript@2.0.10/lib/typescript.js"></script>
 

--- a/public/docs/_examples/homepage-hello-world/ts/index.html
+++ b/public/docs/_examples/homepage-hello-world/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/homepage-tabs/ts/index.1.html
+++ b/public/docs/_examples/homepage-tabs/ts/index.1.html
@@ -13,7 +13,6 @@
     <script src="https://unpkg.com/core-js/client/shim.min.js"></script>
 
     <script src="https://unpkg.com/zone.js@0.7.4"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.8"></script>
     <script src="https://unpkg.com/systemjs@0.19.39/dist/system.src.js"></script>
     <script src="https://unpkg.com/typescript@2.0.10/lib/typescript.js"></script>
 

--- a/public/docs/_examples/homepage-tabs/ts/index.html
+++ b/public/docs/_examples/homepage-tabs/ts/index.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/homepage-todo/ts/index.1.html
+++ b/public/docs/_examples/homepage-todo/ts/index.1.html
@@ -13,7 +13,6 @@
     <script src="https://unpkg.com/core-js/client/shim.min.js"></script>
 
     <script src="https://unpkg.com/zone.js@0.7.4"></script>
-    <script src="https://unpkg.com/reflect-metadata@0.1.8"></script>
     <script src="https://unpkg.com/systemjs@0.19.39/dist/system.src.js"></script>
     <script src="https://unpkg.com/typescript@2.0.10/lib/typescript.js"></script>
 

--- a/public/docs/_examples/homepage-todo/ts/index.html
+++ b/public/docs/_examples/homepage-todo/ts/index.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/lifecycle-hooks/ts/index.html
+++ b/public/docs/_examples/lifecycle-hooks/ts/index.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/ngmodule/ts/index.0.html
+++ b/public/docs/_examples/ngmodule/ts/index.0.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
     <script src="systemjs.config.js"></script>
     <script>

--- a/public/docs/_examples/ngmodule/ts/index.1.html
+++ b/public/docs/_examples/ngmodule/ts/index.1.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
     <script src="systemjs.config.js"></script>
     <script>

--- a/public/docs/_examples/ngmodule/ts/index.1b.html
+++ b/public/docs/_examples/ngmodule/ts/index.1b.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
     <script src="systemjs.config.js"></script>
     <script>

--- a/public/docs/_examples/ngmodule/ts/index.2.html
+++ b/public/docs/_examples/ngmodule/ts/index.2.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
     <script src="systemjs.config.js"></script>
     <script>

--- a/public/docs/_examples/ngmodule/ts/index.3.html
+++ b/public/docs/_examples/ngmodule/ts/index.3.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
     <script src="systemjs.config.js"></script>
     <script>

--- a/public/docs/_examples/ngmodule/ts/index.html
+++ b/public/docs/_examples/ngmodule/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -24,9 +24,8 @@
     "@angular/router": "~3.4.0",
     "@angular/tsc-wrapped": "^0.5.0",
     "@angular/upgrade": "~2.4.0",
-    "angular-in-memory-web-api": "~0.2.2",
+    "angular-in-memory-web-api": "~0.2.4",
     "core-js": "^2.4.1",
-    "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.1",
     "systemjs": "0.19.39",
     "zone.js": "^0.7.4"

--- a/public/docs/_examples/pipes/ts/index.html
+++ b/public/docs/_examples/pipes/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/quickstart/js/index.html
+++ b/public/docs/_examples/quickstart/js/index.html
@@ -14,7 +14,6 @@
     <!-- #enddocregion ie-polyfills -->
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
 
     <script src="node_modules/rxjs/bundles/Rx.js"></script>
     <script src="node_modules/@angular/core/bundles/core.umd.js"></script>

--- a/public/docs/_examples/quickstart/js/package.1.json
+++ b/public/docs/_examples/quickstart/js/package.1.json
@@ -17,9 +17,8 @@
     "@angular/router": "~3.4.0",
     "@angular/upgrade": "~2.4.0",
 
-    "angular-in-memory-web-api": "~0.1.16",
+    "angular-in-memory-web-api": "~0.2.4",
     "core-js": "^2.4.1",
-    "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.1",
     "zone.js": "^0.7.4"
   },

--- a/public/docs/_examples/quickstart/ts/index.html
+++ b/public/docs/_examples/quickstart/ts/index.html
@@ -14,7 +14,6 @@
     <!-- #enddocregion polyfills -->
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <!-- #docregion autobootstrap-->

--- a/public/docs/_examples/router/ts/index.html
+++ b/public/docs/_examples/router/ts/index.html
@@ -15,7 +15,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/security/ts/index.html
+++ b/public/docs/_examples/security/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/server-communication/ts/index.html
+++ b/public/docs/_examples/server-communication/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/setup/ts/index.html
+++ b/public/docs/_examples/setup/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
     <script src="systemjs.config.js"></script>
     <script>

--- a/public/docs/_examples/setup/ts/quickstart-specs.html
+++ b/public/docs/_examples/setup/ts/quickstart-specs.html
@@ -17,8 +17,6 @@
   <script src="node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
   <script src="node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
-  <script src="node_modules/reflect-metadata/Reflect.js"></script>
-
   <script src="node_modules/zone.js/dist/zone.js"></script>
   <script src="node_modules/zone.js/dist/long-stack-trace-zone.js"></script>
   <script src="node_modules/zone.js/dist/proxy.js"></script>

--- a/public/docs/_examples/structural-directives/ts/index.html
+++ b/public/docs/_examples/structural-directives/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/style-guide/ts/index.html
+++ b/public/docs/_examples/style-guide/ts/index.html
@@ -13,7 +13,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/styleguide/js/index.html
+++ b/public/docs/_examples/styleguide/js/index.html
@@ -8,7 +8,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
 
     <script src="node_modules/rxjs/bundles/Rx.js"></script>
     <script src="node_modules/@angular/core/bundles/core.umd.js"></script>

--- a/public/docs/_examples/styleguide/package.1.json
+++ b/public/docs/_examples/styleguide/package.1.json
@@ -12,7 +12,6 @@
     "angular2": "2.0.0-beta.0",
     "systemjs": "0.19.6",
     "core-js": "^2.4.0",
-    "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "zone.js": "0.5.10"
   },

--- a/public/docs/_examples/styleguide/ts/index.html
+++ b/public/docs/_examples/styleguide/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/template-syntax/ts/index.html
+++ b/public/docs/_examples/template-syntax/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/testing/ts/1st-specs.html
+++ b/public/docs/_examples/testing/ts/1st-specs.html
@@ -17,8 +17,6 @@
   <script src="node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
   <script src="node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
-  <script src="node_modules/reflect-metadata/Reflect.js"></script>
-
   <script src="node_modules/zone.js/dist/zone.js"></script>
   <script src="node_modules/zone.js/dist/long-stack-trace-zone.js"></script>
   <script src="node_modules/zone.js/dist/proxy.js"></script>

--- a/public/docs/_examples/testing/ts/app-specs.html
+++ b/public/docs/_examples/testing/ts/app-specs.html
@@ -18,8 +18,6 @@
   <script src="node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
   <script src="node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
-  <script src="node_modules/reflect-metadata/Reflect.js"></script>
-
   <script src="node_modules/zone.js/dist/zone.js"></script>
   <script src="node_modules/zone.js/dist/long-stack-trace-zone.js"></script>
   <script src="node_modules/zone.js/dist/proxy.js"></script>

--- a/public/docs/_examples/testing/ts/bag-specs.html
+++ b/public/docs/_examples/testing/ts/bag-specs.html
@@ -18,8 +18,6 @@
   <script src="node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
   <script src="node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
-  <script src="node_modules/reflect-metadata/Reflect.js"></script>
-
   <script src="node_modules/zone.js/dist/zone.js"></script>
   <script src="node_modules/zone.js/dist/long-stack-trace-zone.js"></script>
   <script src="node_modules/zone.js/dist/proxy.js"></script>

--- a/public/docs/_examples/testing/ts/bag.html
+++ b/public/docs/_examples/testing/ts/bag.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/testing/ts/banner-inline-specs.html
+++ b/public/docs/_examples/testing/ts/banner-inline-specs.html
@@ -16,8 +16,6 @@
   <script src="node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
   <script src="node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
-  <script src="node_modules/reflect-metadata/Reflect.js"></script>
-
   <script src="node_modules/zone.js/dist/zone.js"></script>
   <script src="node_modules/zone.js/dist/long-stack-trace-zone.js"></script>
   <script src="node_modules/zone.js/dist/proxy.js"></script>

--- a/public/docs/_examples/testing/ts/banner-specs.html
+++ b/public/docs/_examples/testing/ts/banner-specs.html
@@ -16,8 +16,6 @@
   <script src="node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
   <script src="node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
-  <script src="node_modules/reflect-metadata/Reflect.js"></script>
-
   <script src="node_modules/zone.js/dist/zone.js"></script>
   <script src="node_modules/zone.js/dist/long-stack-trace-zone.js"></script>
   <script src="node_modules/zone.js/dist/proxy.js"></script>

--- a/public/docs/_examples/testing/ts/index.html
+++ b/public/docs/_examples/testing/ts/index.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/testing/ts/karma.conf.js
+++ b/public/docs/_examples/testing/ts/karma.conf.js
@@ -39,7 +39,6 @@ module.exports = function(config) {
 
       // Polyfills
       'node_modules/core-js/client/shim.js',
-      'node_modules/reflect-metadata/Reflect.js',
 
       // zone.js
       'node_modules/zone.js/dist/zone.js',

--- a/public/docs/_examples/testing/ts/wallaby.js
+++ b/public/docs/_examples/testing/ts/wallaby.js
@@ -12,7 +12,6 @@ module.exports = function () {
 
       // Polyfills
       {pattern: 'node_modules/core-js/client/shim.min.js', instrument: false},
-      {pattern: 'node_modules/reflect-metadata/Reflect.js', instrument: false},
 
       // zone.js
       {pattern: 'node_modules/zone.js/dist/zone.js', instrument: false},

--- a/public/docs/_examples/toh-1/ts/index.html
+++ b/public/docs/_examples/toh-1/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/toh-2/ts/index.html
+++ b/public/docs/_examples/toh-2/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/toh-3/ts/index.html
+++ b/public/docs/_examples/toh-3/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/toh-4/ts/index.html
+++ b/public/docs/_examples/toh-4/ts/index.html
@@ -10,7 +10,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/toh-5/ts/index.html
+++ b/public/docs/_examples/toh-5/ts/index.html
@@ -18,7 +18,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/toh-6/ts/index.html
+++ b/public/docs/_examples/toh-6/ts/index.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-1-2-hybrid-bootstrap.html
+++ b/public/docs/_examples/upgrade-module/ts/index-1-2-hybrid-bootstrap.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-1-to-2-projection.html
+++ b/public/docs/_examples/upgrade-module/ts/index-1-to-2-projection.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-1-to-2-providers.html
+++ b/public/docs/_examples/upgrade-module/ts/index-1-to-2-providers.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-2-to-1-providers.html
+++ b/public/docs/_examples/upgrade-module/ts/index-2-to-1-providers.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-2-to-1-transclusion.html
+++ b/public/docs/_examples/upgrade-module/ts/index-2-to-1-transclusion.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-downgrade-io.html
+++ b/public/docs/_examples/upgrade-module/ts/index-downgrade-io.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-downgrade-static.html
+++ b/public/docs/_examples/upgrade-module/ts/index-downgrade-static.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-upgrade-io.html
+++ b/public/docs/_examples/upgrade-module/ts/index-upgrade-io.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-module/ts/index-upgrade-static.html
+++ b/public/docs/_examples/upgrade-module/ts/index-upgrade-static.html
@@ -12,7 +12,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/_examples/upgrade-phonecat-2-hybrid/ts/index.html
+++ b/public/docs/_examples/upgrade-phonecat-2-hybrid/ts/index.html
@@ -28,7 +28,6 @@
     <!-- #docregion ng2 -->
     <script src="/node_modules/core-js/client/shim.min.js"></script>
     <script src="/node_modules/zone.js/dist/zone.js"></script>
-    <script src="/node_modules/reflect-metadata/Reflect.js"></script>
     <script src="/node_modules/systemjs/dist/system.src.js"></script>
     <!-- #enddocregion ng2 -->
     <script src="/systemjs.config.1.js"></script>

--- a/public/docs/_examples/upgrade-phonecat-2-hybrid/ts/karma.conf.ng1.js
+++ b/public/docs/_examples/upgrade-phonecat-2-hybrid/ts/karma.conf.ng1.js
@@ -19,7 +19,6 @@ module.exports = function(config) {
 
       // Polyfills
       'node_modules/core-js/client/shim.js',
-      'node_modules/reflect-metadata/Reflect.js',
 
       // zone.js
       'node_modules/zone.js/dist/zone.js',

--- a/public/docs/_examples/upgrade-phonecat-3-final/ts/index.html
+++ b/public/docs/_examples/upgrade-phonecat-3-final/ts/index.html
@@ -13,7 +13,6 @@
 
     <script src="/node_modules/core-js/client/shim.min.js"></script>
     <script src="/node_modules/zone.js/dist/zone.js"></script>
-    <script src="/node_modules/reflect-metadata/Reflect.js"></script>
     <script src="/node_modules/systemjs/dist/system.src.js"></script>
     <!-- #enddocregion full -->
     <script src="/systemjs.config.1.js"></script>

--- a/public/docs/_examples/upgrade-phonecat-3-final/ts/karma.conf.ng1.js
+++ b/public/docs/_examples/upgrade-phonecat-3-final/ts/karma.conf.ng1.js
@@ -19,7 +19,6 @@ module.exports = function(config) {
 
       // Polyfills
       'node_modules/core-js/client/shim.js',
-      'node_modules/reflect-metadata/Reflect.js',
 
       // zone.js
       'node_modules/zone.js/dist/zone.js',

--- a/public/docs/_examples/user-input/ts/index.html
+++ b/public/docs/_examples/user-input/ts/index.html
@@ -11,7 +11,6 @@
     <script src="node_modules/core-js/client/shim.min.js"></script>
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
-    <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
 
     <script src="systemjs.config.js"></script>

--- a/public/docs/ts/latest/cookbook/aot-compiler.jade
+++ b/public/docs/ts/latest/cookbook/aot-compiler.jade
@@ -374,11 +374,11 @@ a#toh
 )
 
 :marked
-  The JIT version relies on `SystemJS` to load individual modules and requires the `reflect-metadata` shim. 
-  Both scripts appear in its `index.html`.
+  The JIT version relies on `SystemJS` to load individual modules. 
+  Its scripts appear in its `index.html`.
 
   The AOT version loads the entire application in a single script, `aot/dist/build.js`.
-  It does not need `SystemJS` or the `reflect-metadata` shim; those scripts are absent from its `index.html`
+  It does not need `SystemJS`, so that script is absent from its `index.html`
   
   ***main.ts***
   

--- a/public/docs/ts/latest/guide/npm-packages.jade
+++ b/public/docs/ts/latest/guide/npm-packages.jade
@@ -108,10 +108,6 @@ a(id="polyfills")
   ***core-js*** - Patches the global context (window) with essential features of ES2015 (ES6).
    You may substitute an alternative polyfill that provides the same core APIs. 
    When these APIs are implemented by the major browsers, this dependency will become unnecessary.
-
-  ***reflect-metadata*** - A dependency shared between Angular and the ***TypeScript compiler***. 
-  You can update a TypeScript package without upgrading Angular, 
-  which is why this is a dependency of the application and not a dependency of Angular.
   
   ***rxjs*** - A polyfill for the [Observables specification](https://github.com/zenparsing/es-observable) currently before the 
   [TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.

--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -61,11 +61,6 @@ var _rxData = [
   },
   {
     pattern: 'script',
-    from: 'node_modules/reflect-metadata/Reflect.js',
-    to:   'https://unpkg.com/reflect-metadata@0.1.8'
-  },
-  {
-    pattern: 'script',
     from: 'node_modules/rxjs/bundles/Rx.js',
     to:   'https://unpkg.com/rxjs@5.0.1/bundles/Rx.js'
   },


### PR DESCRIPTION
Blocked on https://github.com/angular/in-memory-web-api/pull/86
Should be merged together with https://github.com/angular/quickstart/pull/343.

As per https://github.com/zloirock/core-js/issues/152, `core-js` already includes `reflect-metadata`.

Close https://github.com/angular/angular.io/issues/1748

/cc @wardbell @Foxandxss 