### PR TITLE
docs(di): reference the correct component

### DIFF
--- a/public/docs/ts/latest/cookbook/dependency-injection.jade
+++ b/public/docs/ts/latest/cookbook/dependency-injection.jade
@@ -740,7 +740,7 @@ a(id='alex')
   The parent must cooperate by providing an *alias* to itself in the name of a *class-interface* token. 
 
   Recall that Angular always adds a component instance to its own injector; 
-  that's why we could inject *Alex* into *Carol* [earlier](#known-parent).
+  that's why we could inject *Alex* into *Cathy* [earlier](#known-parent).
 
   We write an [*alias provider*](#useexisting) &mdash; a `provide` object literal with a `useExisting` definition &mdash;
   that creates an *alternative* way to inject the same component instance


### PR DESCRIPTION
In the referenced section the Alex component is being injected into Cathy, not Carol.