### PR TITLE
examples: consistently quote event binding expressions

### DIFF
--- a/public/docs/_examples/dependency-injection/ts/app/app.component.ts
+++ b/public/docs/_examples/dependency-injection/ts/app/app.component.ts
@@ -18,7 +18,7 @@ import { UserService } from './user.service';
     <h2>User</h2>
     <p id="user">
       {{userInfo}}
-      <button (click)='nextUser()'>Next User</button>
+      <button (click)="nextUser()">Next User</button>
     <p>
     <my-heroes id="authorized" *ngIf="isAuthorized"></my-heroes>
     <my-heroes id="unauthorized" *ngIf="!isAuthorized"></my-heroes>

--- a/public/docs/_examples/testing/ts/app/bag/bag.ts
+++ b/public/docs/_examples/testing/ts/app/bag/bag.ts
@@ -346,7 +346,7 @@ export class MyIfChildComponent implements OnInit, OnChanges, OnDestroy {
     <label>Parent value:
       <input [(ngModel)]="parentValue">
     </label>
-    <button (click)='clicked()'>{{toggleLabel}} Child</button><br>
+    <button (click)="clicked()">{{toggleLabel}} Child</button><br>
     <div *ngIf="showChild"
          style="margin: 4px; padding: 4px; background-color: aliceblue;">
       <my-if-child-1  [(value)]="parentValue"></my-if-child-1>

--- a/public/docs/_examples/user-input/ts/app/little-tour.component.ts
+++ b/public/docs/_examples/user-input/ts/app/little-tour.component.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
       (keyup.enter)="addHero(newHero.value)"
       (blur)="addHero(newHero.value); newHero.value='' ">
 
-    <button (click)=addHero(newHero.value)>Add</button>
+    <button (click)="addHero(newHero.value)">Add</button>
 
     <ul><li *ngFor="let hero of heroes">{{hero}}</li></ul>
   `


### PR DESCRIPTION
Note how the `user-input/ts/app/little-tour.component.ts` click binding had no quotes whatsoever.

Cf. https://github.com/dart-lang/site-webdev/issues/285

cc @kwalrath 