### PR TITLE
docs(ngmodule-faq): fix typo

### DIFF
--- a/public/docs/ts/latest/cookbook/ngmodule-faq.jade
+++ b/public/docs/ts/latest/cookbook/ngmodule-faq.jade
@@ -1160,7 +1160,7 @@ table
         The router creates them and drops them into the DOM near a `<router-outlet>`.
 
         While the bootstrapped and routed components are _entry components_,
-        we usally don't have to add them to a module's `entryComponents` list.
+        we usually don't have to add them to a module's `entryComponents` list.
 
         Angular automatically adds components in the module's `bootstrap` list to the `entryComponents` list.
         The `RouterModule` adds routed components to that list.


### PR DESCRIPTION
This PR fixes a typo in the NgModule FAQ Cookbook.