### PR TITLE
docs(deployment): fix broken deployment nav link and ordering

### DIFF
--- a/public/docs/ts/latest/guide/_data.json
+++ b/public/docs/ts/latest/guide/_data.json
@@ -127,6 +127,11 @@
     "intro": "Learn how to apply CSS styles to components."
   },
 
+  "deployment": {
+    "title": "Deployment",
+    "intro": "Learn how to deploy your Angular app."
+  },
+
   "hierarchical-dependency-injection": {
     "title": "Hierarchical Dependency Injectors",
     "navTitle": "Hierarchical Injectors",
@@ -151,11 +156,6 @@
   "pipes": {
     "title": "Pipes",
     "intro": "Pipes transform displayed values within a template."
-  },
-
-  "production-deploy": {
-    "title": "Deployment",
-    "intro": "Learn how to deploy your Angular app."
   },
 
   "router": {


### PR DESCRIPTION
This pull request fixes an issue with the recent deployment guide docs (pull request #3043).

The changes to the relevant [_data.json](https://github.com/angular/angular.io/commit/8a537b122535f5f614a0123c23e89a2a40885228#diff-51333d74a1356c6bef2d5c03fb6cdf68R156) referenced `production-deploy`, while the jade template was named `deployment`. This pull request also updates the alphabetic ordering for the deployment guide in the navigation sidebar to reflect the "Deployment" title.