### PR TITLE
docs(glossary): Pipes entry update - custom pipes are not functions

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -518,16 +518,15 @@ a#N
 .l-sub-section
   :marked
     An Angular pipe is a function that transforms input values to output values for
-    display in a [view](#view). Use the `!{_at}Pipe` !{_decoratorLink}
-    to associate the pipe function with a name. You then use that
-    name in your HTML to declaratively transform values on screen.
-
+    display in a [view](#view).
     Here's an example that uses the built-in `currency` pipe to display
     a numeric value in the local currency.
 
   code-example(language="html" escape="html").
     <label>Price: </label>{{product.price | currency}}
+
   :marked
+    You can also write your own custom pipes.
     Read more in the page on [pipes](!{docsLatest}/guide/pipes.html).
 
 :marked


### PR DESCRIPTION
Change Pipe glossary entry; it  used to suggested that one could implemented a custom pipe by annotating a function with `@Pipe`.

Cf. https://github.com/dart-lang/site-webdev/pull/415

cc @kwalrath 