### PR TITLE
chore: add systemjs.config.js back to plunkers

### DIFF
--- a/public/docs/_examples/setup/ts/quickstart-specs.plnkr.json
+++ b/public/docs/_examples/setup/ts/quickstart-specs.plnkr.json
@@ -9,6 +9,5 @@
   ],
   "main": "quickstart-specs.html",
   "open": "app/app.component.spec.ts",
-  "tags": ["quickstart", "setup", "testing"],
-  "includeSystemConfig": true
+  "tags": ["quickstart", "setup", "testing"]
 }

--- a/public/docs/_examples/testing/ts/1st-specs.plnkr.json
+++ b/public/docs/_examples/testing/ts/1st-specs.plnkr.json
@@ -10,6 +10,5 @@
   ],
   "main": "1st-specs.html",
   "open": "app/1st.spec.ts",
-  "tags": ["testing"],
-  "includeSystemConfig": true
+  "tags": ["testing"]
 }

--- a/public/docs/_examples/testing/ts/app-specs.plnkr.json
+++ b/public/docs/_examples/testing/ts/app-specs.plnkr.json
@@ -20,6 +20,5 @@
     "app-specs.html"
   ],
   "main": "app-specs.html",
-  "tags": ["testing"],
-  "includeSystemConfig": true
+  "tags": ["testing"]
 }

--- a/public/docs/_examples/testing/ts/bag-specs.plnkr.json
+++ b/public/docs/_examples/testing/ts/bag-specs.plnkr.json
@@ -17,6 +17,5 @@
     "bag-specs.html"
   ],
   "main": "bag-specs.html",
-  "tags": ["testing"],
-  "includeSystemConfig": true
+  "tags": ["testing"]
 }

--- a/public/docs/_examples/testing/ts/banner-inline-specs.plnkr.json
+++ b/public/docs/_examples/testing/ts/banner-inline-specs.plnkr.json
@@ -11,6 +11,5 @@
   ],
   "main": "banner-inline-specs.html",
   "open": "app/banner-inline.component.spec.ts",
-  "tags": ["testing"],
-  "includeSystemConfig": true
+  "tags": ["testing"]
 }

--- a/public/docs/_examples/testing/ts/banner-specs.plnkr.json
+++ b/public/docs/_examples/testing/ts/banner-specs.plnkr.json
@@ -13,6 +13,5 @@
   ],
   "main": "banner-specs.html",
   "open": "app/banner.component.spec.ts",
-  "tags": ["testing"],
-  "includeSystemConfig": true
+  "tags": ["testing"]
 }

--- a/tools/plunker-builder/builder.js
+++ b/tools/plunker-builder/builder.js
@@ -39,10 +39,8 @@ class PlunkerBuilder {
 
   _addPlunkerFiles(config, postData) {
     if (config.basePath.indexOf('/ts') > -1) {
-      if (config.includeSystemConfig) {
-        // uses systemjs.config.js so add plunker version
-        this.options.addField(postData, 'systemjs.config.js', this.systemjsConfig);
-      }
+      // uses systemjs.config.js so add plunker version
+      this.options.addField(postData, 'systemjs.config.js', this.systemjsConfig);
     }
   }
 

--- a/tools/plunker-builder/indexHtmlTranslator.js
+++ b/tools/plunker-builder/indexHtmlTranslator.js
@@ -19,10 +19,6 @@ var _rxRules = {
     from: '/<link rel="stylesheet" href=".*%tag%".*>/',
     to:    '<link rel="stylesheet" href="%tag%">'
   },
-  systemjs: {
-    from: /<script src="systemjs.config.js"><\/script>/,
-    to:   '<script src="https://cdn.rawgit.com/angular/angular.io/b3c65a9/public/docs/_examples/_boilerplate/systemjs.config.web.js"></script>'
-  },
   // Clear script like this:
   // <script>
   //   System.import('app').catch(function(err){ console.error(err); });
@@ -105,9 +101,6 @@ var _rxData = [
   },
   {
     pattern: 'zone_pkg',
-  },
-  {
-    pattern: 'systemjs',
   },
   // {
   //   pattern: 'system_strip_import_app',


### PR DESCRIPTION
The part where we hide some `System.import` are still in place.