### PR TITLE
docs - change-log - Fix i18n link in changelog

### DIFF
--- a/public/docs/ts/latest/guide/change-log.jade
+++ b/public/docs/ts/latest/guide/change-log.jade
@@ -67,7 +67,7 @@ block includes
   Linked to these plunkers in [Testing](testing.html#live-examples) and [Setup anatomy](setup-systemjs-anatomy) guides.
 
   ## Internationalization: pluralization and _select_ (2016-11-30)
-  The [Internationalization (i18n)](i18n.html) guide explains how to handle pluralization and
+  The [Internationalization (i18n)](../cookbook/i18n.html) guide explains how to handle pluralization and
   translation of alternative texts with `select`.
   The sample demonstrates these features too.
 


### PR DESCRIPTION
Link in changelog was pointing to old location of i18n docs (https://angular.io/docs/ts/latest/guide/i18n.html) instead of new one (https://angular.io/docs/ts/latest/cookbook/i18n.html)