### PR TITLE
doc(pipes): copyedit and removed Jade block used for Dart

### DIFF
--- a/public/docs/ts/latest/guide/learning-angular.jade
+++ b/public/docs/ts/latest/guide/learning-angular.jade
@@ -11,14 +11,14 @@ figure
 
   1. [Setup](setup.html "Setup locally withe Quickstart seed") for local Angular development, if you haven't already done so.
 
-  1. Take the [*Tour of Heroes* tutorial](../tutorial "Tour of Heroes"). 
-  
+  1. Take the [*Tour of Heroes* tutorial](../tutorial "Tour of Heroes").
+
     The *Tour of Heroes* takes you step-by-step from [setup](setup.html)
     to a full-featured example that demonstrates the essential characteristics of a professional application:
     a sensible project structure, data binding, master/detail, services, dependency injection, navigation, and remote data access.
 
   1. <a id="architecture"></a>Read the [Architecture](architecture.html) overview for the big picture.
-  
+
   1. [The Root Module](appmodule.html) introduces the `NgModule` class that tells Angular how to compile and run your application.
 
   1. [Displaying Data](displaying-data.html) shows how data binding puts component property values on screen.
@@ -38,5 +38,5 @@ figure
   :marked
     ### Next Step
 
-    Try the [tutorial](../tutorial "Tour of Heroes") if you're ready to start coding or 
+    Try the [tutorial](../tutorial "Tour of Heroes") if you're ready to start coding or
     visit the [Architecture](architecture.html "Basic Concepts") page if you prefer to learn the basic concepts first.

--- a/public/docs/ts/latest/guide/pipes.jade
+++ b/public/docs/ts/latest/guide/pipes.jade
@@ -197,7 +197,7 @@ a#change-detection
 :marked
   ## Pipes and change detection
 
-  Angular looks for changes to data-bound values through a *change detection* process that runs after every JavaScript event:
+  Angular looks for changes to data-bound values through a *change detection* process that runs after every DOM event:
   every keystroke, mouse move, timer tick, and server response. This could be expensive.
   Angular strives to lower the cost whenever possible and appropriate.
 
@@ -284,13 +284,10 @@ figure.image-display
 
   ### Pure pipes
 
-block pure-change
-  :marked
-    Angular executes a *pure pipe* only when it detects a *pure change* to the input value.
-    A pure change is either a change to a primitive input value (`String`, `Number`, `Boolean`, `Symbol`)
-    or a changed object reference (`Date`, `Array`, `Function`, `Object`).
+  Angular executes a *pure pipe* only when it detects a *pure change* to the input value.
+  A pure change is either a change to a primitive input value (`String`, `Number`, `Boolean`, `Symbol`)
+  or a changed object reference (`Date`, `Array`, `Function`, `Object`).
 
-:marked
   Angular ignores changes within (composite) objects.
   It won't call a pure pipe if you change an input month, add to an input #{_array}, or update an input object property.
 


### PR DESCRIPTION
- JS event --> DOM event
- The Jade block isn't used by Dart anymore.
- In `learning-angular.jade`, removed trailing whitespace.

cc @kwalrath 