### PR TITLE
Removed a typo.

### DIFF
--- a/public/docs/js/latest/quickstart.jade
+++ b/public/docs/js/latest/quickstart.jade
@@ -7,7 +7,7 @@ include _util-fns
   header Don't want JavaScript?
   :marked
     Although we're getting started in JavaScript, you can also write Angular apps
-    in TypeScript and Dart by selecting either of those languages from the combo-box in the banner.
+    in TypeScript by selecting it from the combo-box in the banner.
 
 .l-main-section
 :marked


### PR DESCRIPTION
There was a typo in the docs, telling that you can also use dart language from the combo box while there was no docs for dart in combo-box.