### PR TITLE
docs(pipes): fix link to api page w/ search box properly filled in

### DIFF
--- a/public/docs/ts/latest/guide/pipes.jade
+++ b/public/docs/ts/latest/guide/pipes.jade
@@ -56,7 +56,7 @@ block includes
 
 .l-sub-section
   :marked
-    Learn more about these and many other built-in pipes in the [API Reference](../api/#!?apiFilter=pipe);
+    Learn more about these and many other built-in pipes in the [API Reference](../api/#!?query=pipe);
     filter for entries that include the word "pipe".
 
     Angular doesn't have a `FilterPipe` or an `OrderByPipe` for reasons explained in an [appendix below](#no-filter-pipe).
@@ -103,7 +103,7 @@ figure.image-display
 
 .l-sub-section
   :marked
-    Learn more about the `DatePipes` format options in the [API Docs](../api/common/index/DatePipe-pipe.html).
+    Learn more about the `DatePipe` format options in the [API Docs](../api/common/index/DatePipe-pipe.html).
 
 :marked
   ## Chaining pipes
@@ -437,7 +437,7 @@ a#pure-pipe-pure-fn
   into our templates expressions to enrich the appeal and usability
   of our views.
 
-  Explore Angular's inventory of built-in pipes in the [API Reference](../api/#!?apiFilter=pipe).
+  Explore Angular's inventory of built-in pipes in the [API Reference](../api/#!?query=pipe).
   Try writing a custom pipe and perhaps contributing it to the community.
 
 a(id="no-filter-pipe")


### PR DESCRIPTION
The link to the API Reference page with the search box pre-filled with “pipe” wasn’t working anymore. This is because the API Reference search query parameter name is now `query` (it used to be `apiFilter`).

cc @kwalrath 