### PR TITLE
chore: lock jasmine types

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -38,7 +38,7 @@
     "@types/angular-resource": "^1.5.6",
     "@types/angular-route": "^1.3.2",
     "@types/angular-sanitize": "^1.3.3",
-    "@types/jasmine": "~2.5.36",
+    "@types/jasmine": "2.5.36",
     "@types/node": "^6.0.45",
     "angular-cli": "^1.0.0-beta.26",
     "angular2-template-loader": "^0.6.0",


### PR DESCRIPTION
Latest types requires Typescript 2.1 which we don't use yet.

This fixes the travis build.