### PR TITLE
docs(webpack) missing commas in webpack snippet code

### DIFF
--- a/public/docs/_examples/webpack/ts-snippets/webpack.config.snippets.ts
+++ b/public/docs/_examples/webpack/ts-snippets/webpack.config.snippets.ts
@@ -34,11 +34,11 @@ output: {
 // #docregion loaders
 rules: [
   {
-    test: /\.ts$/
+    test: /\.ts$/,
     loader: 'awesome-typescript-loader'
   },
   {
-    test: /\.css$/
+    test: /\.css$/,
     loaders: 'style-loader!css-loader'
   }
 ]


### PR DESCRIPTION
Ref. https://angular.io/docs/ts/latest/guide/webpack.html#!#loaders