### PR TITLE
docs(toh-5): fix typo

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -436,7 +436,7 @@ code-example(language="html").
   ### Parameterized route
 
   We *can* add the hero's `id` to the URL. When routing to the hero whose `id` is 11,
-  we could expect to see an URL such as this:
+  we could expect to see a URL such as this:
 
 code-example(format="nocode").
   /detail/11


### PR DESCRIPTION
This PR fixes a typo in the Tour of Heroes tutorial part 5.