### PR TITLE
docs(upgrade): Fix 'resulit' typo

### DIFF
--- a/public/docs/ts/latest/guide/upgrade.jade
+++ b/public/docs/ts/latest/guide/upgrade.jade
@@ -504,7 +504,7 @@ figure
     All Angular components, directives and pipes must be declared in an NgModule.
 
 :marked
-  The net resulit is an AngularJS directive called `heroDetail`, that we can
+  The net result is an AngularJS directive called `heroDetail`, that we can
   use like any other directive in our AngularJS templates.
 
 +makeExample('upgrade-module/ts/src/index-downgrade-static.html', 'usecomponent')


### PR DESCRIPTION
Fixes small 'resulit' typo in component downgrade section