### PR TITLE
example(security): display video URL as plain text

### DIFF
--- a/public/docs/_examples/security/ts/app/bypass-security.component.html
+++ b/public/docs/_examples/security/ts/app/bypass-security.component.html
@@ -10,7 +10,7 @@
 
 <!--#docregion iframe -->
 <h4>Resource URL:</h4>
-<p><label>Showing: <input (input)="updateVideoUrl($event.target.value)"></label></p>
+<p>Showing: {{dangerousVideoUrl}}</p>
 <p>Trusted:</p>
 <iframe class="e2e-iframe-trusted-src" width="640" height="390" [src]="videoUrl"></iframe>
 <p>Untrusted:</p>


### PR DESCRIPTION
Simplify the example by just displaying the videoUrl (the string value of which is contained in `dangerousVideoUrl`). We don’t need the URL to be changeable anymore than we need the dangerousUrl to be editable.

cc @kwalrath 

Fixes #3121