### PR TITLE
Update router.jade

### DIFF
--- a/public/docs/ts/latest/guide/router.jade
+++ b/public/docs/ts/latest/guide/router.jade
@@ -1941,7 +1941,7 @@ a#can-activate-guard
 
 .l-sub-section
   :marked
-    Since the admin dashboard `RouterLink` is an empty path route in the `AdminModule`, it
+    Since the admin dashboard `RouterLink` is an empty path route in the `AdminComponent`, it
     is considered a match to any route within the admin feature area. 
     You only want the `Dashboard` link to be active when the user visits that route. 
     Add an additional binding to the `Dashboard` routerLink,


### PR DESCRIPTION
docs: Router

Fix "Since the admin dashboard RouterLink is an empty path route in the AdminModule," ... "AdminModule" s/b "AdminComponent," AFICT.