### PR TITLE
Improve instruction on including angular.png in webpack demo

### DIFF
--- a/public/docs/ts/latest/guide/webpack.jade
+++ b/public/docs/ts/latest/guide/webpack.jade
@@ -430,6 +430,7 @@ p.
   The <code>app.component.html</code> displays this downloadable Angular logo
   <a href="https://raw.githubusercontent.com/angular/angular.io/master/public/resources/images/logos/angular2/angular.png" target="_blank">
   <img src="/resources/images/logos/angular2/angular.png" height="40px" title="download Angular logo"></a>.
+  Create folder "images" under the project's "public" folder, then right-click and download the image to that folder.
 
 
 +makeTabs(


### PR DESCRIPTION
Instruction to create the necessary folder and download.  Current version only says "download" (not where) and only appears if you hover over the image, so it is not clear.