### PR TITLE
Fix build for webpack example

### DIFF
--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -79,7 +79,7 @@
     "style-loader": "^0.13.1",
     "ts-node": "^1.3.0",
     "tslint": "^3.15.1",
-    "typescript": "~2.0.10",
+    "typescript": "^2.0.0",
     "webpack": "2.2.0",
     "webpack-dev-server": "2.2.0-rc.0",
     "webpack-merge": "^2.4.0"

--- a/public/docs/_examples/package.json
+++ b/public/docs/_examples/package.json
@@ -79,7 +79,7 @@
     "style-loader": "^0.13.1",
     "ts-node": "^1.3.0",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.0",
+    "typescript": "~2.0.10",
     "webpack": "2.2.0",
     "webpack-dev-server": "2.2.0-rc.0",
     "webpack-merge": "^2.4.0"

--- a/public/docs/_examples/webpack/ts/config/webpack.common.js
+++ b/public/docs/_examples/webpack/ts/config/webpack.common.js
@@ -24,10 +24,7 @@ module.exports = {
     rules: [
       {
         test: /\.ts$/,
-        loaders: [{
-          loader: 'awesome-typescript-loader',
-          options: { configFileName: helpers.root('src', 'tsconfig.json') }
-        } , 'angular2-template-loader']
+        loaders: ['awesome-typescript-loader', 'angular2-template-loader']
       },
       {
         test: /\.html$/,

--- a/public/docs/_examples/webpack/ts/package.webpack.json
+++ b/public/docs/_examples/webpack/ts/package.webpack.json
@@ -42,7 +42,7 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
-    "typescript": "~2.0.10",
+    "typescript": "^2.0.0",
     "webpack": "2.2.0",
     "webpack-dev-server": "2.2.0-rc.0",
     "webpack-merge": "^2.4.0"


### PR DESCRIPTION
The webpack example needs to use a newer Typescript compiler and point to the default location for tsconfig.json file in order to build. Right now it's failing with:

    Error in bail mode: [at-loader] node_modules/@types/jasmine/index.d.ts:39:52
    TS1005: '=' expected.

And

    Error in bail mode: [at-loader] node_modules/@angular/common/src/directives/ng_class.d.ts:48:34
    TS2304: Cannot find name 'Set'.