### PR TITLE
docs(setup): note that `npm start` fails in Bash for Windows

### DIFF
--- a/public/docs/ts/latest/guide/setup.jade
+++ b/public/docs/ts/latest/guide/setup.jade
@@ -45,6 +45,10 @@ code-example(language="sh" class="code-shell").
   !{_npm} !{_install}
   !{_npm} !{_start}
 
+.alert.is-important
+  :marked
+    `npm start` fails in _Bash for Windows_ which does not support networking to servers as of January, 2017.
+
 a#download
 :marked
   ### Download
@@ -55,6 +59,10 @@ code-example(language="sh" class="code-shell").
   cd quickstart
   !{_npm} !{_install}
   !{_npm} !{_start}
+
+.alert.is-important
+  :marked
+    `npm start` fails in _Bash for Windows_ which does not support networking to servers as of January, 2017.
 
 .l-main-section#seed
 :marked


### PR DESCRIPTION
See issue raised in [QuickStart seed](https://github.com/angular/quickstart/issues/345#issuecomment-270025336).