### PR TITLE
docs(router): fix Router.forRoot -> RouterModule.forRoot

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -113,7 +113,7 @@ include ../../../_includes/_see-addr-bar
 a#example-config
 :marked
   The `appRoutes` array of *routes* describes how to navigate.
-  Pass it to the `Router.forRoot` method in the module `imports` to configure the router.
+  Pass it to the `RouterModule.forRoot` method in the module `imports` to configure the router.
 
   Each `Route` maps a URL `path` to a component.
   There are _no leading slashes_ in the _path_. 


### PR DESCRIPTION
Fix error:

> The appRoutes array of routes describes how to navigate. 
Pass it to the **Router.forRoot** method in the module imports to configure the router.

To:
> The appRoutes array of routes describes how to navigate. 
Pass it to the **RouterModule.forRoot** method in the module imports to configure the router.