### PR TITLE
docs(aio) : update htttp.get() to http.get()

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt6.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt6.jade
@@ -382,7 +382,7 @@ h1 Providing HTTP Services
   in the `HeroService`, although the URL now has a query string.
 
   More importantly, you no longer call `toPromise()`.
-  Instead you return the *Observable* from the the `htttp.get()`,
+  Instead you return the *Observable* from the the `http.get()`,
   after chaining it to another RxJS operator, <code>map()</code>,
   to extract heroes from the response data.
   RxJS operator chaining makes response processing easy and readable.


### PR DESCRIPTION
I found an error on HTTP section in tutorial documentation