### PR TITLE
docs(toh-2): clarify onSelect() method placement

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt2.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt2.jade
@@ -183,7 +183,7 @@ code-example(language="sh" class="code-shell").
     The hero names should all be unselected before the user picks a hero, so
     you won't initialize the `selectedHero` as you did with `hero`.
 
-    Add an `onSelect` method that sets the `selectedHero` property to the `hero` that the user clicks.
+    Add an `onSelect` method to the `AppComponent` export that sets the `selectedHero` property to the `hero` that the user clicks.
   +makeExample('toh-2/ts/src/app/app.component.ts', 'on-select', 'src/app/app.component.ts (onSelect)')(format='.')
 
   :marked


### PR DESCRIPTION
docs(toh-2): clarify onSelect() method placement

As a beginner to Angular, it was unclear from the instructions where the placement of the `onSelect()` method should go.  I propose clarifying that it should be placed in the export statement.
