### PR TITLE
fix: github link in documentation

### DIFF
--- a/tools/api-builder/angular.io-package/templates/lib/githubLinks.html
+++ b/tools/api-builder/angular.io-package/templates/lib/githubLinks.html
@@ -1,5 +1,5 @@
 {% macro githubHref(doc, versionInfo) -%}
-https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/modules/{$ doc.fileInfo.projectRelativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}
+https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/packages/{$ doc.fileInfo.projectRelativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}
 {%- endmacro %}
 
 {% macro githubViewLink(doc, versionInfo) -%}


### PR DESCRIPTION
the angular repo has changed its structure