### PR TITLE
chore: make the moduleid loader working on safari

### DIFF
--- a/public/docs/_examples/_boilerplate/src/systemjs-angular-loader.js
+++ b/public/docs/_examples/_boilerplate/src/systemjs-angular-loader.js
@@ -23,7 +23,7 @@ module.exports.translate = function(load){
 
   load.source = load.source
     .replace(templateUrlRegex, function(match, quote, url){
-      let resolvedUrl = url;
+      var resolvedUrl = url;
 
       if (url.startsWith('.')) {
         resolvedUrl = basePath + url.substr(1);


### PR DESCRIPTION
Fixes #3485