### PR TITLE
Remove hover pseudo-selector from selected LI.

### DIFF
--- a/public/docs/_examples/toh-2/ts/src/app/app.component.ts
+++ b/public/docs/_examples/toh-2/ts/src/app/app.component.ts
@@ -64,7 +64,7 @@ const HEROES: Hero[] = [
       height: 1.6em;
       border-radius: 4px;
     }
-    .heroes li.selected:hover {
+    .heroes li.selected {
       background-color: #BBD8DC !important;
       color: white;
     }


### PR DESCRIPTION
Having the :hover pseudo-selector on the `.heroes li.selected` is redundant and only makes the selected hero distinguishable if you hover your mouse over all items in the list.  I propose removing it.