### PR TITLE
docs(reactive-forms): fix typo in link

### DIFF
--- a/public/docs/ts/latest/guide/reactive-forms.jade
+++ b/public/docs/ts/latest/guide/reactive-forms.jade
@@ -708,7 +708,7 @@ a#set-data
 :marked
   In this approach, the value of `hero` in the `HeroDetailComponent` changes 
   every time the user selects a new hero.
-  You should call  _setValue_ in the [ngOnChanges](lifecyle-hooks.html#onchanges)
+  You should call  _setValue_ in the [ngOnChanges](lifecycle-hooks.html#onchanges)
   hook, which Angular calls whenever the input `hero` property changes
   as the following steps demonstrate.
 


### PR DESCRIPTION
This PR fixes a typo in the link to lifecycle-hooks.

Fixes #3462.