### PR TITLE
Update the Angular CLI installation command

### DIFF
--- a/public/docs/ts/latest/cli-quickstart.jade
+++ b/public/docs/ts/latest/cli-quickstart.jade
@@ -40,7 +40,7 @@ h2#devenv Step 1. Set up the Development Environment
   Then **install the [Angular-CLI](https://github.com/angular/angular-cli)** globally.
   
 code-example(language="sh" class="code-shell").
-  npm install -g angular-cli
+  npm install -g @angular/cli
   
 .l-main-section
 h2#create-project Step 2. Create a new project


### PR DESCRIPTION
Updated the `cli-quickstart.jade` file to the new Angular CLI installation command:

```
npm install -g @angular/cli
```