### PR TITLE
docs(di): fix broken link to ngmodules faq

### DIFF
--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -289,7 +289,7 @@ block ngmodule-vs-component
 
   .l-sub-section
     :marked
-     Also see *"Should I add app-wide providers to the root `AppModule` or the root `AppComponent`?"* in the [NgModule FAQ](../cookbook/ngmodule-faq.html#root-component-or-module).
+     Also see *"Should I add app-wide providers to the root `AppModule` or the root `AppComponent`?"* in the [NgModule FAQ](../cookbook/ngmodule-faq.html#q-root-component-or-module).
 
 :marked
   ### Preparing the HeroListComponent for injection


### PR DESCRIPTION
There is a broken link in the [dependency injection guide](https://angular.io/docs/ts/latest/guide/dependency-injection.html), pointing to the [ngModule FAQ](https://angular.io/docs/ts/latest/cookbook/ngmodule-faq.html#!#q-root-component-or-module)