### PR TITLE
docs(DI): OpaqueToken was replaced by InjectionToken

### DIFF
--- a/public/docs/_examples/cb-dependency-injection/ts/src/app/hero-of-the-month.component.ts
+++ b/public/docs/_examples/cb-dependency-injection/ts/src/app/hero-of-the-month.component.ts
@@ -1,9 +1,9 @@
 /* tslint:disable:one-line:check-open-brace*/
 // #docplaster
 // #docregion opaque-token
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
-export const TITLE = new OpaqueToken('title');
+export const TITLE = new InjectionToken<string>('title');
 // #enddocregion opaque-token
 
 // #docregion hero-of-the-month

--- a/public/docs/_examples/cb-dependency-injection/ts/src/app/runners-up.ts
+++ b/public/docs/_examples/cb-dependency-injection/ts/src/app/runners-up.ts
@@ -1,12 +1,12 @@
 // #docplaster
 // #docregion
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
 import { Hero }        from './hero';
 import { HeroService } from './hero.service';
 
 // #docregion runners-up
-export const RUNNERS_UP = new OpaqueToken('RunnersUp');
+export const RUNNERS_UP = new InjectionToken('RunnersUp');
 // #enddocregion runners-up
 
 // #docregion factory-synopsis

--- a/public/docs/_examples/dependency-injection/e2e-spec.ts
+++ b/public/docs/_examples/dependency-injection/e2e-spec.ts
@@ -117,7 +117,7 @@ describe('Dependency Injection Tests', function () {
       expect(element(by.css('#p8')).getText()).toEqual(expectedMsg);
     });
 
