### PR TITLE
docs ts/latest/guide/attribute-directives fix typo

### DIFF
--- a/public/docs/ts/latest/guide/attribute-directives.jade
+++ b/public/docs/ts/latest/guide/attribute-directives.jade
@@ -169,7 +169,7 @@ a#respond-to-user
   and respond by setting or clearing the highlight color.
 
   Begin by adding `HostListener` to the list of imported symbols;
-  add the `Import` symbol as well because you'll need it soon.
+  add the `Input` symbol as well because you'll need it soon.
 +makeExample('attribute-directives/ts/src/app/highlight.directive.ts','imports')(format=".")
 
 :marked


### PR DESCRIPTION
Change `Import` to `Input` which is used in the example
```
import { Directive, ElementRef, HostListener, Input } from '@angular/core';
```