### PR TITLE
docs(ngmodule-faq): fix typo

### DIFF
--- a/public/docs/ts/latest/cookbook/ngmodule-faq.jade
+++ b/public/docs/ts/latest/cookbook/ngmodule-faq.jade
@@ -729,7 +729,7 @@ a#q-module-recommendations
   #### Feature Modules
   Create _Feature Modules_ around specific application business domains, user workflows, and utility collections.
 
-  Feature modules tend to fall into one of these four groups:
+  Feature modules tend to fall into one of these five groups:
     * [Domain Feature Modules](#domain-feature-module)
     * [Routed Feature Modules](#routed-feature-module)
     * [Routing Modules](#routing-module)


### PR DESCRIPTION
This PR fixes a typo in the NgModule FAQ Cookbook.