### PR TITLE
docs(testing): karma.conf add slash appAssets

### DIFF
--- a/public/docs/_examples/testing/ts/karma.conf.js
+++ b/public/docs/_examples/testing/ts/karma.conf.js
@@ -1,9 +1,9 @@
 // #docregion
 module.exports = function(config) {
 
-  var appBase    = 'app/';      // transpiled app JS and map files
-  var appSrcBase = 'app/';      // app source TS files
-  var appAssets  = 'base/app/'; // component assets fetched by Angular's compiler
+  var appBase    = 'app/';       // transpiled app JS and map files
+  var appSrcBase = 'app/';       // app source TS files
+  var appAssets  = '/base/app/'; // component assets fetched by Angular's compiler
 
   // Testing helpers (optional) are conventionally in a folder called `testing`
   var testingBase    = 'testing/'; // transpiled test JS and map files


### PR DESCRIPTION
Add leading slash to appAssets variable
Discovered in issue https://github.com/angular/quickstart/issues/329