### PR TITLE
[WIP] chore(hierarchical-dependency-injection): Subscriber -> Observer

### DIFF
--- a/public/docs/_examples/hierarchical-dependency-injection/ts/app/heroes.service.ts
+++ b/public/docs/_examples/hierarchical-dependency-injection/ts/app/heroes.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
-import { Subscriber } from 'rxjs/Subscriber';
+import { Observer } from 'rxjs/Observer';
 
 import { Hero, HeroTaxReturn } from './hero';
 
@@ -18,30 +18,30 @@ export class HeroesService {
   ];
 
   getHeroes(): Observable<Hero[]> {
-    return new Observable<Hero[]>((subscriber: Subscriber<Hero[]>) => {
-      subscriber.next(this.heroes);
-      subscriber.complete();
+    return new Observable<Hero[]>((observer: Observer<Hero[]>) => {
+      observer.next(this.heroes);
+      observer.complete();
     });
   }
 
   getTaxReturn(hero: Hero): Observable<HeroTaxReturn> {
-    return new Observable<HeroTaxReturn>((subscriber: Subscriber<HeroTaxReturn>) => {
+    return new Observable<HeroTaxReturn>((observer: Observer<HeroTaxReturn>) => {
       const htr = this.heroTaxReturns.find(t => t.hero.id === hero.id);
-      subscriber.next(htr || new HeroTaxReturn(0, hero));
-      subscriber.complete();
+      observer.next(htr || new HeroTaxReturn(0, hero));
+      observer.complete();
     });
   }
 
   saveTaxReturn(heroTaxReturn: HeroTaxReturn): Observable<HeroTaxReturn> {
-    return new Observable<HeroTaxReturn>((subscriber: Subscriber<HeroTaxReturn>) => {
+    return new Observable<HeroTaxReturn>((observer: Observer<HeroTaxReturn>) => {
       const htr = this.heroTaxReturns.find(t => t.id === heroTaxReturn.id);
       if (htr) {
         heroTaxReturn = Object.assign(htr, heroTaxReturn); // demo: mutate
       } else {
         this.heroTaxReturns.push(heroTaxReturn);
       }
-      subscriber.next(heroTaxReturn);
-      subscriber.complete();
+      observer.next(heroTaxReturn);
+      observer.complete();
     });
   }
 }


### PR DESCRIPTION
**WIP - Do not merge until the question below has been answered**

Current `heroes.service.ts` code in the form of 
```
new Observable<Hero[]>((subscriber: Subscriber<Hero[]>) => {...}); // (1)
```
That conforms to the type of the parameter for [`Observable` constructor](https://github.com/blesh/RxJS/blob/master/src/Observable.ts#L33).

But it appears that [`Subscriber` isn't supposed to be used in "public API"](https://github.com/blesh/RxJS/blob/master/src/Subscriber.ts#L12)
and that the conventional thing to do (which works also) is to write.

```
new Observable<Hero[]>((observer: Observer<Hero[]>) => {...}); // (2)
```
I have asked those who know which is the preferred style ... (1) or (2) ... and if (2 ... as this PR would do), why is the arg to the ctor (and to the `create` method) typed as `Subscriber`? 