### PR TITLE
fix(toh-6): update search result styling

### DIFF
--- a/public/docs/_examples/toh-6/ts/src/app/hero-search.component.css
+++ b/public/docs/_examples/toh-6/ts/src/app/hero-search.component.css
@@ -4,10 +4,15 @@
   border-left: 1px solid gray;
   border-right: 1px solid gray;
   width:195px;
-  height: 20px;
+  height: 16px;
   padding: 5px;
   background-color: white;
   cursor: pointer;
+}
+
+.search-result:hover {
+  color: #eee;
+  background-color: #607D8B;
 }
 
 #search-box{


### PR DESCRIPTION
Change the height of the search results so that the height of each
places the text inside directly in the middle.

Apply a styling similar to the dashboard's heroes when hovering
over a search result.