-    it('P9 (OpaqueToken) displays as expected', function () {
+    it('P9 (InjectionToken) displays as expected', function () {
       expectedMsg = 'APP_CONFIG Application title is Dependency Injection';
       expect(element(by.css('#p9')).getText()).toEqual(expectedMsg);
     });

--- a/public/docs/_examples/dependency-injection/ts/src/app/app.config.ts
+++ b/public/docs/_examples/dependency-injection/ts/src/app/app.config.ts
@@ -1,7 +1,7 @@
 // #docregion token
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
-export let APP_CONFIG = new OpaqueToken('app.config');
+export let APP_CONFIG = new InjectionToken<AppConfig>('app.config');
 // #enddocregion token
 
 // #docregion config

--- a/public/docs/ts/latest/cookbook/dependency-injection.jade
+++ b/public/docs/ts/latest/cookbook/dependency-injection.jade
@@ -33,7 +33,7 @@ include ../_util-fns
   [Provider token alternatives](#tokens)
 
   * [class-interface](#class-interface)
-  * [OpaqueToken](#opaque-token)
+  * [InjectionToken](#injection-token)
 
   [Inject into a derived class](#di-inheritance)
 
@@ -425,8 +425,8 @@ a(id='usevalue')
   and the consumer of the injected hero would want the type information.
 
   The `TITLE` provider token is *not a class*.
-  It's a special kind of provider lookup key called an [OpaqueToken](#opaquetoken).
-  We often use an `OpaqueToken` when the dependency is a simple value like a string, a number, or a function.
+  It's a special kind of provider lookup key called an [InjectionToken](#injectiontoken).
+  We often use an `InjectionToken` when the dependency is a simple value like a string, a number, or a function.
 
   The value of a *value provider* must be defined *now*. We can't create the value later.
   Obviously the title string literal is immediately available.
@@ -535,7 +535,7 @@ a(id='usefactory')
 a(id="tokens")
 .l-main-section
 :marked
-  ## Provider token alternatives: the *class-interface* and *OpaqueToken*
+  ## Provider token alternatives: the *class-interface* and *InjectionToken*
 
   Angular dependency injection is easiest when the provider *token* is a class
   that is also the type of the returned dependency object (what we usually call the *service*).
@@ -590,9 +590,9 @@ a(id="tokens")
   :marked
      It never grows larger no matter how many members we add *as long as they are typed but not implemented*.
 
-a(id='opaque-token')
+a(id='injection-token')
 :marked
-  ### OpaqueToken
+  ### InjectionToken
 
   Dependency objects can be simple values like dates, numbers and strings or
   shapeless objects like arrays and functions.
@@ -602,13 +602,15 @@ a(id='opaque-token')
   a JavaScript object that has a friendly name but won't conflict with
   another token that happens to have the same name.
 
-  The `OpaqueToken` has these characteristics.
+  The `InjectionToken` has these characteristics.
+  InjectionToken<T> is parametrize on T which is the type of object which will be returned by the Injector. 
+  This provides additional level of type safety.
   We encountered them twice in the *Hero of the Month* example,
   in the *title* value provider and in the *runnersUp* factory provider.
-+makeExample('cb-dependency-injection/ts/src/app/hero-of-the-month.component.ts','provide-opaque-token')(format='.')
++makeExample('cb-dependency-injection/ts/src/app/hero-of-the-month.component.ts','provide-injection-token')(format='.')
 :marked
   We created the `TITLE` token like this:
-+makeExample('cb-dependency-injection/ts/src/app/hero-of-the-month.component.ts','opaque-token')(format='.')
++makeExample('cb-dependency-injection/ts/src/app/hero-of-the-month.component.ts','injection-token')(format='.')
 
 
 a(id="di-inheritance")

--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -250,7 +250,7 @@ a#decoration
     At the core, an [`injector`](#injector) returns dependency values on request.
     The expression `injector.get(token)` returns the value associated with the given token.
 
-    A token is an Angular type (`OpaqueToken`). You rarely need to work with tokens directly; most
+    A token is an Angular type (`InjectionToken`). You rarely need to work with tokens directly; most
     methods accept a class name (`Foo`) or a string ("foo") and Angular converts it
     to a token. When you write `injector.get(Foo)`, the injector returns
     the value associated with the token for the `Foo` class, typically an instance of `Foo` itself.

--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -34,7 +34,7 @@ block includes
     - [Factory providers](#factory-provider)
   - [Dependency injection tokens](#dependency-injection-tokens)
     - [Non-class dependencies](#non-class-dependencies)
-    - [`OpaqueToken`](#opaquetoken)
+    - [`InjectionToken`](#injectiontoken)
   - [Optional dependencies](#optional)
   - [Summary](#summary)
   - [Appendix: Working with injectors directly](#explicit-injector)
@@ -638,7 +638,7 @@ a#value-provider
 :marked
   See more `useValue` examples in the
   [Non-class dependencies](#non-class-dependencies) and
-  [OpaqueToken](#opaquetoken) sections.
+  [InjectionToken](#injectiontoken) sections.
 
 #factory-provider
 :marked
@@ -777,18 +777,18 @@ p
     The TypeScript interface disappears from the generated JavaScript.
     There is no interface type information left for Angular to find at runtime.
 
-a#opaquetoken
+a#injectiontoken
 :marked
-  ### _OpaqueToken_
+  ### _InjectionToken_
 
   One solution to choosing a provider token for non-class dependencies is
-  to define and use an <a href="../api/core/index/OpaqueToken-class.html"><b>OpaqueToken</b></a>.
+  to define and use an <a href="../api/core/index/InjectionToken-class.html"><b>InjectionToken</b></a>.
   The definition looks like this:
 
 +makeExample('dependency-injection/ts/src/app/app.config.ts','token')(format='.')
 
 :marked
-  Register the dependency provider using the `OpaqueToken` object:
+  Register the dependency provider using the `InjectionToken` object:
 
 +makeExample('dependency-injection/ts/src/app/providers.component.ts','providers-9')(format=".")
 


### PR DESCRIPTION
Since Angular 4, OpaqueToken was replaced by InjectionToken.