### PR TITLE
docs(toh6): fix span if-docs applied to multiple paragraphs

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt6.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt6.jade
@@ -401,6 +401,7 @@ block observables-section-intro
   It's easy with *!{_Observable}s* as we'll see.
 
   ### Search-by-name
+
   We're going to add a *hero search* feature to the Tour of Heroes.
   As the user types a name into a search box, we'll make repeated HTTP requests for heroes filtered by that name.
 
@@ -412,15 +413,17 @@ block observables-section-intro
   The `!{_priv}http.get()` call in `HeroSearchService` is similar to the one
   in the `HeroService`, although the URL now has a query string.
 
-  <span if-docs="ts">A more important difference: we no longer call `toPromise`.
-  Instead we return the *observable* from the the `htttp.get`, 
-  after chaining it to another RxJS operator, <code>map</code>, 
-  to extract heroes from the response data.
++ifDocsFor('ts')
+  :marked
+    A more important difference: we no longer call `toPromise`.
+    Instead we return the *observable* from the the `htttp.get`, 
+    after chaining it to another RxJS operator, <code>map</code>, 
+    to extract heroes from the response data.
 
-  RxJS operator chaining makes response processing easy and readable.
-  See the [discuss below about operators](#rxjs-imports).
-  </span>
+    RxJS operator chaining makes response processing easy and readable.
+    See the [discuss below about operators](#rxjs-imports).
 
+:marked
   ### HeroSearchComponent
 
   Let's create a new `HeroSearchComponent` that calls this new `HeroSearchService`.
@@ -513,6 +516,7 @@ block observable-transformers
   a#rxjs-imports
   :marked
     ### Import RxJS operators
+
     Most RxJS operators are not included in Angular's base `Observable` implementation.
     The base implementation includes only what Angular itself requires.
 


### PR DESCRIPTION
Fix: we can’t have a markdown `<span>` ranging over multiple paragraphs; instead we use the `+ifDocsFor()` mixin.

The text of the paragraphs in question wasn't changed, as can be seen by a look at the diff ignoring whitespace.

cc @kwalrath 