### PR TITLE
docs(hierarchical-di): clarify that component injector may be a proxy

### DIFF
--- a/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
@@ -20,10 +20,17 @@ block includes
   In the [Dependency Injection](./dependency-injection.html) guide,
   you learned how to configure a dependency injector and how to retrieve dependencies where you need them.
 
-  In fact, there is no such thing as *the* injector.
+  In fact, there is no such thing as ***the*** injector.
   An application may have multiple injectors.
-  An Angular application is a tree of components. Each component instance has its own injector!
+  An Angular application is a tree of components. Each component instance has its own injector.
   The tree of components parallels the tree of injectors.
+
+.l-sub-section
+ :marked
+   The component's injector may be a _proxy_ for an ancestor injector higher in the component tree.
+   That's an implementation detail that improves efficiency.
+   You won't notice the difference and
+   your mental model should be that every component has its own injector.
 
 :marked
   Consider this guide's variation on the Tour of Heroes application.
@@ -37,14 +44,6 @@ figure.image-display
   img(src="/resources/images/devguide/dependency-injection/component-hierarchy.png" alt="injector tree" width="600")
 
 :marked
-  Angular doesn't actually _create_ a separate injector for each component.
-  Every component doesn't need its own injector and it would be horribly inefficient to create
-  masses of injectors for no good purpose.
-
-  But every component _has an injector_, even if it shares that injector with another component or with the injector of the root `AppModule`.
-  And there _may_ be multiple injector instances operating at different levels of the component tree 
-  depending upon how the developer registers providers, which is the subject of this guide.
-
   ### Injector bubbling  
 
   When a component requests a dependency, Angular tries to satisfy that dependency with a provider registered in that component's own injector.


### PR DESCRIPTION
closes #3242 and #3246