### PR TITLE
fix(zipper): add ‘use strict’ to exampleZipper.js

### DIFF
--- a/tools/example-zipper/exampleZipper.js
+++ b/tools/example-zipper/exampleZipper.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Canonical path provides a consistent path (i.e. always forward slashes) across different OSes
 var path = require('canonical-path');
 var jsonfile = require('jsonfile');


### PR DESCRIPTION
To beat error “SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode”. 