### PR TITLE
chore: fix moduleId loader on plunkers

### DIFF
--- a/public/docs/_examples/_boilerplate/src/systemjs-angular-loader.js
+++ b/public/docs/_examples/_boilerplate/src/systemjs-angular-loader.js
@@ -8,13 +8,13 @@ module.exports.translate = function(load){
 
   var basePathParts = url.pathname.split('/');
 
-  if (url.href.indexOf('plnkr') != -1) {
-    basePathParts.shift();
-    basePathParts.shift();
-  }
-
   basePathParts.pop();
   var basePath = basePathParts.join('/');
+
+  var baseHref = new URL(this.baseURL).pathname;
+
+  basePath = basePath.replace(baseHref, '');
+
   load.source = load.source
     .replace(templateUrlRegex, function(match, quote, url){
       let resolvedUrl = url;
@@ -30,7 +30,7 @@ module.exports.translate = function(load){
 
       while ((match = stringRegex.exec(relativeUrls)) !== null) {
         if (match[2].startsWith('.')) {
-          urls.push(`'${basePath.substr(1)}${match[2].substr(1)}'`);
+          urls.push(`'${basePath}${match[2].substr(1)}'`);
         } else {
           urls.push(`'${match[2]}'`);
         }

--- a/public/docs/_examples/_boilerplate/src/systemjs.config.web.build.js
+++ b/public/docs/_examples/_boilerplate/src/systemjs.config.web.build.js
@@ -34,7 +34,6 @@
     },
     // map tells the System loader where to look for things
     map: {
-      'ng-loader': './systemjs-angular-loader.js',
       // our app is within the app folder
       'app': 'app',
 
@@ -75,7 +74,7 @@
         defaultExtension: 'ts',
         meta: {
           './*.ts': {
-            loader: 'ng-loader'
+            loader: 'systemjs-angular-loader.js'
           }
         }
       },

--- a/public/docs/_examples/_boilerplate/src/systemjs.config.web.js
+++ b/public/docs/_examples/_boilerplate/src/systemjs.config.web.js
@@ -31,7 +31,6 @@
     },
     // map tells the System loader where to look for things
     map: {
-      'ng-loader': './systemjs-angular-loader.js',
       // our app is within the app folder
       'app': 'app',
 
@@ -62,7 +61,7 @@
         defaultExtension: 'ts',
         meta: {
           './*.ts': {
-            loader: 'ng-loader'
+            loader: 'systemjs-angular-loader.js'
           }
         }
       },


### PR DESCRIPTION
Seems like embedded plunkers needs a different parsing, I didn't expect that.