### PR TITLE
Fix typo in router.jade

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -1671,7 +1671,7 @@ a#relative-navigation
 +makeExcerpt('src/app/crisis-center/crisis-detail.component.ts (relative navigation)', 'gotoCrises-navigate')
 :marked
   Notice that the path goes up a level (`../`) syntax.
-  If the current crisis `id` is `1`, the resulting path back to the crisis list is  `/crisis-center/;id=3;foo=foo`.
+  If the current crisis `id` is `3`, the resulting path back to the crisis list is  `/crisis-center/;id=3;foo=foo`.
 
 a#named-outlets
 .l-main-section


### PR DESCRIPTION
I believe the current crisis id match the resulting path matrix notation