### PR TITLE
docs(browser-support): copy edits

### DIFF
--- a/public/docs/ts/latest/guide/browser-support.jade
+++ b/public/docs/ts/latest/guide/browser-support.jade
@@ -64,18 +64,18 @@ table
   Angular is built on the latest standards of the web platform.
   Targeting such a wide range of browsers is challenging because they do not support all features of modern browsers.
   
-  You compensate by loading polyfill scripts ("polyfills") on the host web page (`index.html`)
+  You can compensate by loading polyfill scripts ("polyfills") on the host web page (`index.html`)
   that implement missing features in JavaScript.
 +makeExample('quickstart/ts/src/index.html', 'polyfills')(format='.')
 :marked
   A particular browser may require at least one polyfill to run _any_ Angular application. 
   You may need additional polyfills for specific features.
 
-  The tables below will help you determine which polyfills to load, depending on the browsers you target and the features you use.
+  The tables below can help you determine which polyfills to load, depending on the browsers you target and the features you use.
   
 .alert.is-important
   :marked
-    The suggested polyfills are the ones we know will run full Angular applications.
+    The suggested polyfills are the ones that run full Angular applications.
     You may need additional polyfills to support features not covered by this list.
     Note that polyfills cannot magically transform an old, slow browser into a modern, fast one.
   
@@ -161,7 +161,7 @@ table
 table
   tr
     th Polyfill
-    th Licence
+    th License
     th Size*
   tr
     td
@@ -176,7 +176,7 @@ table
   tr
     td
      a#intl(href="https://github.com/andyearnshaw/Intl.js" target="_blank") Intl
-    td MIT / Unicode licence
+    td MIT / Unicode license
     td 13.5KB
   tr
     td 
@@ -200,4 +200,5 @@ table
     td 0.4KB
 
 :marked
-  \* Figures are for minified and gzipped code, computed with the <a href="http://closure-compiler.appspot.com/home" target="_blank">closure compiler</a>
+  \* Figures are for minified and gzipped code, 
+  computed with the <a href="http://closure-compiler.appspot.com/home" target="_blank">closure compiler</a>.


### PR DESCRIPTION
Copy edits to apply guidelines. Changed "licence" to "license" because the styles and spelling throughout docs are standard American. Happy to revert if "licence" is the preference.