### PR TITLE
fix(api-builder): fix path to upgrade/static library

### DIFF
--- a/tools/api-builder/angular.io-package/index.js
+++ b/tools/api-builder/angular.io-package/index.js
@@ -70,7 +70,7 @@ module.exports = new Package('angular.io', [basePackage, targetPackage, cheatshe
     'router/index.ts',
     'router/testing/index.ts',
     'upgrade/index.ts',
-    'upgrade/static.ts'
+    'upgrade/static/index.ts'
   ];
   readTypeScriptModules.hidePrivateMembers = true;
 


### PR DESCRIPTION
This invalid path was causing the static upgrade library to be missed from the API documentation.

Fixes https://github.com/angular/angular/issues/15524