### PR TITLE
docs(dependency-injection): fix html space

### DIFF
--- a/public/docs/_examples/dependency-injection/ts/src/app/heroes/hero.service.provider.ts
+++ b/public/docs/_examples/dependency-injection/ts/src/app/heroes/hero.service.provider.ts
@@ -12,7 +12,7 @@ let heroServiceFactory = (logger: Logger, userService: UserService) => {
 
 // #docregion provider
 export let heroServiceProvider =
-  { provide: HeroService,
+  { provide: HeroService,
     useFactory: heroServiceFactory,
     deps: [Logger, UserService]
   };


### PR DESCRIPTION
So it wasn't a real space what we had, now we do. The interesting thing is that plunker complains but `tsc` doesn't.

Fixes #3228 