### PR TITLE
docs(toh-pt5): fix capitalization of Router & update screenshot

### DIFF
--- a/public/docs/ts/latest/tutorial/toh-pt5.jade
+++ b/public/docs/ts/latest/tutorial/toh-pt5.jade
@@ -726,8 +726,8 @@ figure.image-display
 
   This approach requires the following changes to the component class:
 
-  1. Import the `router` from the Angular router library.
-  1. Inject the `router` in the constructor, along with the `HeroService`.
+  1. Import the `Router` from the Angular router library.
+  1. Inject the `Router` in the constructor, along with the `HeroService`.
   1. Implement `gotoDetail()` by calling the router `navigate()` method.
 
 +makeExample('toh-5/ts/src/app/heroes.component.ts', 'gotoDetail', 'src/app/heroes.component.ts (gotoDetail)')
@@ -837,7 +837,7 @@ figure.image-display
   Look at the app now. The dashboard, heroes, and navigation links are styled.
 
 figure.image-display
-  img(src='/resources/images/devguide/toh/dashboard-top-heroes.png' alt="View navigations")
+  img(src='/resources/images/devguide/toh/heroes-dashboard-1.png' alt="View navigations")
 
 .l-main-section
 :marked


### PR DESCRIPTION
This PR includes two updates: 
- Capitalize router --> Router because it's referring to the import statement and injecting it into the constructor, as opposed to the variable named `router`.
- Update screenshot of dashboard to reflect the correct title.

Fixes #3385 #3444
