### PR TITLE
**docs(aio):** Fix makeExcerpt spacing

### DIFF
--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -815,7 +815,7 @@ a#injection-token
 :marked
   Aternatively, you can provide and inject the configuration object in an ngModule like `AppModule`.
 
-  +makeExcerpt('src/app/app.module.ts','ngmodule-providers')
++makeExcerpt('src/app/app.module.ts','ngmodule-providers')
 
 #optional
 :marked


### PR DESCRIPTION
Fix the makeExcerpt spacing so jade compiler properly recognizes it.

**Please do not add issues or pull requests to this repo.**
We are no longer making changes to documentation in this repository.
We will no longer process new issues or PRs and we will close them automatically.

**Please post new [issues](https://github.com/angular/angular/issues) and [pull requests](https://github.com/angular/angular/pulls) to the content folder in [https://github.com/angular/angular/tree/master/aio/content](https://github.com/angular/angular/tree/master/aio/content)**.

Be sure to prefix your issue/PR title with "**docs(aio):**"
