### PR TITLE
Fixes issue #3242 - Contradiction in "HIERARCHICAL DEPENDENCY INJECOTRS" Section

### DIFF
--- a/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
@@ -22,8 +22,10 @@ block includes
 
   In fact, there is no such thing as *the* injector.
   An application may have multiple injectors.
-  An Angular application is a tree of components. Each component instance has its own injector!
-  The tree of components parallels the tree of injectors.
+  An angular application is a tree of components with each component instance containing it's own injector
+  when the `providers' array within the `@Component` annotation is non-null.  
+  Since this tree of components parallels the tree of injectors, the association between 
+  injectors and components can be thought of as symmetric.
 
 :marked
   Consider this guide's variation on the Tour of Heroes application.
@@ -37,13 +39,12 @@ figure.image-display
   img(src="/resources/images/devguide/dependency-injection/component-hierarchy.png" alt="injector tree" width="600")
 
 :marked
-  Angular doesn't actually _create_ a separate injector for each component.
-  Every component doesn't need its own injector and it would be horribly inefficient to create
-  masses of injectors for no good purpose.
-
-  But every component _has an injector_, even if it shares that injector with another component or with the injector of the root `AppModule`.
-  And there _may_ be multiple injector instances operating at different levels of the component tree 
-  depending upon how the developer registers providers, which is the subject of this guide.
+  Although every component _has an injector_, Angular creates a separate injector for components only if the 
+  `providers` array within the `@Component` decorator is non-null.  If no `providers` are specified in the 
+  `@Component` decorator, the component does not need it's own injector so a new one is not created. Instead, 
+  it shares an injector with another component or with the injector of the root `AppModule`.
+  As a result, there _may_ be multiple injector instances operating at different levels of the component tree 
+  depending upon how the developer registers providers. The subject of this guide covers this topic in greater detail.
 
   ### Injector bubbling  
 


### PR DESCRIPTION
This PR provides a fix for issue #3242 based on the following changes:

1. Fixes improper sentence structure.
2. Revises language to prevent starting a paragraph with "But".
3. Revises language to prevent placing the predicate before the subject in a non-question format.
4. Removes the contradictory language regarding "injectors".
5. Provides better clarity and sentence flow.
6. Reinforces the subject to the reader.