### PR TITLE
Update template-syntax.jade

### DIFF
--- a/public/docs/ts/latest/guide/template-syntax.jade
+++ b/public/docs/ts/latest/guide/template-syntax.jade
@@ -848,16 +848,11 @@ a#event-binding
   Consider this example:
 +makeExample('template-syntax/ts/src/app/app.component.html', 'without-NgModel')(format=".")
 
-.alert.is-critical
-  :marked
-    Ward: `firstName` appears here (below) for the first time without any mention it was coming and isn't in the 
-    code sample. Do we mean `name` instead?
-
 :marked
-  This code sets the input box `value` property by binding to the `firstName` property. To listen for changes to the value, the code binds to the input box's `input` event.
+  This code sets the input box `value` property by binding to the `name` property. To listen for changes to the value, the code binds to the input box's `input` event.
   When the user makes changes, the `input` event is raised, and the binding executes the statement within a context that includes the DOM event object, `$event`.
 
-  To update the `firstName` property, the changed text is retrieved by following the path `$event.target.value`.
+  To update the `name` property, the changed text is retrieved by following the path `$event.target.value`.
 
   If the event belongs to a directive (recall that components are directives), `$event` has whatever shape the directive decides to produce.
 
@@ -1416,7 +1411,7 @@ a#ref-var
 
   In most cases, Angular sets the reference variable's value to the element on which it was declared.
   In the previous example, `phone` refers to the _phone number_ `<input>` box.
-  The phone button click handler passes the _input_ value to the component's `phoneCall` method.
+  The phone button click handler passes the _input_ value to the component's `callPhone` method.
   But a directive can change that behavior and set the value to something else, such as itself.
   The `NgForm` directive does that.
 


### PR DESCRIPTION
docs: Template Syntax

Remove call-out to author (these should all be removed and issued as PRs, I think) and update code-referenced property "name" (not "firstName"). Also fix mis-named "phoneCall" method reference (s/b "callPhone").