### PR TITLE
improvement(guide:structural-directives): add links to source

### DIFF
--- a/public/docs/ts/latest/guide/structural-directives.jade
+++ b/public/docs/ts/latest/guide/structural-directives.jade
@@ -254,7 +254,10 @@ a#microsyntax
   describes additional `NgFor` directive properties and context properties.
 
   These microsyntax mechanisms are available to you when you write your own structural directives.
-  Studying the source code for `NgIf` and `NgFor` is a great way to learn more.
+  Studying the 
+  [source code for `NgIf`](https://github.com/angular/angular/blob/master/packages/common/src/directives/ng_if.ts "Source: NgIf")
+  and [`NgFor`](https://github.com/angular/angular/blob/master/packages/common/src/directives/ng_for_of.ts "Source: NgFor") 
+  is a great way to learn more.
 
 
 a#template-input-variable


### PR DESCRIPTION
Guide suggests reading *ngIf* and *ngFor* sources. They are linked to github now.