### PR TITLE
fix(guide): Message in dev mode has changed

### DIFF
--- a/public/docs/ts/latest/guide/deployment.jade
+++ b/public/docs/ts/latest/guide/deployment.jade
@@ -330,7 +330,7 @@ a#enable-prod-mode
   console:
 
 code-example(format="nocode").
-  Angular 2 is running in the development mode. Call enableProdMode() to enable the production mode.
+  Angular is running in the development mode. Call enableProdMode() to enable the production mode.
 :marked
   Switching to production mode can make it run faster by disabling development specific checks such as the dual change detection cycles.
 


### PR DESCRIPTION
**What is the current behavior? (You can also link to an open issue here)**
The following message is wrong , it has changed :

Angular 2 is running in the development mode. Call enableProdMode() to enable the production mode.

**What is the new behavior?**

Angular is running in the development mode. Call enableProdMode() to enable the production mode.

