### PR TITLE
docs(cookbook-overview): copy edits

### DIFF
--- a/public/docs/ts/latest/cookbook/index.jade
+++ b/public/docs/ts/latest/cookbook/index.jade
@@ -1,28 +1,30 @@
-include ../_util-fns 
+include ../_util-fns
 
 :marked
   The *Cookbook* offers answers to common implementation questions.
-  
-  Each cookbook chapter is a collection of recipes focused on a particular Angular feature or application challenge
+
+  Each cookbook page is a collection of recipes focused on a particular Angular feature or application challenge
   such as data binding, cross-component interaction, and communicating with a remote server via HTTP.
-  
+
 .l-sub-section
   :marked
     The cookbook is just getting started. Many more recipes are on the way.
 
 :marked
-  Each cookbook chapter links to a live sample with every recipe included.
-  
-  Recipes are deliberately brief and code-centric. 
-  Each recipe links to a chapter of the Developer Guide or the API Guide
-  where you can learn more about the purpose, context, and design choices behind the code snippets.
-  
+  Each cookbook links to a live sample with every recipe included.
+
+  Recipes are deliberately brief and code-centric.
+  Each recipe links to a relevant page of the [Developer Guide](../guide) or the
+  [API Reference](../api) where you can learn more about
+  the purpose, context, and design choices behind the code snippets.
+
   ## Feedback
-    
-  The cookbook is a perpetual *work-in-progress*. 
-  We welcome feedback! Leave a comment by clicking the icon in upper right corner of the banner.
-  
-  Post *documentation* issues and pull requests on the 
-  [angular.io](https://github.com/angular/angular.io) github repository.
-  
+
+  Post *documentation* requests and comments as
+  <a href="https://github.com/angular/angular.io/issues" target="_blank" title="Documentation issues on github">
+  <i>issues</i> on the angular.io</a> github repository.
+  Fixes (small ones) are greatly appreciated as
+  <a href="https://github.com/angular/angular.io/pulls" target="_blank" title="Documentation PRs on github">
+  <i>pull requests</i></a>.
+
   Post issues with *Angular itself* to the [angular](https://github.com/angular/angular) github repository.


### PR DESCRIPTION
Applying guidelines to Cookbook Overview. Removed sentence about icon in upper right of banner since it isn't there.