### PR TITLE
docs(toh-5): copyedit + add callout to importance of base href

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -168,6 +168,21 @@ block angular-router
     and a configuration (`Routes`). We'll configure our routes first.
 
 :marked
+  ### *&lt;base href>*
+
+  Open `index.html` and ensure there is a `<base href="...">` element
+  (or a script that dynamically sets this element)
+  at the top of the `<head>` section.
+
++makeExcerpt('src/index.html', 'base-href')
+
+.callout.is-important
+  header base href is essential
+  :marked
+    See the *base href* section of the [router](../guide/router.html#base-href)
+    guide to learn why this matters, and what to add if the `base`
+    element is missing.
+
 a#configure-routes
 block router-config-intro
   :marked
@@ -599,7 +614,7 @@ block extract-id
   When hovering over a hero block, the target URL should display in the browser status bar 
   and the user should be able to copy the link or open the hero detail view in a new tab.
 
-  To achieve this effect, reopen the `dashboard.component.html` and replace the repeated `<div *ngFor...>` tags
+  To achieve this effect, reopen the <span ngio-ex>dashboard.component.html</span> and replace the repeated `<div *ngFor...>` tags
   with `<a>` tags. The opening `<a>` tag looks like this:
 
 +makeExample('src/app/dashboard.component.html', 'click', 'src/app/dashboard.component.html (repeated <a> tag)')


### PR DESCRIPTION
@wardbell - I realize that all the doc example code now has a `<base href>` from the start. We're also doing that on the Dart side of the docs. But currently there is **_no_ mention of `<base href>` in the tutorial routing page**. Yet this element is so central to routing that there should at least be a brief mention of it, if only to point to the Routing guide.

This PR adds a line and a callout for `<base href>`.
It also fixes a path issue.

cc @kwalrath 

Here is the addition:
> ![screen shot 2017-02-20 at 9 57 36 am](https://cloud.githubusercontent.com/assets/4140793/23136775/1f022374-f753-11e6-937f-239271f06c8f.png)
