### PR TITLE
Update dependency-injection.jade

### DIFF
--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -259,7 +259,7 @@ block register-provider-ngmodule
     We can either register a provider within an [NgModule](ngmodule.html) or in application components
 
     ### Registering providers in an NgModule
-    Here's our AppModule where we register a `Logger`, a `UserService`, and an `APP_CONFIG` provider.
+    Here's our AppModule where we register a `UserService` and an `APP_CONFIG` provider.
 
   - var app_module_ts = 'src/app/app.module.ts';
   +makeExcerpt(app_module_ts + ' (excerpt)', 'ngmodule', app_module_ts, { otl: /(providers:)/ })


### PR DESCRIPTION
docs: Dependency Injection

"Here's our AppModule where we register a `Logger`, a `UserService`, and an `APP_CONFIG` provider." No Logger appears to be registered in the source code.