### PR TITLE
docs(template-syntax): fix x event binding typo

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -848,7 +848,7 @@ block style-property-name-dart-diff
 
   Angular offers a special _two-way data binding_ syntax for this purpose, **`[(x)]`**.
   The `[(x)]` syntax combines the brackets 
-  of _property binding_, `[x]`, with the parentheses of _event binding_, `(x)`.
+  of _property binding_, `[x]`, with the parentheses of _event binding_, `(xChange)`.
 
 .callout.is-important
   header [( )] = banana in a box


### PR DESCRIPTION
(x) should be (xChanged)