### PR TITLE
docs(upgrade): Fix typos in AngularJS versions (1.5 and 1.x)

### DIFF
--- a/public/docs/ts/latest/guide/upgrade.jade
+++ b/public/docs/ts/latest/guide/upgrade.jade
@@ -188,7 +188,7 @@ include ../_util-fns
 +makeExample('upgrade-module/ts/src/app/hero-detail.directive.ts')
 
 :marked
-  AngularJS.5 introduces the [component API](https://docs.angularjs.org/api/ng/type/angular.Module)
+  AngularJS 1.5 introduces the [component API](https://docs.angularjs.org/api/ng/type/angular.Module)
   that makes it easier to define directives like these. It is a good idea to use
   this API for component directives for several reasons:
 
@@ -203,7 +203,7 @@ include ../_util-fns
 
 :marked
   Controller lifecycle hook methods `$onInit()`, `$onDestroy()`, and `$onChanges()`
-  are another convenient feature that AngularJS.5 introduces. They all have nearly
+  are another convenient feature that AngularJS 1.5 introduces. They all have nearly
   exact [equivalents in Angular](lifecycle-hooks.html), so organizing component lifecycle
   logic around them will ease the eventual Angular upgrade process.
 
@@ -571,7 +571,7 @@ figure
   [described in the preparation guide above](#using-component-directives).
   Our safest bet for ensuring compatibility is using the
   [component API](https://docs.angularjs.org/api/ng/type/angular.Module)
-  introduced in AngularJS.5.
+  introduced in AngularJS 1.5.
 
   A simple example of an upgradable component is one that just has a template
   and a controller:
@@ -846,7 +846,7 @@ figure
       .file scenarios.js
 
 :marked
-  This is actually a pretty good starting point. The code uses the AngularJS.5
+  This is actually a pretty good starting point. The code uses the AngularJS 1.5
   component API and the organization follows the
   [AngularJS Style Guide](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md),
   which is an important [preparation step](#following-the-angular-style-guide) before
@@ -959,9 +959,9 @@ code-example(format="").
 
 .l-sub-section
   :marked
-    The [AngularJS.x type definitions](https://www.npmjs.com/package/@types/angular)
+    The [AngularJS 1.x type definitions](https://www.npmjs.com/package/@types/angular)
     we installed are not officially maintained by the Angular team,
-    but are quite comprehensive. It is possible to make an AngularJS.x application
+    but are quite comprehensive. It is possible to make an AngularJS 1.x application
     fully type-annotated with the help of these definitions.
 
     If this is something we wanted to do, it would be a good idea to enable
@@ -1111,7 +1111,7 @@ code-example(format="").
 
 :marked
   The arguments used here are the root element of the application (which is
-  the same element we had `ng-app` on earlier), and the AngularJS.x modules
+  the same element we had `ng-app` on earlier), and the AngularJS 1.x modules
   that we want to load. Since we're bootstrapping the app through
   an `UpgradeModule`, we're actually now running the app as a **hybrid app**.
 


### PR DESCRIPTION
Upgrade guide has an incorrect AngularJS versions in it:
- `AngularJS.x` instead of `AngularJS 1.x`
- `AngularJS.5` instead of `AngularJS 1.5`
