### PR TITLE
e2e(router): fix test for canceling of crisis detail change

### DIFF
--- a/public/docs/_examples/template-syntax/ts/src/app/app.component.ts
+++ b/public/docs/_examples/template-syntax/ts/src/app/app.component.ts
@@ -5,11 +5,6 @@ import { AfterViewInit, Component, ElementRef, OnInit, QueryList, ViewChildren }
 
 import { Hero } from './hero';
 
-// Alerter fn: monkey patch during test
-export function alerter(msg?: string) {
-  window.alert(msg);
-}
-
 export enum Color {Red, Green, Blue};
 
 /**
@@ -38,13 +33,13 @@ export class AppComponent implements AfterViewInit, OnInit {
   @ViewChildren('withTrackBy') heroesWithTrackBy: QueryList<ElementRef>;
 
   actionName = 'Go for it';
-  alert = alerter;
   badCurly = 'bad curly';
   classes = 'special';
   help = '';
 
-  callFax(value: string)   {this.alert(`Faxing ${value} ...`); }
-  callPhone(value: string) {this.alert(`Calling ${value} ...`); }
+  alert(msg?: string)      { window.alert(msg); }
+  callFax(value: string)   { this.alert(`Faxing ${value} ...`); }
+  callPhone(value: string) { this.alert(`Calling ${value} ...`); }
   canSave =  true;
 
   changeIds() {


### PR DESCRIPTION
- Await for alert dialog and use it in test for canceling crisis detail change.
- Tests now use async/await. It makes them easier to read.
- Remove "monkey patch" alerter comment.